### PR TITLE
feat: implement @gitpm/cli init & validate commands (Phase 2)

### DIFF
--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -1,0 +1,62 @@
+import { readdir } from 'node:fs/promises';
+import { join } from 'node:path';
+import { scaffoldMeta } from '@gitpm/core';
+import { input } from '@inquirer/prompts';
+import chalk from 'chalk';
+import { Command } from 'commander';
+import { resolveMetaDir } from '../utils/config.js';
+import { printError, printSuccess } from '../utils/output.js';
+
+async function collectFiles(dir: string, prefix = ''): Promise<string[]> {
+  const entries = await readdir(dir, { withFileTypes: true });
+  const results: string[] = [];
+  for (const entry of entries) {
+    const rel = prefix ? `${prefix}/${entry.name}` : entry.name;
+    if (entry.isDirectory()) {
+      results.push(rel);
+      const children = await collectFiles(join(dir, entry.name), rel);
+      results.push(...children);
+    } else {
+      results.push(rel);
+    }
+  }
+  return results;
+}
+
+export const initCommand = new Command('init')
+  .description('Initialize a new .meta/ project structure')
+  .argument('[project-name]', 'Name of the project')
+  .action(async (nameArg: string | undefined, _opts, cmd) => {
+    const metaDir = resolveMetaDir(cmd.optsWithGlobals().metaDir);
+
+    let projectName = nameArg;
+    if (!projectName) {
+      projectName = await input({
+        message: 'Project name:',
+        required: true,
+      });
+    }
+
+    const result = await scaffoldMeta(metaDir, projectName);
+
+    if (!result.ok) {
+      printError(result.error.message);
+      process.exit(1);
+    }
+
+    // Print created file tree
+    const files = await collectFiles(metaDir);
+    console.log();
+    console.log(chalk.bold('.meta/'));
+    for (const file of files) {
+      const parts = file.split('/');
+      const indent = '  '.repeat(parts.length);
+      const name = parts[parts.length - 1];
+      const isDir = !name.includes('.');
+      console.log(`${indent}${isDir ? chalk.blue(`${name}/`) : name}`);
+    }
+
+    const fileCount = files.filter((f) => f.includes('.')).length;
+    console.log();
+    printSuccess(`Created ${fileCount} files in .meta/`);
+  });

--- a/packages/cli/src/commands/validate.ts
+++ b/packages/cli/src/commands/validate.ts
@@ -1,0 +1,79 @@
+import { relative } from 'node:path';
+import { parseTree, resolveRefs, validateTree } from '@gitpm/core';
+import chalk from 'chalk';
+import { Command } from 'commander';
+import { resolveMetaDir } from '../utils/config.js';
+import { printError, printSuccess, printWarning } from '../utils/output.js';
+
+export const validateCommand = new Command('validate')
+  .description('Validate the .meta/ project tree')
+  .action(async (_opts, cmd) => {
+    const metaDir = resolveMetaDir(cmd.optsWithGlobals().metaDir);
+
+    // Parse tree
+    const parseResult = await parseTree(metaDir);
+    if (!parseResult.ok) {
+      printError(parseResult.error.message);
+      process.exit(1);
+    }
+
+    const tree = parseResult.value;
+
+    // Check for parse errors
+    if (tree.errors.length > 0) {
+      for (const err of tree.errors) {
+        const rel = relative(process.cwd(), err.filePath);
+        console.log(chalk.red(`  ✗ ${rel}: ${err.message}`));
+      }
+    }
+
+    // Resolve refs
+    const resolveResult = resolveRefs(tree);
+    if (!resolveResult.ok) {
+      printError(resolveResult.error.message);
+      process.exit(1);
+    }
+
+    // Validate
+    const result = validateTree(resolveResult.value);
+
+    // Print validation errors
+    for (const err of result.errors) {
+      const rel = err.filePath ? relative(process.cwd(), err.filePath) : '';
+      const location = rel ? `${rel}: ` : '';
+      const id = err.entityId ? `[${err.entityId}] ` : '';
+      console.log(chalk.red(`  ✗ ${location}${id}${err.code}: ${err.message}`));
+    }
+
+    // Print validation warnings
+    for (const warn of result.warnings) {
+      const rel = warn.filePath ? relative(process.cwd(), warn.filePath) : '';
+      const location = rel ? `${rel}: ` : '';
+      const id = warn.entityId ? `[${warn.entityId}] ` : '';
+      console.log(
+        chalk.yellow(`  ⚠ ${location}${id}${warn.code}: ${warn.message}`),
+      );
+    }
+
+    if (!result.valid) {
+      console.log();
+      printError(
+        `Validation failed with ${result.errors.length} error(s) and ${result.warnings.length} warning(s)`,
+      );
+      process.exit(1);
+    }
+
+    const entityCount =
+      tree.stories.length +
+      tree.epics.length +
+      tree.milestones.length +
+      tree.roadmaps.length +
+      tree.prds.length;
+
+    if (result.warnings.length > 0) {
+      console.log();
+      printWarning(`${result.warnings.length} warning(s)`);
+    }
+
+    printSuccess(`.meta/ tree is valid (${entityCount} entities)`);
+  });

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,1 +1,24 @@
-export const name = 'gitpm';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { Command } from 'commander';
+import { initCommand } from './commands/init.js';
+import { validateCommand } from './commands/validate.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const pkg = JSON.parse(
+  readFileSync(join(__dirname, '..', 'package.json'), 'utf-8'),
+);
+
+const program = new Command();
+
+program
+  .name('gitpm')
+  .description('Git-native project management')
+  .version(pkg.version)
+  .option('--meta-dir <path>', 'Path to .meta directory', '.meta');
+
+program.addCommand(initCommand);
+program.addCommand(validateCommand);
+
+program.parse();

--- a/packages/cli/src/utils/config.ts
+++ b/packages/cli/src/utils/config.ts
@@ -1,0 +1,5 @@
+import { resolve } from 'node:path';
+
+export function resolveMetaDir(metaDirOption: string): string {
+  return resolve(process.cwd(), metaDirOption);
+}

--- a/packages/cli/src/utils/output.ts
+++ b/packages/cli/src/utils/output.ts
@@ -1,0 +1,23 @@
+import chalk from 'chalk';
+
+export function printSuccess(msg: string): void {
+  console.log(chalk.green(`✓ ${msg}`));
+}
+
+export function printError(msg: string): void {
+  console.error(chalk.red(`✗ ${msg}`));
+}
+
+export function printWarning(msg: string): void {
+  console.warn(chalk.yellow(`⚠ ${msg}`));
+}
+
+export function printTree(files: string[]): void {
+  for (const file of files) {
+    const parts = file.split('/');
+    const indent = '  '.repeat(parts.length - 1);
+    const name = parts[parts.length - 1];
+    const isDir = !name.includes('.');
+    console.log(`${indent}${isDir ? chalk.blue(`${name}/`) : name}`);
+  }
+}


### PR DESCRIPTION
Add CLI framework with commander, interactive prompts, and two commands:
- `gitpm init [project-name]` scaffolds a .meta/ directory with sample entities
- `gitpm validate` runs the full parse → resolve → validate pipeline

https://claude.ai/code/session_013ST5dWxz9RNERcn3rxADtw