### PR TITLE
feat: map GitHub labels to priority field during import (#34)

### DIFF
--- a/.meta/stories/feat-map-github-labels-to-priority-field-during-import.md
+++ b/.meta/stories/feat-map-github-labels-to-priority-field-during-import.md
@@ -2,7 +2,7 @@
 type: story
 id: ByzFySLXPYcc
 title: "feat: map GitHub labels to priority field during import"
-status: todo
+status: done
 priority: medium
 assignee: null
 labels:

--- a/packages/sync-github/src/__tests__/mapper.test.ts
+++ b/packages/sync-github/src/__tests__/mapper.test.ts
@@ -3,6 +3,7 @@ import type { GhIssue, GhMilestone } from '../client.js';
 import {
   determineFilePath,
   entityToGhIssue,
+  extractPriority,
   ghIssueToEntity,
   ghMilestoneToMilestone,
   isEpicIssue,
@@ -68,6 +69,30 @@ const noBodyIssue: GhIssue = {
   milestone: null,
   created_at: '2026-03-01T08:00:00Z',
   updated_at: '2026-03-01T08:00:00Z',
+};
+
+const highPriorityIssue: GhIssue = {
+  number: 7,
+  title: 'Critical bug fix',
+  body: 'Needs immediate attention.',
+  state: 'open',
+  assignee: { login: 'dave' },
+  labels: [{ name: 'backend' }, { name: 'priority:high' }],
+  milestone: null,
+  created_at: '2026-03-05T08:00:00Z',
+  updated_at: '2026-03-05T08:00:00Z',
+};
+
+const p0Issue: GhIssue = {
+  number: 8,
+  title: 'Production down',
+  body: 'Everything is broken.',
+  state: 'open',
+  assignee: null,
+  labels: [{ name: 'P0' }, { name: 'bug' }],
+  milestone: null,
+  created_at: '2026-03-06T08:00:00Z',
+  updated_at: '2026-03-06T08:00:00Z',
 };
 
 describe('ghMilestoneToMilestone', () => {
@@ -237,5 +262,97 @@ describe('entityToGhIssue', () => {
     const entity = ghIssueToEntity(closedIssue, undefined, REPO);
     const params = entityToGhIssue(entity as never);
     expect(params.state).toBe('closed');
+  });
+
+  it('re-adds priority label for non-medium priorities on export', () => {
+    const entity = ghIssueToEntity(highPriorityIssue, undefined, REPO);
+    expect(entity.priority).toBe('high');
+    const params = entityToGhIssue(entity as never);
+    expect(params.labels).toContain('priority:high');
+  });
+
+  it('does not add priority label for medium priority on export', () => {
+    const entity = ghIssueToEntity(storyIssue, undefined, REPO);
+    expect(entity.priority).toBe('medium');
+    const params = entityToGhIssue(entity as never);
+    expect(params.labels).not.toContain('priority:medium');
+    expect(params.labels).not.toContain('P2');
+  });
+});
+
+describe('extractPriority', () => {
+  it('extracts high priority from priority:high label', () => {
+    const { priority, filteredLabels } = extractPriority([
+      'backend',
+      'priority:high',
+    ]);
+    expect(priority).toBe('high');
+    expect(filteredLabels).toEqual(['backend']);
+  });
+
+  it('extracts critical priority from P0 label', () => {
+    const { priority, filteredLabels } = extractPriority(['P0', 'bug']);
+    expect(priority).toBe('critical');
+    expect(filteredLabels).toEqual(['bug']);
+  });
+
+  it('defaults to medium when no priority label present', () => {
+    const { priority, filteredLabels } = extractPriority([
+      'backend',
+      'feature',
+    ]);
+    expect(priority).toBe('medium');
+    expect(filteredLabels).toEqual(['backend', 'feature']);
+  });
+
+  it('uses custom priority mapping', () => {
+    const customMapping = { severity1: 'critical' as const };
+    const { priority, filteredLabels } = extractPriority(
+      ['severity1', 'frontend'],
+      customMapping,
+    );
+    expect(priority).toBe('critical');
+    expect(filteredLabels).toEqual(['frontend']);
+  });
+
+  it('handles empty labels', () => {
+    const { priority, filteredLabels } = extractPriority([]);
+    expect(priority).toBe('medium');
+    expect(filteredLabels).toEqual([]);
+  });
+});
+
+describe('ghIssueToEntity priority mapping', () => {
+  it('maps priority:high label to high priority', () => {
+    const entity = ghIssueToEntity(highPriorityIssue, undefined, REPO);
+    expect(entity.priority).toBe('high');
+    expect(entity.labels).toEqual(['backend']);
+    expect(entity.labels).not.toContain('priority:high');
+  });
+
+  it('maps P0 label to critical priority', () => {
+    const entity = ghIssueToEntity(p0Issue, undefined, REPO);
+    expect(entity.priority).toBe('critical');
+    expect(entity.labels).toEqual(['bug']);
+    expect(entity.labels).not.toContain('P0');
+  });
+
+  it('defaults to medium when no priority label', () => {
+    const entity = ghIssueToEntity(storyIssue, undefined, REPO);
+    expect(entity.priority).toBe('medium');
+  });
+
+  it('uses custom priority mapping from config', () => {
+    const config: Pick<GitHubConfig, 'label_mapping' | 'priority_mapping'> = {
+      label_mapping: { epic_labels: ['epic'] },
+      priority_mapping: { urgent: 'critical' },
+    };
+    const urgentIssue: GhIssue = {
+      ...storyIssue,
+      labels: [{ name: 'urgent' }, { name: 'backend' }],
+    };
+    const entity = ghIssueToEntity(urgentIssue, config, REPO);
+    expect(entity.priority).toBe('critical');
+    expect(entity.labels).toEqual(['backend']);
   });
 });

--- a/packages/sync-github/src/config.ts
+++ b/packages/sync-github/src/config.ts
@@ -3,7 +3,11 @@ import { dirname, join } from 'node:path';
 import type { Result, Status } from '@gitpm/core';
 import YAML from 'yaml';
 import type { GitHubConfig } from './types.js';
-import { DEFAULT_EPIC_LABELS, DEFAULT_STATUS_MAPPING } from './types.js';
+import {
+  DEFAULT_EPIC_LABELS,
+  DEFAULT_PRIORITY_MAPPING,
+  DEFAULT_STATUS_MAPPING,
+} from './types.js';
 
 export async function loadConfig(
   metaDir: string,
@@ -54,6 +58,7 @@ export function createDefaultConfig(
     label_mapping: {
       epic_labels: [...DEFAULT_EPIC_LABELS],
     },
+    priority_mapping: { ...DEFAULT_PRIORITY_MAPPING },
     auto_sync: false,
   };
 }

--- a/packages/sync-github/src/index.ts
+++ b/packages/sync-github/src/index.ts
@@ -11,6 +11,7 @@ export {
   ghMilestoneToMilestone,
   ghIssueToEntity,
   isEpicIssue,
+  extractPriority,
   determineFilePath,
   milestoneToGhMilestone,
   entityToGhIssue,
@@ -64,4 +65,5 @@ export type {
 export {
   DEFAULT_STATUS_MAPPING,
   DEFAULT_EPIC_LABELS,
+  DEFAULT_PRIORITY_MAPPING,
 } from './types.js';

--- a/packages/sync-github/src/mapper.ts
+++ b/packages/sync-github/src/mapper.ts
@@ -1,9 +1,16 @@
-import type { Epic, GitHubSync, Milestone, Status, Story } from '@gitpm/core';
+import type {
+  Epic,
+  GitHubSync,
+  Milestone,
+  Priority,
+  Status,
+  Story,
+} from '@gitpm/core';
 import { toSlug } from '@gitpm/core';
 import { nanoid } from 'nanoid';
 import type { GhIssue, GhMilestone } from './client.js';
 import type { GitHubConfig } from './types.js';
-import { DEFAULT_EPIC_LABELS } from './types.js';
+import { DEFAULT_EPIC_LABELS, DEFAULT_PRIORITY_MAPPING } from './types.js';
 
 export function ghMilestoneToMilestone(
   gh: GhMilestone,
@@ -46,22 +53,49 @@ export function isEpicIssue(
   return issueLabels.some((label) => epicLabels.includes(label));
 }
 
+/**
+ * Extracts priority from GitHub issue labels using a mapping.
+ * Returns the extracted priority and the remaining labels (with priority labels removed).
+ */
+export function extractPriority(
+  issueLabels: string[],
+  priorityMapping?: Record<string, Priority>,
+): { priority: Priority; filteredLabels: string[] } {
+  const mapping = priorityMapping ?? DEFAULT_PRIORITY_MAPPING;
+  let priority: Priority = 'medium';
+  const matchedLabels = new Set<string>();
+
+  for (const label of issueLabels) {
+    const mapped = mapping[label];
+    if (mapped) {
+      priority = mapped;
+      matchedLabels.add(label);
+    }
+  }
+
+  const filteredLabels = issueLabels.filter((l) => !matchedLabels.has(l));
+  return { priority, filteredLabels };
+}
+
 export function ghIssueToEntity(
   gh: GhIssue,
-  config?: Pick<GitHubConfig, 'label_mapping'>,
+  config?: Pick<GitHubConfig, 'label_mapping' | 'priority_mapping'>,
   repoSlug?: string,
 ): Story | Epic {
   const repo = repoSlug ?? '';
   const isEpic = isEpicIssue(gh, config);
   const id = nanoid(12);
   const now = new Date().toISOString();
-  const labels = gh.labels
+
+  const epicLabels = config?.label_mapping?.epic_labels ?? DEFAULT_EPIC_LABELS;
+  const rawLabels = gh.labels
     .map((l) => (typeof l === 'string' ? l : l.name))
-    .filter((l) => {
-      const epicLabels =
-        config?.label_mapping?.epic_labels ?? DEFAULT_EPIC_LABELS;
-      return !epicLabels.includes(l);
-    });
+    .filter((l) => !epicLabels.includes(l));
+
+  const { priority, filteredLabels: labels } = extractPriority(
+    rawLabels,
+    config?.priority_mapping,
+  );
 
   const github: GitHubSync = {
     issue_number: gh.number,
@@ -79,7 +113,7 @@ export function ghIssueToEntity(
       id,
       title: gh.title,
       status,
-      priority: 'medium',
+      priority,
       owner: gh.assignee?.login ?? null,
       labels,
       milestone_ref: null,
@@ -96,7 +130,7 @@ export function ghIssueToEntity(
     id,
     title: gh.title,
     status,
-    priority: 'medium',
+    priority,
     assignee: gh.assignee?.login ?? null,
     labels,
     estimate: null,
@@ -161,10 +195,25 @@ export interface CreateIssueParams {
   state?: 'open' | 'closed';
 }
 
-export function entityToGhIssue(entity: Story | Epic): CreateIssueParams {
+export function entityToGhIssue(
+  entity: Story | Epic,
+  config?: Pick<GitHubConfig, 'priority_mapping'>,
+): CreateIssueParams {
   const labels = [...(entity.labels ?? [])];
   if (entity.type === 'epic') {
     labels.push('epic');
+  }
+
+  // Re-add priority label for round-trip fidelity
+  if (entity.priority && entity.priority !== 'medium') {
+    const mapping = config?.priority_mapping ?? DEFAULT_PRIORITY_MAPPING;
+    // Find the first label that maps to this priority
+    const priorityLabel = Object.entries(mapping).find(
+      ([, val]) => val === entity.priority,
+    )?.[0];
+    if (priorityLabel) {
+      labels.push(priorityLabel);
+    }
   }
 
   const assignee = entity.type === 'story' ? entity.assignee : entity.owner;

--- a/packages/sync-github/src/types.ts
+++ b/packages/sync-github/src/types.ts
@@ -1,4 +1,4 @@
-import type { EntityId, Status } from '@gitpm/core';
+import type { EntityId, Priority, Status } from '@gitpm/core';
 
 export type LinkStrategy =
   | 'body-refs'
@@ -30,6 +30,7 @@ export interface GitHubConfig {
   label_mapping: {
     epic_labels: string[];
   };
+  priority_mapping: Record<string, Priority>;
   auto_sync: boolean;
 }
 
@@ -58,6 +59,19 @@ export const DEFAULT_STATUS_MAPPING: Record<string, Status> = {
 };
 
 export const DEFAULT_EPIC_LABELS = ['epic'];
+
+export const DEFAULT_PRIORITY_MAPPING: Record<string, Priority> = {
+  'priority:critical': 'critical',
+  'priority:high': 'high',
+  'priority:medium': 'medium',
+  'priority:low': 'low',
+  P0: 'critical',
+  P1: 'high',
+  P2: 'medium',
+  P3: 'low',
+  critical: 'critical',
+  urgent: 'critical',
+};
 
 // Phase 4 types
 


### PR DESCRIPTION
Add priority_mapping to GitHubConfig that maps GitHub labels (priority:high,
P0, P1, etc.) to GitPM priority values (low, medium, high, critical).
Priority labels are extracted during import and filtered from the labels
array. On export, priority labels are re-added for round-trip fidelity.

https://claude.ai/code/session_01MWCDseWdFVL6wwxdkNmUCV