### PR TITLE
feat: add GitLab integration package (@gitpm/sync-gitlab)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -21,6 +21,7 @@
       "dependencies": {
         "@gitpm/core": "workspace:*",
         "@gitpm/sync-github": "workspace:*",
+        "@gitpm/sync-gitlab": "workspace:*",
         "@inquirer/prompts": "^7.0.0",
         "chalk": "^5.3.0",
         "commander": "^12.1.0",
@@ -46,6 +47,15 @@
       "dependencies": {
         "@gitpm/core": "workspace:*",
         "@octokit/rest": "^21.0.0",
+        "nanoid": "^5.0.8",
+        "yaml": "^2.6.0",
+      },
+    },
+    "packages/sync-gitlab": {
+      "name": "@gitpm/sync-gitlab",
+      "version": "0.1.0",
+      "dependencies": {
+        "@gitpm/core": "workspace:*",
         "nanoid": "^5.0.8",
         "yaml": "^2.6.0",
       },
@@ -196,6 +206,8 @@
     "@gitpm/core": ["@gitpm/core@workspace:packages/core"],
 
     "@gitpm/sync-github": ["@gitpm/sync-github@workspace:packages/sync-github"],
+
+    "@gitpm/sync-gitlab": ["@gitpm/sync-gitlab@workspace:packages/sync-gitlab"],
 
     "@gitpm/sync-jira": ["@gitpm/sync-jira@workspace:packages/sync-jira"],
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "@gitpm/core": "workspace:*",
     "@gitpm/sync-github": "workspace:*",
+    "@gitpm/sync-gitlab": "workspace:*",
     "@inquirer/prompts": "^7.0.0",
     "chalk": "^5.3.0",
     "commander": "^12.1.0",

--- a/packages/cli/src/commands/import.ts
+++ b/packages/cli/src/commands/import.ts
@@ -1,5 +1,7 @@
 import { importFromGitHub } from '@gitpm/sync-github';
 import type { LinkStrategy } from '@gitpm/sync-github';
+import { importFromGitLab } from '@gitpm/sync-gitlab';
+import type { LinkStrategy as GitLabLinkStrategy } from '@gitpm/sync-gitlab';
 import chalk from 'chalk';
 import { Command } from 'commander';
 import ora from 'ora';
@@ -15,77 +17,168 @@ const VALID_LINK_STRATEGIES = [
   'all',
 ] as const;
 
+const VALID_GITLAB_LINK_STRATEGIES = [
+  'body-refs',
+  'native-epics',
+  'milestone',
+  'labels',
+  'all',
+] as const;
+
 export const importCommand = new Command('import')
-  .description('Import project data from GitHub into .meta/')
-  .requiredOption('--repo <owner/repo>', 'GitHub repository (owner/repo)')
-  .option('--project <number>', 'GitHub Project number', Number.parseInt)
-  .option('--token <token>', 'GitHub personal access token')
+  .description('Import project data from GitHub or GitLab into .meta/')
+  .option(
+    '--source <source>',
+    'Source platform: github or gitlab (default: github)',
+    'github',
+  )
+  .option('--repo <owner/repo>', 'GitHub repository (owner/repo)')
+  .option(
+    '--project <value>',
+    'GitHub Project number or GitLab project path (namespace/project)',
+  )
+  .option('--token <token>', 'Personal access token')
+  .option('--base-url <url>', 'GitLab base URL (default: https://gitlab.com)')
   .option(
     '--link-strategy <strategy>',
-    'Epic-story linkage strategy: body-refs, sub-issues, milestone, labels, all (default: all)',
+    'Epic-story linkage strategy (default: all)',
   )
   .action(async (opts, cmd) => {
     const metaDir = resolveMetaDir(cmd.optsWithGlobals().metaDir);
+    const source: string = opts.source;
 
-    // Validate repo format
-    const repo: string = opts.repo;
-    if (!repo.includes('/') || repo.split('/').length !== 2) {
-      printError('Invalid repo format. Expected "owner/repo".');
+    if (source === 'gitlab') {
+      await importGitLab(opts, metaDir);
+    } else if (source === 'github') {
+      await importGitHub(opts, metaDir);
+    } else {
+      printError(`Unknown source "${source}". Use "github" or "gitlab".`);
       process.exit(1);
     }
-
-    let token: string;
-    try {
-      token = await resolveToken(opts.token);
-    } catch (err) {
-      printError(
-        err instanceof Error ? err.message : 'Failed to resolve token.',
-      );
-      process.exit(1);
-    }
-
-    // Validate link strategy
-    const linkStrategy: LinkStrategy | undefined = opts.linkStrategy;
-    if (
-      linkStrategy &&
-      !VALID_LINK_STRATEGIES.includes(
-        linkStrategy as (typeof VALID_LINK_STRATEGIES)[number],
-      )
-    ) {
-      printError(
-        `Invalid link strategy "${linkStrategy}". Must be one of: ${VALID_LINK_STRATEGIES.join(', ')}`,
-      );
-      process.exit(1);
-    }
-
-    const spinner = ora('Importing from GitHub...').start();
-
-    const result = await importFromGitHub({
-      token,
-      repo,
-      projectNumber: opts.project,
-      metaDir,
-      linkStrategy,
-    });
-
-    if (!result.ok) {
-      spinner.fail('Import failed.');
-      printError(result.error.message);
-      process.exit(1);
-    }
-
-    spinner.succeed('Import complete.');
-
-    const { milestones, epics, stories, totalFiles } = result.value;
-    console.log();
-    console.log(chalk.bold('Summary:'));
-    console.log(`  Milestones: ${milestones}`);
-    console.log(`  Epics:      ${epics}`);
-    console.log(`  Stories:    ${stories}`);
-    console.log(`  Files:      ${totalFiles}`);
-    console.log();
-    printSuccess(
-      `Imported ${milestones + epics + stories} entities (${totalFiles} files).`,
-    );
-    console.log(chalk.dim('Run `gitpm validate` to verify the imported tree.'));
   });
+
+async function importGitHub(
+  opts: Record<string, string | undefined>,
+  metaDir: string,
+): Promise<void> {
+  const repo = opts.repo;
+  if (!repo || !repo.includes('/') || repo.split('/').length !== 2) {
+    printError('--repo is required for GitHub import. Expected "owner/repo".');
+    process.exit(1);
+  }
+
+  let token: string;
+  try {
+    token = await resolveToken(opts.token);
+  } catch (err) {
+    printError(err instanceof Error ? err.message : 'Failed to resolve token.');
+    process.exit(1);
+  }
+
+  const linkStrategy: LinkStrategy | undefined = opts.linkStrategy as
+    | LinkStrategy
+    | undefined;
+  if (
+    linkStrategy &&
+    !VALID_LINK_STRATEGIES.includes(
+      linkStrategy as (typeof VALID_LINK_STRATEGIES)[number],
+    )
+  ) {
+    printError(
+      `Invalid link strategy "${linkStrategy}". Must be one of: ${VALID_LINK_STRATEGIES.join(', ')}`,
+    );
+    process.exit(1);
+  }
+
+  const spinner = ora('Importing from GitHub...').start();
+
+  const result = await importFromGitHub({
+    token,
+    repo,
+    projectNumber: opts.project ? Number.parseInt(opts.project, 10) : undefined,
+    metaDir,
+    linkStrategy,
+  });
+
+  if (!result.ok) {
+    spinner.fail('Import failed.');
+    printError(result.error.message);
+    process.exit(1);
+  }
+
+  spinner.succeed('Import complete.');
+  printImportSummary(result.value);
+}
+
+async function importGitLab(
+  opts: Record<string, string | undefined>,
+  metaDir: string,
+): Promise<void> {
+  const project = opts.project ?? opts.repo;
+  if (!project) {
+    printError('--project (namespace/project) is required for GitLab import.');
+    process.exit(1);
+  }
+
+  const token = opts.token ?? process.env.GITLAB_TOKEN;
+  if (!token) {
+    printError(
+      'No GitLab token found. Provide via --token flag or GITLAB_TOKEN env var.',
+    );
+    process.exit(1);
+  }
+
+  const linkStrategy: GitLabLinkStrategy | undefined = opts.linkStrategy as
+    | GitLabLinkStrategy
+    | undefined;
+  if (
+    linkStrategy &&
+    !VALID_GITLAB_LINK_STRATEGIES.includes(
+      linkStrategy as (typeof VALID_GITLAB_LINK_STRATEGIES)[number],
+    )
+  ) {
+    printError(
+      `Invalid link strategy "${linkStrategy}". Must be one of: ${VALID_GITLAB_LINK_STRATEGIES.join(', ')}`,
+    );
+    process.exit(1);
+  }
+
+  const spinner = ora('Importing from GitLab...').start();
+
+  const result = await importFromGitLab({
+    token,
+    project,
+    baseUrl: opts.baseUrl,
+    metaDir,
+    linkStrategy,
+  });
+
+  if (!result.ok) {
+    spinner.fail('Import failed.');
+    printError(result.error.message);
+    process.exit(1);
+  }
+
+  spinner.succeed('Import complete.');
+  printImportSummary(result.value);
+}
+
+function printImportSummary(value: {
+  milestones: number;
+  epics: number;
+  stories: number;
+  totalFiles: number;
+}): void {
+  const { milestones, epics, stories, totalFiles } = value;
+  console.log();
+  console.log(chalk.bold('Summary:'));
+  console.log(`  Milestones: ${milestones}`);
+  console.log(`  Epics:      ${epics}`);
+  console.log(`  Stories:    ${stories}`);
+  console.log(`  Files:      ${totalFiles}`);
+  console.log();
+  printSuccess(
+    `Imported ${milestones + epics + stories} entities (${totalFiles} files).`,
+  );
+  console.log(chalk.dim('Run `gitpm validate` to verify the imported tree.'));
+}

--- a/packages/cli/src/commands/pull.ts
+++ b/packages/cli/src/commands/pull.ts
@@ -1,5 +1,12 @@
-import { loadConfig, syncWithGitHub } from '@gitpm/sync-github';
+import {
+  loadConfig as loadGitHubConfig,
+  syncWithGitHub,
+} from '@gitpm/sync-github';
 import type { ConflictStrategy } from '@gitpm/sync-github';
+import {
+  loadConfig as loadGitLabConfig,
+  syncWithGitLab,
+} from '@gitpm/sync-gitlab';
 import chalk from 'chalk';
 import { Command } from 'commander';
 import ora from 'ora';
@@ -9,8 +16,8 @@ import { promptConflictResolution } from '../utils/conflict-ui.js';
 import { printError, printSuccess } from '../utils/output.js';
 
 export const pullCommand = new Command('pull')
-  .description('Pull changes from GitHub into local .meta/')
-  .option('--token <token>', 'GitHub personal access token')
+  .description('Pull changes from GitHub or GitLab into local .meta/')
+  .option('--token <token>', 'Personal access token')
   .option(
     '--strategy <strategy>',
     'Conflict resolution strategy (local-wins, remote-wins, ask)',
@@ -20,65 +27,119 @@ export const pullCommand = new Command('pull')
     const metaDir = resolveMetaDir(cmd.optsWithGlobals().metaDir);
     const strategy = opts.strategy as ConflictStrategy;
 
-    let token: string;
-    try {
-      token = await resolveToken(opts.token);
-    } catch (err) {
-      printError(
-        err instanceof Error ? err.message : 'Failed to resolve token.',
-      );
-      process.exit(1);
-    }
+    // Detect platform
+    const ghConfig = await loadGitHubConfig(metaDir);
+    const glConfig = await loadGitLabConfig(metaDir);
 
-    // Load config to get repo
-    const configResult = await loadConfig(metaDir);
-    if (!configResult.ok) {
+    if (glConfig.ok) {
+      await pullFromGitLab(opts, metaDir, glConfig.value, strategy);
+    } else if (ghConfig.ok) {
+      await pullFromGitHub(opts, metaDir, ghConfig.value.repo, strategy);
+    } else {
       printError(
         'No sync config found. Run `gitpm import` first to set up sync.',
       );
       process.exit(1);
     }
-    const repo = configResult.value.repo;
-
-    const spinner = ora('Pulling from GitHub...').start();
-
-    // Use sync with the given strategy — pull uses remote-wins by default
-    const result = await syncWithGitHub({
-      token,
-      repo,
-      metaDir,
-      strategy: strategy === 'ask' ? 'ask' : strategy,
-    });
-
-    if (!result.ok) {
-      spinner.fail('Pull failed.');
-      printError(result.error.message);
-      process.exit(1);
-    }
-
-    spinner.succeed('Pull complete.');
-
-    const { pulled, conflicts, resolved, skipped } = result.value;
-
-    // Handle interactive conflict resolution if strategy is 'ask'
-    if (strategy === 'ask' && conflicts.length > 0) {
-      console.log();
-      console.log(
-        chalk.yellow(`${conflicts.length} conflict(s) require resolution:`),
-      );
-      const resolutions = await promptConflictResolution(conflicts);
-      console.log(
-        chalk.dim(
-          `Resolved ${resolutions.length}, skipped ${conflicts.length - resolutions.length}`,
-        ),
-      );
-    }
-
-    console.log();
-    console.log(chalk.bold('Pull Summary:'));
-    console.log(`  Pulled: ${pulled.milestones + pulled.issues} changes`);
-    console.log(`  Conflicts resolved: ${resolved}`);
-    console.log(`  Skipped: ${skipped}`);
-    console.log();
-    printSuccess('Pull complete.');
   });
+
+async function pullFromGitHub(
+  opts: Record<string, string | undefined>,
+  metaDir: string,
+  repo: string,
+  strategy: ConflictStrategy,
+): Promise<void> {
+  let token: string;
+  try {
+    token = await resolveToken(opts.token);
+  } catch (err) {
+    printError(err instanceof Error ? err.message : 'Failed to resolve token.');
+    process.exit(1);
+  }
+
+  const spinner = ora('Pulling from GitHub...').start();
+  const result = await syncWithGitHub({
+    token,
+    repo,
+    metaDir,
+    strategy: strategy === 'ask' ? 'ask' : strategy,
+  });
+
+  if (!result.ok) {
+    spinner.fail('Pull failed.');
+    printError(result.error.message);
+    process.exit(1);
+  }
+
+  spinner.succeed('Pull complete.');
+  await handleConflictsAndPrint(result.value, strategy);
+}
+
+async function pullFromGitLab(
+  opts: Record<string, string | undefined>,
+  metaDir: string,
+  config: { project: string; project_id: number; base_url: string },
+  strategy: ConflictStrategy,
+): Promise<void> {
+  const token = opts.token ?? process.env.GITLAB_TOKEN;
+  if (!token) {
+    printError(
+      'No GitLab token found. Provide via --token flag or GITLAB_TOKEN env var.',
+    );
+    process.exit(1);
+  }
+
+  const spinner = ora('Pulling from GitLab...').start();
+  const result = await syncWithGitLab({
+    token,
+    project: config.project,
+    projectId: config.project_id,
+    baseUrl: config.base_url,
+    metaDir,
+    strategy: strategy === 'ask' ? 'ask' : strategy,
+  });
+
+  if (!result.ok) {
+    spinner.fail('Pull failed.');
+    printError(result.error.message);
+    process.exit(1);
+  }
+
+  spinner.succeed('Pull complete.');
+  await handleConflictsAndPrint(result.value, strategy);
+}
+
+async function handleConflictsAndPrint(
+  result: {
+    pulled: { milestones: number; issues: number };
+    conflicts: unknown[];
+    resolved: number;
+    skipped: number;
+  },
+  strategy: ConflictStrategy,
+): Promise<void> {
+  const { pulled, conflicts, resolved, skipped } = result;
+
+  if (strategy === 'ask' && conflicts.length > 0) {
+    console.log();
+    console.log(
+      chalk.yellow(`${conflicts.length} conflict(s) require resolution:`),
+    );
+    const resolutions = await promptConflictResolution(
+      conflicts as Parameters<typeof promptConflictResolution>[0],
+    );
+    console.log(
+      chalk.dim(
+        `Resolved ${resolutions.length}, skipped ${conflicts.length - resolutions.length}`,
+      ),
+    );
+  }
+
+  console.log();
+  console.log(chalk.bold('Pull Summary:'));
+  console.log(`  Pulled: ${pulled.milestones + pulled.issues} changes`);
+  console.log(`  Conflicts resolved: ${resolved}`);
+  console.log(`  Skipped: ${skipped}`);
+  console.log();
+  printSuccess('Pull complete.');
+}

--- a/packages/cli/src/commands/push.ts
+++ b/packages/cli/src/commands/push.ts
@@ -1,4 +1,11 @@
-import { exportToGitHub, loadConfig } from '@gitpm/sync-github';
+import {
+  exportToGitHub,
+  loadConfig as loadGitHubConfig,
+} from '@gitpm/sync-github';
+import {
+  exportToGitLab,
+  loadConfig as loadGitLabConfig,
+} from '@gitpm/sync-gitlab';
 import { confirm } from '@inquirer/prompts';
 import chalk from 'chalk';
 import { Command } from 'commander';
@@ -8,113 +15,198 @@ import { resolveMetaDir } from '../utils/config.js';
 import { printError, printSuccess } from '../utils/output.js';
 
 export const pushCommand = new Command('push')
-  .description('Push local .meta/ changes to GitHub')
-  .option('--token <token>', 'GitHub personal access token')
+  .description('Push local .meta/ changes to GitHub or GitLab')
+  .option('--token <token>', 'Personal access token')
   .option('--dry-run', 'Preview changes without pushing')
   .option('--yes', 'Skip confirmation prompt')
   .action(async (opts, cmd) => {
     const metaDir = resolveMetaDir(cmd.optsWithGlobals().metaDir);
 
-    let token: string;
-    try {
-      token = await resolveToken(opts.token);
-    } catch (err) {
-      printError(
-        err instanceof Error ? err.message : 'Failed to resolve token.',
-      );
-      process.exit(1);
-    }
+    // Detect which platform config exists
+    const ghConfig = await loadGitHubConfig(metaDir);
+    const glConfig = await loadGitLabConfig(metaDir);
 
-    // Load config to get repo
-    const configResult = await loadConfig(metaDir);
-    if (!configResult.ok) {
+    if (glConfig.ok) {
+      await pushToGitLab(opts, metaDir, glConfig.value);
+    } else if (ghConfig.ok) {
+      await pushToGitHub(opts, metaDir, ghConfig.value.repo);
+    } else {
       printError(
         'No sync config found. Run `gitpm import` first to set up sync.',
       );
       process.exit(1);
     }
-    const repo = configResult.value.repo;
+  });
 
-    if (opts.dryRun) {
-      const spinner = ora('Calculating changes...').start();
-      const result = await exportToGitHub({
-        token,
-        repo,
-        metaDir,
-        dryRun: true,
-      });
+async function pushToGitHub(
+  opts: Record<string, string | boolean | undefined>,
+  metaDir: string,
+  repo: string,
+): Promise<void> {
+  let token: string;
+  try {
+    token = await resolveToken(opts.token as string | undefined);
+  } catch (err) {
+    printError(err instanceof Error ? err.message : 'Failed to resolve token.');
+    process.exit(1);
+  }
 
-      if (!result.ok) {
-        spinner.fail('Dry run failed.');
-        printError(result.error.message);
-        process.exit(1);
-      }
-
-      spinner.succeed('Dry run complete.');
-      printPreview(result.value);
-      return;
-    }
-
-    // First do a dry run to preview
-    const previewSpinner = ora('Calculating changes...').start();
-    const preview = await exportToGitHub({
-      token,
-      repo,
-      metaDir,
-      dryRun: true,
-    });
-
-    if (!preview.ok) {
-      previewSpinner.fail('Failed to calculate changes.');
-      printError(preview.error.message);
-      process.exit(1);
-    }
-
-    previewSpinner.succeed('Changes calculated.');
-    printPreview(preview.value);
-
-    if (preview.value.totalChanges === 0) {
-      printSuccess('Nothing to push — already in sync.');
-      return;
-    }
-
-    if (!opts.yes) {
-      const confirmed = await confirm({
-        message: 'Push these changes to GitHub?',
-        default: false,
-      });
-      if (!confirmed) {
-        console.log(chalk.dim('Push cancelled.'));
-        return;
-      }
-    }
-
-    const pushSpinner = ora('Pushing to GitHub...').start();
-    const result = await exportToGitHub({
-      token,
-      repo,
-      metaDir,
-      dryRun: false,
-    });
+  if (opts.dryRun) {
+    const spinner = ora('Calculating changes...').start();
+    const result = await exportToGitHub({ token, repo, metaDir, dryRun: true });
 
     if (!result.ok) {
-      pushSpinner.fail('Push failed.');
+      spinner.fail('Dry run failed.');
       printError(result.error.message);
       process.exit(1);
     }
 
-    pushSpinner.succeed('Push complete.');
-    const { created, updated } = result.value;
-    const unchanged =
-      result.value.totalChanges -
-      created.milestones -
-      created.issues -
-      updated.milestones -
-      updated.issues;
-    console.log(
-      `  Created ${created.milestones + created.issues}, Updated ${updated.milestones + updated.issues}, Unchanged ${Math.max(0, unchanged)}`,
-    );
+    spinner.succeed('Dry run complete.');
+    printPreview(result.value);
+    return;
+  }
+
+  const previewSpinner = ora('Calculating changes...').start();
+  const preview = await exportToGitHub({
+    token,
+    repo,
+    metaDir,
+    dryRun: true,
   });
+
+  if (!preview.ok) {
+    previewSpinner.fail('Failed to calculate changes.');
+    printError(preview.error.message);
+    process.exit(1);
+  }
+
+  previewSpinner.succeed('Changes calculated.');
+  printPreview(preview.value);
+
+  if (preview.value.totalChanges === 0) {
+    printSuccess('Nothing to push — already in sync.');
+    return;
+  }
+
+  if (!opts.yes) {
+    const confirmed = await confirm({
+      message: 'Push these changes to GitHub?',
+      default: false,
+    });
+    if (!confirmed) {
+      console.log(chalk.dim('Push cancelled.'));
+      return;
+    }
+  }
+
+  const pushSpinner = ora('Pushing to GitHub...').start();
+  const result = await exportToGitHub({ token, repo, metaDir, dryRun: false });
+
+  if (!result.ok) {
+    pushSpinner.fail('Push failed.');
+    printError(result.error.message);
+    process.exit(1);
+  }
+
+  pushSpinner.succeed('Push complete.');
+  const { created, updated } = result.value;
+  console.log(
+    `  Created ${created.milestones + created.issues}, Updated ${updated.milestones + updated.issues}`,
+  );
+}
+
+async function pushToGitLab(
+  opts: Record<string, string | boolean | undefined>,
+  metaDir: string,
+  config: { project: string; project_id: number; base_url: string },
+): Promise<void> {
+  const token = (opts.token as string | undefined) ?? process.env.GITLAB_TOKEN;
+  if (!token) {
+    printError(
+      'No GitLab token found. Provide via --token flag or GITLAB_TOKEN env var.',
+    );
+    process.exit(1);
+  }
+
+  if (opts.dryRun) {
+    const spinner = ora('Calculating changes...').start();
+    const result = await exportToGitLab({
+      token,
+      project: config.project,
+      projectId: config.project_id,
+      baseUrl: config.base_url,
+      metaDir,
+      dryRun: true,
+    });
+
+    if (!result.ok) {
+      spinner.fail('Dry run failed.');
+      printError(result.error.message);
+      process.exit(1);
+    }
+
+    spinner.succeed('Dry run complete.');
+    printPreview(result.value);
+    return;
+  }
+
+  const previewSpinner = ora('Calculating changes...').start();
+  const preview = await exportToGitLab({
+    token,
+    project: config.project,
+    projectId: config.project_id,
+    baseUrl: config.base_url,
+    metaDir,
+    dryRun: true,
+  });
+
+  if (!preview.ok) {
+    previewSpinner.fail('Failed to calculate changes.');
+    printError(preview.error.message);
+    process.exit(1);
+  }
+
+  previewSpinner.succeed('Changes calculated.');
+  printPreview(preview.value);
+
+  if (preview.value.totalChanges === 0) {
+    printSuccess('Nothing to push — already in sync.');
+    return;
+  }
+
+  if (!opts.yes) {
+    const confirmed = await confirm({
+      message: 'Push these changes to GitLab?',
+      default: false,
+    });
+    if (!confirmed) {
+      console.log(chalk.dim('Push cancelled.'));
+      return;
+    }
+  }
+
+  const pushSpinner = ora('Pushing to GitLab...').start();
+  const result = await exportToGitLab({
+    token,
+    project: config.project,
+    projectId: config.project_id,
+    baseUrl: config.base_url,
+    metaDir,
+    dryRun: false,
+  });
+
+  if (!result.ok) {
+    pushSpinner.fail('Push failed.');
+    printError(result.error.message);
+    process.exit(1);
+  }
+
+  pushSpinner.succeed('Push complete.');
+  const { created, updated } = result.value;
+  console.log(
+    `  Created ${created.milestones + created.issues}, Updated ${updated.milestones + updated.issues}`,
+  );
+}
 
 function printPreview(result: {
   created: { milestones: number; issues: number };

--- a/packages/cli/src/commands/sync.ts
+++ b/packages/cli/src/commands/sync.ts
@@ -1,5 +1,12 @@
-import { loadConfig, syncWithGitHub } from '@gitpm/sync-github';
+import {
+  loadConfig as loadGitHubConfig,
+  syncWithGitHub,
+} from '@gitpm/sync-github';
 import type { ConflictStrategy } from '@gitpm/sync-github';
+import {
+  loadConfig as loadGitLabConfig,
+  syncWithGitLab,
+} from '@gitpm/sync-gitlab';
 import { confirm } from '@inquirer/prompts';
 import chalk from 'chalk';
 import { Command } from 'commander';
@@ -10,8 +17,8 @@ import { promptConflictResolution } from '../utils/conflict-ui.js';
 import { printError, printSuccess } from '../utils/output.js';
 
 export const syncCommand = new Command('sync')
-  .description('Bidirectional sync between local .meta/ and GitHub')
-  .option('--token <token>', 'GitHub personal access token')
+  .description('Bidirectional sync between local .meta/ and GitHub/GitLab')
+  .option('--token <token>', 'Personal access token')
   .option(
     '--strategy <strategy>',
     'Conflict resolution strategy (local-wins, remote-wins, ask)',
@@ -23,100 +30,189 @@ export const syncCommand = new Command('sync')
     const metaDir = resolveMetaDir(cmd.optsWithGlobals().metaDir);
     const strategy = opts.strategy as ConflictStrategy;
 
-    let token: string;
-    try {
-      token = await resolveToken(opts.token);
-    } catch (err) {
-      printError(
-        err instanceof Error ? err.message : 'Failed to resolve token.',
-      );
-      process.exit(1);
-    }
+    // Detect platform
+    const ghConfig = await loadGitHubConfig(metaDir);
+    const glConfig = await loadGitLabConfig(metaDir);
 
-    // Load config to get repo
-    const configResult = await loadConfig(metaDir);
-    if (!configResult.ok) {
+    if (glConfig.ok) {
+      await syncGitLab(opts, metaDir, glConfig.value, strategy);
+    } else if (ghConfig.ok) {
+      await syncGitHub(opts, metaDir, ghConfig.value.repo, strategy);
+    } else {
       printError(
         'No sync config found. Run `gitpm import` first to set up sync.',
       );
       process.exit(1);
     }
-    const repo = configResult.value.repo;
+  });
 
-    if (opts.dryRun) {
-      const spinner = ora('Calculating sync changes...').start();
-      const result = await syncWithGitHub({
-        token,
-        repo,
-        metaDir,
-        strategy,
-        dryRun: true,
-      });
+async function syncGitHub(
+  opts: Record<string, string | boolean | undefined>,
+  metaDir: string,
+  repo: string,
+  strategy: ConflictStrategy,
+): Promise<void> {
+  let token: string;
+  try {
+    token = await resolveToken(opts.token as string | undefined);
+  } catch (err) {
+    printError(err instanceof Error ? err.message : 'Failed to resolve token.');
+    process.exit(1);
+  }
 
-      if (!result.ok) {
-        spinner.fail('Dry run failed.');
-        printError(result.error.message);
-        process.exit(1);
-      }
-
-      spinner.succeed('Dry run complete.');
-      printSyncSummary(result.value);
-      return;
-    }
-
-    if (!opts.yes) {
-      const confirmed = await confirm({
-        message: 'Run bidirectional sync with GitHub?',
-        default: true,
-      });
-      if (!confirmed) {
-        console.log(chalk.dim('Sync cancelled.'));
-        return;
-      }
-    }
-
-    const spinner = ora('Syncing with GitHub...').start();
+  if (opts.dryRun) {
+    const spinner = ora('Calculating sync changes...').start();
     const result = await syncWithGitHub({
       token,
       repo,
       metaDir,
-      strategy: strategy === 'ask' ? 'ask' : strategy,
+      strategy,
+      dryRun: true,
     });
 
     if (!result.ok) {
-      spinner.fail('Sync failed.');
+      spinner.fail('Dry run failed.');
       printError(result.error.message);
       process.exit(1);
     }
 
-    spinner.succeed('Sync complete.');
+    spinner.succeed('Dry run complete.');
+    printSyncSummary(result.value, 'GitHub');
+    return;
+  }
 
-    const { conflicts } = result.value;
-
-    // Handle interactive conflict resolution if strategy is 'ask'
-    if (strategy === 'ask' && conflicts.length > 0) {
-      console.log();
-      console.log(
-        chalk.yellow(`${conflicts.length} conflict(s) require resolution:`),
-      );
-      const resolutions = await promptConflictResolution(conflicts);
-      console.log(
-        chalk.dim(
-          `Resolved ${resolutions.length}, skipped ${conflicts.length - resolutions.length}`,
-        ),
-      );
+  if (!opts.yes) {
+    const confirmed = await confirm({
+      message: 'Run bidirectional sync with GitHub?',
+      default: true,
+    });
+    if (!confirmed) {
+      console.log(chalk.dim('Sync cancelled.'));
+      return;
     }
+  }
 
-    printSyncSummary(result.value);
+  const spinner = ora('Syncing with GitHub...').start();
+  const result = await syncWithGitHub({
+    token,
+    repo,
+    metaDir,
+    strategy: strategy === 'ask' ? 'ask' : strategy,
   });
 
-function printSyncSummary(result: {
-  pushed: { milestones: number; issues: number };
-  pulled: { milestones: number; issues: number };
-  conflicts: unknown[];
-  resolved: number;
-  skipped: number;
-}): void {
+  if (!result.ok) {
+    spinner.fail('Sync failed.');
+    printError(result.error.message);
+    process.exit(1);
+  }
+
+  spinner.succeed('Sync complete.');
+  await handleConflicts(result.value, strategy);
+  printSyncSummary(result.value, 'GitHub');
+}
+
+async function syncGitLab(
+  opts: Record<string, string | boolean | undefined>,
+  metaDir: string,
+  config: { project: string; project_id: number; base_url: string },
+  strategy: ConflictStrategy,
+): Promise<void> {
+  const token = (opts.token as string | undefined) ?? process.env.GITLAB_TOKEN;
+  if (!token) {
+    printError(
+      'No GitLab token found. Provide via --token flag or GITLAB_TOKEN env var.',
+    );
+    process.exit(1);
+  }
+
+  if (opts.dryRun) {
+    const spinner = ora('Calculating sync changes...').start();
+    const result = await syncWithGitLab({
+      token,
+      project: config.project,
+      projectId: config.project_id,
+      baseUrl: config.base_url,
+      metaDir,
+      strategy,
+      dryRun: true,
+    });
+
+    if (!result.ok) {
+      spinner.fail('Dry run failed.');
+      printError(result.error.message);
+      process.exit(1);
+    }
+
+    spinner.succeed('Dry run complete.');
+    printSyncSummary(result.value, 'GitLab');
+    return;
+  }
+
+  if (!opts.yes) {
+    const confirmed = await confirm({
+      message: 'Run bidirectional sync with GitLab?',
+      default: true,
+    });
+    if (!confirmed) {
+      console.log(chalk.dim('Sync cancelled.'));
+      return;
+    }
+  }
+
+  const spinner = ora('Syncing with GitLab...').start();
+  const result = await syncWithGitLab({
+    token,
+    project: config.project,
+    projectId: config.project_id,
+    baseUrl: config.base_url,
+    metaDir,
+    strategy: strategy === 'ask' ? 'ask' : strategy,
+  });
+
+  if (!result.ok) {
+    spinner.fail('Sync failed.');
+    printError(result.error.message);
+    process.exit(1);
+  }
+
+  spinner.succeed('Sync complete.');
+  await handleConflicts(result.value, strategy);
+  printSyncSummary(result.value, 'GitLab');
+}
+
+async function handleConflicts(
+  result: {
+    conflicts: unknown[];
+  },
+  strategy: ConflictStrategy,
+): Promise<void> {
+  const { conflicts } = result;
+  if (strategy === 'ask' && conflicts.length > 0) {
+    console.log();
+    console.log(
+      chalk.yellow(`${conflicts.length} conflict(s) require resolution:`),
+    );
+    const resolutions = await promptConflictResolution(
+      conflicts as Parameters<typeof promptConflictResolution>[0],
+    );
+    console.log(
+      chalk.dim(
+        `Resolved ${resolutions.length}, skipped ${conflicts.length - resolutions.length}`,
+      ),
+    );
+  }
+}
+
+function printSyncSummary(
+  result: {
+    pushed: { milestones: number; issues: number };
+    pulled: { milestones: number; issues: number };
+    conflicts: unknown[];
+    resolved: number;
+    skipped: number;
+  },
+  platform: string,
+): void {
   const pushedTotal = result.pushed.milestones + result.pushed.issues;
   const pulledTotal = result.pulled.milestones + result.pulled.issues;
 
@@ -125,7 +221,7 @@ function printSyncSummary(result: {
   console.log(chalk.bold('│           Sync Complete              │'));
   console.log(chalk.bold('├──────────────────┬───────────────────┤'));
   console.log(
-    `${chalk.bold('│')} Pushed to GitHub │ ${String(pushedTotal).padEnd(17)} ${chalk.bold('│')}`,
+    `${chalk.bold('│')} Pushed to ${platform.padEnd(6)} │ ${String(pushedTotal).padEnd(17)} ${chalk.bold('│')}`,
   );
   console.log(
     `${chalk.bold('│')} Pulled to local  │ ${String(pulledTotal).padEnd(17)} ${chalk.bold('│')}`,

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -21,7 +21,7 @@ program
   .description('Git-native project management')
   .version(pkg.version)
   .option('--meta-dir <path>', 'Path to .meta directory', '.meta')
-  .option('--token <token>', 'GitHub personal access token');
+  .option('--token <token>', 'Personal access token (GitHub or GitLab)');
 
 program.addCommand(initCommand);
 program.addCommand(validateCommand);

--- a/packages/core/src/schemas/common.ts
+++ b/packages/core/src/schemas/common.ts
@@ -42,6 +42,17 @@ export const jiraSyncSchema = z.object({
 });
 export type JiraSync = z.infer<typeof jiraSyncSchema>;
 
+export const gitLabSyncSchema = z.object({
+  issue_iid: z.number().int().optional(),
+  epic_iid: z.number().int().optional(),
+  milestone_id: z.number().int().optional(),
+  project_id: z.number().int(),
+  base_url: z.string(),
+  last_sync_hash: z.string(),
+  synced_at: z.string(),
+});
+export type GitLabSync = z.infer<typeof gitLabSyncSchema>;
+
 export type Result<T, E = Error> =
   | { ok: true; value: T }
   | { ok: false; error: E };

--- a/packages/core/src/schemas/epic.ts
+++ b/packages/core/src/schemas/epic.ts
@@ -3,6 +3,7 @@ import {
   entityIdSchema,
   entityRefSchema,
   gitHubSyncSchema,
+  gitLabSyncSchema,
   jiraSyncSchema,
   prioritySchema,
   statusSchema,
@@ -19,6 +20,7 @@ export const epicFrontmatterSchema = z.object({
   milestone_ref: entityRefSchema.nullable().optional(),
   github: gitHubSyncSchema.nullable().optional(),
   jira: jiraSyncSchema.nullable().optional(),
+  gitlab: gitLabSyncSchema.nullable().optional(),
   created_at: z.string().optional(),
   updated_at: z.string().optional(),
 });

--- a/packages/core/src/schemas/index.ts
+++ b/packages/core/src/schemas/index.ts
@@ -5,6 +5,7 @@ export {
   entityRefSchema,
   gitHubSyncSchema,
   jiraSyncSchema,
+  gitLabSyncSchema,
 } from './common.js';
 export type {
   EntityId,
@@ -13,6 +14,7 @@ export type {
   EntityRef,
   GitHubSync,
   JiraSync,
+  GitLabSync,
   Result,
 } from './common.js';
 

--- a/packages/core/src/schemas/milestone.ts
+++ b/packages/core/src/schemas/milestone.ts
@@ -2,6 +2,7 @@ import { z } from 'zod';
 import {
   entityIdSchema,
   gitHubSyncSchema,
+  gitLabSyncSchema,
   jiraSyncSchema,
   statusSchema,
 } from './common.js';
@@ -14,6 +15,7 @@ export const milestoneFrontmatterSchema = z.object({
   status: statusSchema,
   github: gitHubSyncSchema.nullable().optional(),
   jira: jiraSyncSchema.nullable().optional(),
+  gitlab: gitLabSyncSchema.nullable().optional(),
   created_at: z.string().optional(),
   updated_at: z.string().optional(),
 });

--- a/packages/core/src/schemas/story.ts
+++ b/packages/core/src/schemas/story.ts
@@ -3,6 +3,7 @@ import {
   entityIdSchema,
   entityRefSchema,
   gitHubSyncSchema,
+  gitLabSyncSchema,
   jiraSyncSchema,
   prioritySchema,
   statusSchema,
@@ -20,6 +21,7 @@ export const storyFrontmatterSchema = z.object({
   epic_ref: entityRefSchema.nullable().optional(),
   github: gitHubSyncSchema.nullable().optional(),
   jira: jiraSyncSchema.nullable().optional(),
+  gitlab: gitLabSyncSchema.nullable().optional(),
   created_at: z.string().optional(),
   updated_at: z.string().optional(),
 });

--- a/packages/sync-gitlab/package.json
+++ b/packages/sync-gitlab/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "@gitpm/sync-gitlab",
+  "version": "0.1.0",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
+  "scripts": {
+    "build": "tsup"
+  },
+  "dependencies": {
+    "@gitpm/core": "workspace:*",
+    "nanoid": "^5.0.8",
+    "yaml": "^2.6.0"
+  }
+}

--- a/packages/sync-gitlab/src/__fixtures__/gitlab-issues.json
+++ b/packages/sync-gitlab/src/__fixtures__/gitlab-issues.json
@@ -1,0 +1,72 @@
+[
+  {
+    "id": 1001,
+    "iid": 1,
+    "title": "User Authentication",
+    "description": "Implement user login and registration flow.\n\nPart of #2",
+    "state": "opened",
+    "assignee": { "id": 42, "username": "alice" },
+    "labels": ["feature", "epic"],
+    "milestone": { "id": 101, "iid": 1, "title": "v0.1 - MVP" },
+    "weight": 5,
+    "epic_iid": null,
+    "created_at": "2026-02-01T10:00:00Z",
+    "updated_at": "2026-02-01T10:00:00Z"
+  },
+  {
+    "id": 1002,
+    "iid": 2,
+    "title": "API Gateway",
+    "description": "Set up API gateway with rate limiting and auth middleware.",
+    "state": "opened",
+    "assignee": { "id": 43, "username": "bob" },
+    "labels": ["feature", "epic"],
+    "milestone": { "id": 101, "iid": 1, "title": "v0.1 - MVP" },
+    "weight": 8,
+    "epic_iid": null,
+    "created_at": "2026-02-01T10:00:00Z",
+    "updated_at": "2026-02-01T10:00:00Z"
+  },
+  {
+    "id": 1003,
+    "iid": 3,
+    "title": "Add OAuth2 provider support",
+    "description": "Support Google and GitHub OAuth2 login.\n\nRelated to #1",
+    "state": "opened",
+    "assignee": { "id": 42, "username": "alice" },
+    "labels": ["feature"],
+    "milestone": { "id": 101, "iid": 1, "title": "v0.1 - MVP" },
+    "weight": 3,
+    "epic_iid": null,
+    "created_at": "2026-02-05T10:00:00Z",
+    "updated_at": "2026-02-05T10:00:00Z"
+  },
+  {
+    "id": 1004,
+    "iid": 4,
+    "title": "Implement rate limiter middleware",
+    "description": "Token bucket rate limiter for API endpoints.",
+    "state": "closed",
+    "assignee": { "id": 43, "username": "bob" },
+    "labels": ["feature"],
+    "milestone": { "id": 101, "iid": 1, "title": "v0.1 - MVP" },
+    "weight": 2,
+    "epic_iid": null,
+    "created_at": "2026-02-10T10:00:00Z",
+    "updated_at": "2026-03-01T12:00:00Z"
+  },
+  {
+    "id": 1005,
+    "iid": 5,
+    "title": "Fix login page styling",
+    "description": "The login page has alignment issues on mobile.",
+    "state": "opened",
+    "assignee": null,
+    "labels": ["bug"],
+    "milestone": null,
+    "weight": null,
+    "epic_iid": null,
+    "created_at": "2026-03-01T10:00:00Z",
+    "updated_at": "2026-03-01T10:00:00Z"
+  }
+]

--- a/packages/sync-gitlab/src/__fixtures__/gitlab-milestones.json
+++ b/packages/sync-gitlab/src/__fixtures__/gitlab-milestones.json
@@ -1,0 +1,22 @@
+[
+  {
+    "id": 101,
+    "iid": 1,
+    "title": "v0.1 - MVP",
+    "description": "Initial minimal viable product release.",
+    "state": "active",
+    "due_date": "2026-06-30",
+    "created_at": "2026-01-15T10:00:00Z",
+    "updated_at": "2026-01-15T10:00:00Z"
+  },
+  {
+    "id": 102,
+    "iid": 2,
+    "title": "v0.2 - Polish",
+    "description": "Bug fixes and UX polish.",
+    "state": "closed",
+    "due_date": "2026-09-30",
+    "created_at": "2026-01-15T10:00:00Z",
+    "updated_at": "2026-03-01T12:00:00Z"
+  }
+]

--- a/packages/sync-gitlab/src/__tests__/conflict.test.ts
+++ b/packages/sync-gitlab/src/__tests__/conflict.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest';
+import { applyResolutions, resolveConflicts } from '../conflict.js';
+import type { FieldConflict } from '../types.js';
+
+const conflict: FieldConflict = {
+  entityId: 'e1',
+  entityTitle: 'Test Entity',
+  entityType: 'story',
+  field: 'title',
+  baseValue: 'Original',
+  localValue: 'Local Change',
+  remoteValue: 'Remote Change',
+};
+
+describe('resolveConflicts', () => {
+  it('local-wins picks local for all conflicts', () => {
+    const resolutions = resolveConflicts([conflict], 'local-wins');
+    expect(resolutions).toHaveLength(1);
+    expect(resolutions[0].pick).toBe('local');
+  });
+
+  it('remote-wins picks remote for all conflicts', () => {
+    const resolutions = resolveConflicts([conflict], 'remote-wins');
+    expect(resolutions).toHaveLength(1);
+    expect(resolutions[0].pick).toBe('remote');
+  });
+
+  it('ask returns empty array', () => {
+    const resolutions = resolveConflicts([conflict], 'ask');
+    expect(resolutions).toHaveLength(0);
+  });
+});
+
+describe('applyResolutions', () => {
+  it('applies local pick', () => {
+    const result = applyResolutions(
+      { title: 'Local Change', status: 'todo' },
+      { title: 'Remote Change', status: 'done' },
+      [conflict],
+      [{ entityId: 'e1', field: 'title', pick: 'local' }],
+    );
+    expect(result.title).toBe('Local Change');
+    // Non-conflicting field from remote should be applied
+    expect(result.status).toBe('done');
+  });
+
+  it('applies remote pick', () => {
+    const result = applyResolutions(
+      { title: 'Local Change', status: 'todo' },
+      { title: 'Remote Change', status: 'done' },
+      [conflict],
+      [{ entityId: 'e1', field: 'title', pick: 'remote' }],
+    );
+    expect(result.title).toBe('Remote Change');
+  });
+});

--- a/packages/sync-gitlab/src/__tests__/diff.test.ts
+++ b/packages/sync-gitlab/src/__tests__/diff.test.ts
@@ -1,0 +1,181 @@
+import type { Story } from '@gitpm/core';
+import { describe, expect, it } from 'vitest';
+import type { GlIssue, GlMilestone } from '../client.js';
+import {
+  diffByHash,
+  diffEntity,
+  remoteIssueFields,
+  remoteMilestoneFields,
+} from '../diff.js';
+import { computeContentHash } from '../state.js';
+import type { SyncStateEntry } from '../types.js';
+
+describe('remoteIssueFields', () => {
+  it('extracts fields from GitLab issue', () => {
+    const gl: GlIssue = {
+      id: 1,
+      iid: 1,
+      title: 'Test Issue',
+      description: 'A test issue.',
+      state: 'opened',
+      assignee: { id: 42, username: 'alice' },
+      labels: ['feature', 'epic'],
+      milestone: null,
+      weight: null,
+      epic_iid: null,
+      created_at: '2026-01-01T00:00:00Z',
+      updated_at: '2026-01-01T00:00:00Z',
+    };
+
+    const fields = remoteIssueFields(gl);
+    expect(fields.title).toBe('Test Issue');
+    expect(fields.status).toBe('todo');
+    expect(fields.assignee).toBe('alice');
+    // 'epic' label should be filtered out
+    expect(fields.labels).toEqual(['feature']);
+    expect(fields.body).toBe('A test issue.');
+  });
+
+  it('maps closed state to done', () => {
+    const gl: GlIssue = {
+      id: 1,
+      iid: 1,
+      title: 'Test',
+      description: null,
+      state: 'closed',
+      assignee: null,
+      labels: [],
+      milestone: null,
+      weight: null,
+      epic_iid: null,
+      created_at: '2026-01-01T00:00:00Z',
+      updated_at: '2026-01-01T00:00:00Z',
+    };
+    expect(remoteIssueFields(gl).status).toBe('done');
+  });
+});
+
+describe('remoteMilestoneFields', () => {
+  it('extracts fields from GitLab milestone', () => {
+    const gl: GlMilestone = {
+      id: 1,
+      iid: 1,
+      title: 'v1.0',
+      description: 'First release',
+      state: 'active',
+      due_date: '2026-06-30',
+      created_at: '2026-01-01T00:00:00Z',
+      updated_at: '2026-01-01T00:00:00Z',
+    };
+
+    const fields = remoteMilestoneFields(gl);
+    expect(fields.title).toBe('v1.0');
+    expect(fields.status).toBe('in_progress');
+    expect(fields.target_date).toBe('2026-06-30');
+    expect(fields.body).toBe('First release');
+  });
+
+  it('maps closed state to done', () => {
+    const gl: GlMilestone = {
+      id: 1,
+      iid: 1,
+      title: 'v1.0',
+      description: null,
+      state: 'closed',
+      due_date: null,
+      created_at: '2026-01-01T00:00:00Z',
+      updated_at: '2026-01-01T00:00:00Z',
+    };
+    expect(remoteMilestoneFields(gl).status).toBe('done');
+  });
+});
+
+describe('diffByHash', () => {
+  it('returns in_sync when hashes match', () => {
+    const entry: SyncStateEntry = {
+      local_hash: 'sha256:abc',
+      remote_hash: 'sha256:xyz',
+      synced_at: '2026-01-01T00:00:00Z',
+    };
+    expect(diffByHash('sha256:abc', 'sha256:xyz', entry)).toBe('in_sync');
+  });
+
+  it('returns local_changed when local hash differs', () => {
+    const entry: SyncStateEntry = {
+      local_hash: 'sha256:abc',
+      remote_hash: 'sha256:xyz',
+      synced_at: '2026-01-01T00:00:00Z',
+    };
+    expect(diffByHash('sha256:changed', 'sha256:xyz', entry)).toBe(
+      'local_changed',
+    );
+  });
+
+  it('returns remote_changed when remote hash differs', () => {
+    const entry: SyncStateEntry = {
+      local_hash: 'sha256:abc',
+      remote_hash: 'sha256:xyz',
+      synced_at: '2026-01-01T00:00:00Z',
+    };
+    expect(diffByHash('sha256:abc', 'sha256:changed', entry)).toBe(
+      'remote_changed',
+    );
+  });
+
+  it('returns both_changed when both hashes differ', () => {
+    const entry: SyncStateEntry = {
+      local_hash: 'sha256:abc',
+      remote_hash: 'sha256:xyz',
+      synced_at: '2026-01-01T00:00:00Z',
+    };
+    expect(diffByHash('sha256:new1', 'sha256:new2', entry)).toBe(
+      'both_changed',
+    );
+  });
+});
+
+describe('computeContentHash', () => {
+  it('produces deterministic hash for a story', () => {
+    const story: Story = {
+      type: 'story',
+      id: 'test-id',
+      title: 'Test Story',
+      status: 'todo',
+      priority: 'medium',
+      assignee: 'alice',
+      labels: ['feature'],
+      estimate: null,
+      epic_ref: null,
+      body: 'A test story.',
+      filePath: '.meta/stories/test-story.md',
+    };
+
+    const hash1 = computeContentHash(story);
+    const hash2 = computeContentHash(story);
+    expect(hash1).toBe(hash2);
+    expect(hash1).toMatch(/^sha256:/);
+  });
+
+  it('produces different hash when content changes', () => {
+    const story1: Story = {
+      type: 'story',
+      id: 'test-id',
+      title: 'Test Story',
+      status: 'todo',
+      priority: 'medium',
+      assignee: null,
+      labels: [],
+      estimate: null,
+      epic_ref: null,
+      body: '',
+      filePath: '.meta/stories/test.md',
+    };
+
+    const story2: Story = {
+      ...story1,
+      title: 'Different Story',
+    };
+
+    expect(computeContentHash(story1)).not.toBe(computeContentHash(story2));
+  });
+});

--- a/packages/sync-gitlab/src/__tests__/import.test.ts
+++ b/packages/sync-gitlab/src/__tests__/import.test.ts
@@ -1,0 +1,109 @@
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { parseTree, resolveRefs, validateTree } from '@gitpm/core';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { GlIssue, GlMilestone } from '../client.js';
+import { importFromGitLab } from '../import.js';
+
+import issueFixtures from '../__fixtures__/gitlab-issues.json';
+import milestoneFixtures from '../__fixtures__/gitlab-milestones.json';
+
+// Mock GitLabClient
+vi.mock('../client.js', () => {
+  return {
+    GitLabClient: vi.fn().mockImplementation(() => ({
+      getProject: vi.fn().mockResolvedValue({
+        id: 42,
+        name: 'test-project',
+        path_with_namespace: 'test-ns/test-project',
+        namespace: { id: 10, kind: 'group', full_path: 'test-ns' },
+      }),
+      listMilestones: vi.fn().mockResolvedValue(milestoneFixtures),
+      listIssues: vi.fn().mockResolvedValue(issueFixtures),
+      listGroupEpics: vi.fn().mockResolvedValue([]),
+      listEpicIssues: vi.fn().mockResolvedValue([]),
+    })),
+  };
+});
+
+describe('importFromGitLab', () => {
+  let metaDir: string;
+
+  beforeEach(async () => {
+    metaDir = await mkdtemp(join(tmpdir(), 'gitpm-import-'));
+  });
+
+  afterEach(async () => {
+    await rm(metaDir, { recursive: true });
+  });
+
+  it('imports milestones, epics, and stories', async () => {
+    const result = await importFromGitLab({
+      token: 'test-token',
+      project: 'test-ns/test-project',
+      metaDir,
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+
+    // 2 milestones from fixture
+    expect(result.value.milestones).toBe(2);
+    // 2 epics (issues with 'epic' label: iid 1 and 2)
+    expect(result.value.epics).toBe(2);
+    // 3 stories (issues without 'epic' label: iid 3, 4, 5)
+    expect(result.value.stories).toBe(3);
+    // total files = milestones + epics + stories + roadmap + config + state
+    expect(result.value.totalFiles).toBe(2 + 2 + 3 + 1 + 1 + 1);
+  });
+
+  it('creates valid tree structure', async () => {
+    const result = await importFromGitLab({
+      token: 'test-token',
+      project: 'test-ns/test-project',
+      metaDir,
+    });
+    expect(result.ok).toBe(true);
+
+    const treeResult = await parseTree(metaDir);
+    expect(treeResult.ok).toBe(true);
+    if (!treeResult.ok) return;
+
+    const tree = treeResult.value;
+    expect(tree.milestones.length).toBe(2);
+    expect(tree.epics.length).toBe(2);
+
+    const resolved = resolveRefs(tree);
+    expect(resolved.ok).toBe(true);
+    if (!resolved.ok) return;
+    const validation = validateTree(resolved.value);
+    expect(validation.errors).toHaveLength(0);
+  });
+
+  it('creates config and state files', async () => {
+    const result = await importFromGitLab({
+      token: 'test-token',
+      project: 'test-ns/test-project',
+      metaDir,
+    });
+    expect(result.ok).toBe(true);
+
+    // Verify config exists
+    const { readFile } = await import('node:fs/promises');
+    const configRaw = await readFile(
+      join(metaDir, 'sync', 'gitlab-config.yaml'),
+      'utf-8',
+    );
+    expect(configRaw).toContain('test-ns/test-project');
+
+    // Verify state exists
+    const stateRaw = await readFile(
+      join(metaDir, 'sync', 'gitlab-state.json'),
+      'utf-8',
+    );
+    const state = JSON.parse(stateRaw);
+    expect(state.project).toBe('test-ns/test-project');
+    expect(Object.keys(state.entities).length).toBeGreaterThan(0);
+  });
+});

--- a/packages/sync-gitlab/src/__tests__/linker.test.ts
+++ b/packages/sync-gitlab/src/__tests__/linker.test.ts
@@ -1,0 +1,195 @@
+import type { Epic, Story } from '@gitpm/core';
+import { describe, expect, it } from 'vitest';
+import type { GlIssue } from '../client.js';
+import type { LinkContext } from '../linker.js';
+import { resolveEpicLink } from '../linker.js';
+
+function makeEpic(id: string, title: string): Epic {
+  return {
+    type: 'epic',
+    id,
+    title,
+    status: 'todo',
+    priority: 'medium',
+    owner: null,
+    labels: [],
+    milestone_ref: null,
+    body: '',
+    filePath: '',
+  };
+}
+
+function makeStory(id: string, title: string): Story {
+  return {
+    type: 'story',
+    id,
+    title,
+    status: 'todo',
+    priority: 'medium',
+    assignee: null,
+    labels: [],
+    estimate: null,
+    epic_ref: null,
+    body: '',
+    filePath: '',
+  };
+}
+
+function makeGlIssue(overrides: Partial<GlIssue> & { iid: number }): GlIssue {
+  return {
+    id: overrides.iid * 100,
+    iid: overrides.iid,
+    title: overrides.title ?? `Issue ${overrides.iid}`,
+    description: overrides.description ?? null,
+    state: overrides.state ?? 'opened',
+    assignee: overrides.assignee ?? null,
+    labels: overrides.labels ?? [],
+    milestone: overrides.milestone ?? null,
+    weight: overrides.weight ?? null,
+    epic_iid: overrides.epic_iid ?? null,
+    created_at: '2026-01-01T00:00:00Z',
+    updated_at: '2026-01-01T00:00:00Z',
+  };
+}
+
+describe('resolveEpicLink', () => {
+  const epic = makeEpic('epic-1', 'Auth Epic');
+  const story = makeStory('story-1', 'OAuth Login');
+
+  describe('body-refs strategy', () => {
+    it('finds epic ref in issue description', () => {
+      const epicIssue = makeGlIssue({ iid: 10, labels: ['epic'] });
+      const storyIssue = makeGlIssue({
+        iid: 11,
+        description: 'Related to #10',
+      });
+
+      const ctx: LinkContext = {
+        glIssues: [epicIssue, storyIssue],
+        issueIidToEntity: new Map([
+          [10, epic],
+          [11, story],
+        ]),
+        epicIssueIidToEpic: new Map([[10, epic]]),
+        nativeEpicIssueIids: new Map(),
+      };
+
+      const result = resolveEpicLink(storyIssue, story, ctx, 'body-refs');
+      expect(result).not.toBeNull();
+      expect(result?.epicRef.id).toBe('epic-1');
+      expect(result?.parentEpicSlug).toBe('auth-epic');
+    });
+
+    it('returns null when no ref found', () => {
+      const storyIssue = makeGlIssue({ iid: 11, description: 'No refs here' });
+      const ctx: LinkContext = {
+        glIssues: [storyIssue],
+        issueIidToEntity: new Map([[11, story]]),
+        epicIssueIidToEpic: new Map(),
+        nativeEpicIssueIids: new Map(),
+      };
+
+      const result = resolveEpicLink(storyIssue, story, ctx, 'body-refs');
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('milestone strategy', () => {
+    it('links story to epic when they share a milestone', () => {
+      const milestone = { id: 101, iid: 1, title: 'v1' };
+      const epicIssue = makeGlIssue({
+        iid: 10,
+        labels: ['epic'],
+        milestone,
+      });
+      const storyIssue = makeGlIssue({ iid: 11, milestone });
+
+      const ctx: LinkContext = {
+        glIssues: [epicIssue, storyIssue],
+        issueIidToEntity: new Map([
+          [10, epic],
+          [11, story],
+        ]),
+        epicIssueIidToEpic: new Map([[10, epic]]),
+        nativeEpicIssueIids: new Map(),
+      };
+
+      const result = resolveEpicLink(storyIssue, story, ctx, 'milestone');
+      expect(result).not.toBeNull();
+      expect(result?.epicRef.id).toBe('epic-1');
+    });
+  });
+
+  describe('labels strategy', () => {
+    it('links story to epic when they share exactly one non-epic label', () => {
+      const epicIssue = makeGlIssue({
+        iid: 10,
+        labels: ['epic', 'auth'],
+      });
+      const storyIssue = makeGlIssue({
+        iid: 11,
+        labels: ['auth'],
+      });
+
+      const ctx: LinkContext = {
+        glIssues: [epicIssue, storyIssue],
+        issueIidToEntity: new Map([
+          [10, epic],
+          [11, story],
+        ]),
+        epicIssueIidToEpic: new Map([[10, epic]]),
+        nativeEpicIssueIids: new Map(),
+      };
+
+      const result = resolveEpicLink(storyIssue, story, ctx, 'labels');
+      expect(result).not.toBeNull();
+      expect(result?.epicRef.id).toBe('epic-1');
+    });
+  });
+
+  describe('native-epics strategy', () => {
+    it('links via nativeEpicIssueIids map', () => {
+      const storyIssue = makeGlIssue({ iid: 11 });
+      const epicIssue = makeGlIssue({ iid: 10, labels: ['epic'] });
+
+      const ctx: LinkContext = {
+        glIssues: [epicIssue, storyIssue],
+        issueIidToEntity: new Map([
+          [10, epic],
+          [11, story],
+        ]),
+        epicIssueIidToEpic: new Map([[10, epic]]),
+        nativeEpicIssueIids: new Map([[10, [11]]]),
+      };
+
+      const result = resolveEpicLink(storyIssue, story, ctx, 'native-epics');
+      expect(result).not.toBeNull();
+      expect(result?.epicRef.id).toBe('epic-1');
+    });
+  });
+
+  describe('all strategy', () => {
+    it('tries all strategies in order', () => {
+      const epicIssue = makeGlIssue({ iid: 10, labels: ['epic', 'auth'] });
+      const storyIssue = makeGlIssue({
+        iid: 11,
+        description: 'Related to #10',
+        labels: ['auth'],
+      });
+
+      const ctx: LinkContext = {
+        glIssues: [epicIssue, storyIssue],
+        issueIidToEntity: new Map([
+          [10, epic],
+          [11, story],
+        ]),
+        epicIssueIidToEpic: new Map([[10, epic]]),
+        nativeEpicIssueIids: new Map(),
+      };
+
+      const result = resolveEpicLink(storyIssue, story, ctx, 'all');
+      expect(result).not.toBeNull();
+      expect(result?.epicRef.id).toBe('epic-1');
+    });
+  });
+});

--- a/packages/sync-gitlab/src/__tests__/mapper.test.ts
+++ b/packages/sync-gitlab/src/__tests__/mapper.test.ts
@@ -1,0 +1,313 @@
+import { describe, expect, it } from 'vitest';
+import type { GlIssue, GlMilestone } from '../client.js';
+import {
+  determineFilePath,
+  entityToGlIssue,
+  glEpicToEpic,
+  glIssueToEntity,
+  glMilestoneToMilestone,
+  isEpicIssue,
+  milestoneToGlMilestone,
+} from '../mapper.js';
+import type { GitLabConfig } from '../types.js';
+
+const PROJECT_ID = 42;
+const BASE_URL = 'https://gitlab.com';
+
+const baseMilestone: GlMilestone = {
+  id: 101,
+  iid: 1,
+  title: 'v0.1 - MVP',
+  description: 'Initial minimal viable product release.',
+  state: 'active',
+  due_date: '2026-06-30',
+  created_at: '2026-01-15T10:00:00Z',
+  updated_at: '2026-01-15T10:00:00Z',
+};
+
+const epicIssue: GlIssue = {
+  id: 1001,
+  iid: 1,
+  title: 'User Authentication',
+  description: 'Implement user login and registration flow.',
+  state: 'opened',
+  assignee: { id: 42, username: 'alice' },
+  labels: ['feature', 'epic'],
+  milestone: { id: 101, iid: 1, title: 'v0.1 - MVP' },
+  weight: 5,
+  epic_iid: null,
+  created_at: '2026-02-01T10:00:00Z',
+  updated_at: '2026-02-01T10:00:00Z',
+};
+
+const storyIssue: GlIssue = {
+  id: 1003,
+  iid: 3,
+  title: 'Add OAuth2 provider support',
+  description: 'Support Google and GitHub OAuth2 login.',
+  state: 'opened',
+  assignee: { id: 42, username: 'alice' },
+  labels: ['feature'],
+  milestone: { id: 101, iid: 1, title: 'v0.1 - MVP' },
+  weight: 3,
+  epic_iid: null,
+  created_at: '2026-02-05T10:00:00Z',
+  updated_at: '2026-02-05T10:00:00Z',
+};
+
+const closedIssue: GlIssue = {
+  id: 1004,
+  iid: 4,
+  title: 'Implement rate limiter middleware',
+  description: 'Token bucket rate limiter for API endpoints.',
+  state: 'closed',
+  assignee: { id: 43, username: 'bob' },
+  labels: ['feature'],
+  milestone: { id: 101, iid: 1, title: 'v0.1 - MVP' },
+  weight: 2,
+  epic_iid: null,
+  created_at: '2026-02-10T10:00:00Z',
+  updated_at: '2026-03-01T12:00:00Z',
+};
+
+const noDescIssue: GlIssue = {
+  id: 1005,
+  iid: 5,
+  title: 'Fix login page styling',
+  description: null,
+  state: 'opened',
+  assignee: null,
+  labels: ['bug'],
+  milestone: null,
+  weight: null,
+  epic_iid: null,
+  created_at: '2026-03-01T10:00:00Z',
+  updated_at: '2026-03-01T10:00:00Z',
+};
+
+describe('glMilestoneToMilestone', () => {
+  it('maps an active milestone correctly', () => {
+    const ms = glMilestoneToMilestone(baseMilestone, PROJECT_ID, BASE_URL);
+    expect(ms.type).toBe('milestone');
+    expect(ms.title).toBe('v0.1 - MVP');
+    expect(ms.status).toBe('in_progress');
+    expect(ms.target_date).toBe('2026-06-30');
+    expect(ms.body).toBe('Initial minimal viable product release.');
+    expect(ms.gitlab?.project_id).toBe(PROJECT_ID);
+    expect(ms.gitlab?.milestone_id).toBe(101);
+    expect(ms.gitlab?.base_url).toBe(BASE_URL);
+    expect(ms.id).toHaveLength(12);
+    expect(ms.filePath).toBe('.meta/roadmap/milestones/v01-mvp.md');
+  });
+
+  it('maps a closed milestone to done status', () => {
+    const closedMs: GlMilestone = { ...baseMilestone, state: 'closed' };
+    const ms = glMilestoneToMilestone(closedMs, PROJECT_ID, BASE_URL);
+    expect(ms.status).toBe('done');
+  });
+
+  it('handles milestone with no description or due date', () => {
+    const emptyMs: GlMilestone = {
+      ...baseMilestone,
+      description: null,
+      due_date: null,
+    };
+    const ms = glMilestoneToMilestone(emptyMs, PROJECT_ID, BASE_URL);
+    expect(ms.body).toBe('');
+    expect(ms.target_date).toBeUndefined();
+  });
+});
+
+describe('isEpicIssue', () => {
+  it('returns true for issues with epic label', () => {
+    expect(isEpicIssue(epicIssue)).toBe(true);
+  });
+
+  it('returns false for issues without epic label', () => {
+    expect(isEpicIssue(storyIssue)).toBe(false);
+  });
+
+  it('uses custom epic labels from config', () => {
+    const config: Pick<GitLabConfig, 'label_mapping'> = {
+      label_mapping: { epic_labels: ['theme'] },
+    };
+    expect(isEpicIssue(epicIssue, config)).toBe(false);
+    const themeIssue: GlIssue = {
+      ...storyIssue,
+      labels: ['theme'],
+    };
+    expect(isEpicIssue(themeIssue, config)).toBe(true);
+  });
+});
+
+describe('glIssueToEntity', () => {
+  it('creates an Epic from issue with epic label', () => {
+    const entity = glIssueToEntity(epicIssue, undefined, PROJECT_ID, BASE_URL);
+    expect(entity.type).toBe('epic');
+    expect(entity.title).toBe('User Authentication');
+    expect(entity.status).toBe('todo');
+    if (entity.type === 'epic') {
+      expect(entity.owner).toBe('alice');
+      expect(entity.labels).toEqual(['feature']);
+      expect(entity.priority).toBe('high'); // weight 5
+    }
+    expect(entity.gitlab?.issue_iid).toBe(1);
+    expect(entity.gitlab?.project_id).toBe(PROJECT_ID);
+    expect(entity.id).toHaveLength(12);
+  });
+
+  it('creates a Story from issue without epic label', () => {
+    const entity = glIssueToEntity(storyIssue, undefined, PROJECT_ID, BASE_URL);
+    expect(entity.type).toBe('story');
+    expect(entity.title).toBe('Add OAuth2 provider support');
+    if (entity.type === 'story') {
+      expect(entity.assignee).toBe('alice');
+      expect(entity.labels).toEqual(['feature']);
+      expect(entity.priority).toBe('medium'); // weight 3
+    }
+  });
+
+  it('maps closed issues to done status', () => {
+    const entity = glIssueToEntity(
+      closedIssue,
+      undefined,
+      PROJECT_ID,
+      BASE_URL,
+    );
+    expect(entity.status).toBe('done');
+  });
+
+  it('handles issue with no description', () => {
+    const entity = glIssueToEntity(
+      noDescIssue,
+      undefined,
+      PROJECT_ID,
+      BASE_URL,
+    );
+    expect(entity.body).toBe('');
+  });
+
+  it('handles issue with no assignee', () => {
+    const entity = glIssueToEntity(
+      noDescIssue,
+      undefined,
+      PROJECT_ID,
+      BASE_URL,
+    );
+    if (entity.type === 'story') {
+      expect(entity.assignee).toBeNull();
+    }
+  });
+
+  it('maps weight to priority correctly', () => {
+    const lowWeight: GlIssue = { ...storyIssue, weight: 1 };
+    const medWeight: GlIssue = { ...storyIssue, weight: 4 };
+    const highWeight: GlIssue = { ...storyIssue, weight: 6 };
+    const critWeight: GlIssue = { ...storyIssue, weight: 8 };
+    const nullWeight: GlIssue = { ...storyIssue, weight: null };
+
+    expect(glIssueToEntity(lowWeight).priority).toBe('low');
+    expect(glIssueToEntity(medWeight).priority).toBe('medium');
+    expect(glIssueToEntity(highWeight).priority).toBe('high');
+    expect(glIssueToEntity(critWeight).priority).toBe('critical');
+    expect(glIssueToEntity(nullWeight).priority).toBe('medium');
+  });
+});
+
+describe('glEpicToEpic', () => {
+  it('creates an Epic from native GitLab epic', () => {
+    const glEpic = {
+      id: 201,
+      iid: 1,
+      group_id: 10,
+      title: 'Platform Migration',
+      description: 'Migrate to new platform.',
+      state: 'opened' as const,
+      labels: ['platform'],
+      created_at: '2026-01-01T00:00:00Z',
+      updated_at: '2026-01-01T00:00:00Z',
+    };
+    const epic = glEpicToEpic(glEpic, PROJECT_ID, BASE_URL);
+    expect(epic.type).toBe('epic');
+    expect(epic.title).toBe('Platform Migration');
+    expect(epic.status).toBe('todo');
+    expect(epic.gitlab?.epic_iid).toBe(1);
+    expect(epic.labels).toEqual(['platform']);
+    expect(epic.filePath).toBe('.meta/epics/platform-migration/epic.md');
+  });
+});
+
+describe('determineFilePath', () => {
+  it('places epics in .meta/epics/<slug>/epic.md', () => {
+    const entity = glIssueToEntity(epicIssue, undefined, PROJECT_ID, BASE_URL);
+    const path = determineFilePath(entity as never);
+    expect(path).toBe('.meta/epics/user-authentication/epic.md');
+  });
+
+  it('places orphan stories in .meta/stories/<slug>.md', () => {
+    const entity = glIssueToEntity(storyIssue, undefined, PROJECT_ID, BASE_URL);
+    const path = determineFilePath(entity as never);
+    expect(path).toBe('.meta/stories/add-oauth2-provider-support.md');
+  });
+
+  it('places stories under epic when parentEpicSlug is provided', () => {
+    const entity = glIssueToEntity(storyIssue, undefined, PROJECT_ID, BASE_URL);
+    const path = determineFilePath(entity as never, 'user-authentication');
+    expect(path).toBe(
+      '.meta/epics/user-authentication/stories/add-oauth2-provider-support.md',
+    );
+  });
+
+  it('places milestones in .meta/roadmap/milestones/<slug>.md', () => {
+    const ms = glMilestoneToMilestone(baseMilestone, PROJECT_ID, BASE_URL);
+    const path = determineFilePath(ms);
+    expect(path).toBe('.meta/roadmap/milestones/v01-mvp.md');
+  });
+});
+
+describe('milestoneToGlMilestone', () => {
+  it('maps milestone back to GitLab params', () => {
+    const ms = glMilestoneToMilestone(baseMilestone, PROJECT_ID, BASE_URL);
+    const params = milestoneToGlMilestone(ms);
+    expect(params.title).toBe('v0.1 - MVP');
+    expect(params.description).toBe('Initial minimal viable product release.');
+    expect(params.due_date).toBe('2026-06-30');
+    expect(params.state_event).toBe('activate');
+  });
+
+  it('maps done milestone to close state_event', () => {
+    const closedMs: GlMilestone = { ...baseMilestone, state: 'closed' };
+    const ms = glMilestoneToMilestone(closedMs, PROJECT_ID, BASE_URL);
+    const params = milestoneToGlMilestone(ms);
+    expect(params.state_event).toBe('close');
+  });
+});
+
+describe('entityToGlIssue', () => {
+  it('maps epic to issue with epic label added', () => {
+    const entity = glIssueToEntity(epicIssue, undefined, PROJECT_ID, BASE_URL);
+    const params = entityToGlIssue(entity as never);
+    expect(params.title).toBe('User Authentication');
+    expect(params.labels).toContain('epic');
+    expect(params.labels).toContain('feature');
+    expect(params.state_event).toBe('reopen');
+  });
+
+  it('maps story to issue without epic label', () => {
+    const entity = glIssueToEntity(storyIssue, undefined, PROJECT_ID, BASE_URL);
+    const params = entityToGlIssue(entity as never);
+    expect(params.title).toBe('Add OAuth2 provider support');
+    expect(params.labels).not.toContain('epic');
+  });
+
+  it('maps closed entity to close state_event', () => {
+    const entity = glIssueToEntity(
+      closedIssue,
+      undefined,
+      PROJECT_ID,
+      BASE_URL,
+    );
+    const params = entityToGlIssue(entity as never);
+    expect(params.state_event).toBe('close');
+  });
+});

--- a/packages/sync-gitlab/src/__tests__/state.test.ts
+++ b/packages/sync-gitlab/src/__tests__/state.test.ts
@@ -1,0 +1,103 @@
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { Milestone, Story } from '@gitpm/core';
+import { describe, expect, it } from 'vitest';
+import {
+  computeContentHash,
+  createInitialState,
+  loadState,
+  saveState,
+} from '../state.js';
+
+describe('saveState / loadState', () => {
+  it('round-trips sync state through JSON file', async () => {
+    const metaDir = await mkdtemp(join(tmpdir(), 'gitpm-state-'));
+    try {
+      const state = {
+        project: 'ns/proj',
+        project_id: 42,
+        last_sync: '2026-01-01T00:00:00Z',
+        entities: {
+          ent1: {
+            gitlab_issue_iid: 1,
+            local_hash: 'sha256:abc',
+            remote_hash: 'sha256:abc',
+            synced_at: '2026-01-01T00:00:00Z',
+          },
+        },
+      };
+
+      const saveResult = await saveState(metaDir, state);
+      expect(saveResult.ok).toBe(true);
+
+      const loadResult = await loadState(metaDir);
+      expect(loadResult.ok).toBe(true);
+      if (loadResult.ok) {
+        expect(loadResult.value.project).toBe('ns/proj');
+        expect(loadResult.value.entities.ent1.gitlab_issue_iid).toBe(1);
+      }
+    } finally {
+      await rm(metaDir, { recursive: true });
+    }
+  });
+
+  it('returns error when state file does not exist', async () => {
+    const metaDir = await mkdtemp(join(tmpdir(), 'gitpm-state-'));
+    try {
+      const result = await loadState(metaDir);
+      expect(result.ok).toBe(false);
+    } finally {
+      await rm(metaDir, { recursive: true });
+    }
+  });
+});
+
+describe('createInitialState', () => {
+  it('creates state with correct entries', () => {
+    const story: Story = {
+      type: 'story',
+      id: 'story-1',
+      title: 'Test Story',
+      status: 'todo',
+      priority: 'medium',
+      assignee: null,
+      labels: [],
+      estimate: null,
+      epic_ref: null,
+      gitlab: {
+        issue_iid: 5,
+        project_id: 42,
+        base_url: 'https://gitlab.com',
+        last_sync_hash: 'sha256:abc',
+        synced_at: '2026-01-01T00:00:00Z',
+      },
+      body: '',
+      filePath: '.meta/stories/test-story.md',
+    };
+
+    const milestone: Milestone = {
+      type: 'milestone',
+      id: 'ms-1',
+      title: 'v1.0',
+      status: 'in_progress',
+      gitlab: {
+        milestone_id: 101,
+        project_id: 42,
+        base_url: 'https://gitlab.com',
+        last_sync_hash: 'sha256:def',
+        synced_at: '2026-01-01T00:00:00Z',
+      },
+      body: '',
+      filePath: '.meta/roadmap/milestones/v10.md',
+    };
+
+    const state = createInitialState('ns/proj', [story, milestone], 42);
+    expect(state.project).toBe('ns/proj');
+    expect(state.project_id).toBe(42);
+    expect(state.entities['story-1']).toBeDefined();
+    expect(state.entities['story-1'].gitlab_issue_iid).toBe(5);
+    expect(state.entities['ms-1']).toBeDefined();
+    expect(state.entities['ms-1'].gitlab_milestone_id).toBe(101);
+  });
+});

--- a/packages/sync-gitlab/src/client.ts
+++ b/packages/sync-gitlab/src/client.ts
@@ -1,0 +1,360 @@
+export class GitLabClient {
+  private token: string;
+  private baseUrl: string;
+
+  constructor(token: string, baseUrl = 'https://gitlab.com') {
+    this.token = token;
+    this.baseUrl = baseUrl.replace(/\/$/, '');
+  }
+
+  private async request<T>(
+    path: string,
+    options?: RequestInit,
+  ): Promise<{ data: T; headers: Headers }> {
+    const url = `${this.baseUrl}/api/v4${path}`;
+    let lastError: Error | undefined;
+
+    for (let attempt = 0; attempt < 3; attempt++) {
+      const response = await fetch(url, {
+        ...options,
+        headers: {
+          'PRIVATE-TOKEN': this.token,
+          'Content-Type': 'application/json',
+          ...options?.headers,
+        },
+      });
+
+      // Handle rate limiting
+      if (response.status === 429) {
+        const retryAfter = Number(response.headers.get('Retry-After') ?? '5');
+        const waitMs = retryAfter * 1000;
+        console.warn(
+          `GitLab rate limited. Waiting ${retryAfter}s before retry.`,
+        );
+        await new Promise((resolve) => setTimeout(resolve, waitMs));
+        continue;
+      }
+
+      // Retry on server errors
+      if (response.status >= 500) {
+        const backoff = 2 ** attempt * 1000;
+        lastError = new Error(
+          `GitLab API error ${response.status}: ${response.statusText}`,
+        );
+        await new Promise((resolve) => setTimeout(resolve, backoff));
+        continue;
+      }
+
+      if (!response.ok) {
+        const body = await response.text();
+        throw new Error(`GitLab API error ${response.status}: ${body}`);
+      }
+
+      // Check rate limit remaining
+      const remaining = Number(
+        response.headers.get('RateLimit-Remaining') ?? '100',
+      );
+      if (remaining < 10 && remaining > 0) {
+        console.warn(
+          `GitLab API rate limit low: ${remaining} requests remaining.`,
+        );
+      }
+
+      const data = (await response.json()) as T;
+      return { data, headers: response.headers };
+    }
+
+    throw lastError ?? new Error('GitLab API request failed after retries');
+  }
+
+  async paginate<T>(
+    path: string,
+    params?: Record<string, string | number | undefined>,
+  ): Promise<T[]> {
+    const results: T[] = [];
+    let page = 1;
+    const perPage = 100;
+
+    while (true) {
+      const queryParts: string[] = [`per_page=${perPage}`, `page=${page}`];
+      if (params) {
+        for (const [key, value] of Object.entries(params)) {
+          if (value !== undefined) {
+            queryParts.push(
+              `${encodeURIComponent(key)}=${encodeURIComponent(String(value))}`,
+            );
+          }
+        }
+      }
+      const query = queryParts.join('&');
+      const { data, headers } = await this.request<T[]>(`${path}?${query}`);
+
+      results.push(...data);
+
+      const nextPage = headers.get('x-next-page');
+      if (!nextPage || data.length < perPage) break;
+      page = Number(nextPage);
+    }
+
+    return results;
+  }
+
+  private encodeProject(projectId: string | number): string {
+    if (typeof projectId === 'number') return String(projectId);
+    return encodeURIComponent(projectId);
+  }
+
+  async getProject(projectId: string | number): Promise<GlProject> {
+    const { data } = await this.request<GlProject>(
+      `/projects/${this.encodeProject(projectId)}`,
+    );
+    return data;
+  }
+
+  async listMilestones(projectId: string | number): Promise<GlMilestone[]> {
+    const active = await this.paginate<GlMilestone>(
+      `/projects/${this.encodeProject(projectId)}/milestones`,
+      { state: 'active' },
+    );
+    const closed = await this.paginate<GlMilestone>(
+      `/projects/${this.encodeProject(projectId)}/milestones`,
+      { state: 'closed' },
+    );
+    return [...active, ...closed];
+  }
+
+  async getMilestone(
+    projectId: string | number,
+    milestoneId: number,
+  ): Promise<GlMilestone | null> {
+    try {
+      const { data } = await this.request<GlMilestone>(
+        `/projects/${this.encodeProject(projectId)}/milestones/${milestoneId}`,
+      );
+      return data;
+    } catch {
+      return null;
+    }
+  }
+
+  async createMilestone(
+    projectId: string | number,
+    params: {
+      title: string;
+      description?: string;
+      due_date?: string;
+      state_event?: 'close' | 'activate';
+    },
+  ): Promise<GlMilestone> {
+    const { data } = await this.request<GlMilestone>(
+      `/projects/${this.encodeProject(projectId)}/milestones`,
+      { method: 'POST', body: JSON.stringify(params) },
+    );
+    return data;
+  }
+
+  async updateMilestone(
+    projectId: string | number,
+    milestoneId: number,
+    params: {
+      title?: string;
+      description?: string;
+      due_date?: string;
+      state_event?: 'close' | 'activate';
+    },
+  ): Promise<GlMilestone> {
+    const { data } = await this.request<GlMilestone>(
+      `/projects/${this.encodeProject(projectId)}/milestones/${milestoneId}`,
+      { method: 'PUT', body: JSON.stringify(params) },
+    );
+    return data;
+  }
+
+  async listIssues(
+    projectId: string | number,
+    options?: { state?: 'opened' | 'closed' | 'all' },
+  ): Promise<GlIssue[]> {
+    return this.paginate<GlIssue>(
+      `/projects/${this.encodeProject(projectId)}/issues`,
+      { state: options?.state ?? 'all', order_by: 'created_at', sort: 'asc' },
+    );
+  }
+
+  async getIssue(
+    projectId: string | number,
+    issueIid: number,
+  ): Promise<GlIssue | null> {
+    try {
+      const { data } = await this.request<GlIssue>(
+        `/projects/${this.encodeProject(projectId)}/issues/${issueIid}`,
+      );
+      return data;
+    } catch {
+      return null;
+    }
+  }
+
+  async createIssue(
+    projectId: string | number,
+    params: {
+      title: string;
+      description?: string;
+      labels?: string;
+      assignee_ids?: number[];
+      milestone_id?: number;
+      weight?: number;
+    },
+  ): Promise<GlIssue> {
+    const { data } = await this.request<GlIssue>(
+      `/projects/${this.encodeProject(projectId)}/issues`,
+      { method: 'POST', body: JSON.stringify(params) },
+    );
+    return data;
+  }
+
+  async updateIssue(
+    projectId: string | number,
+    issueIid: number,
+    params: {
+      title?: string;
+      description?: string;
+      state_event?: 'close' | 'reopen';
+      labels?: string;
+      assignee_ids?: number[];
+      milestone_id?: number | null;
+      weight?: number;
+    },
+  ): Promise<GlIssue> {
+    const { data } = await this.request<GlIssue>(
+      `/projects/${this.encodeProject(projectId)}/issues/${issueIid}`,
+      { method: 'PUT', body: JSON.stringify(params) },
+    );
+    return data;
+  }
+
+  async listGroupEpics(groupId: number): Promise<GlEpic[]> {
+    try {
+      return await this.paginate<GlEpic>(`/groups/${groupId}/epics`);
+    } catch {
+      // Epics require Premium — gracefully return empty on 403
+      return [];
+    }
+  }
+
+  async getGroupEpic(groupId: number, epicIid: number): Promise<GlEpic | null> {
+    try {
+      const { data } = await this.request<GlEpic>(
+        `/groups/${groupId}/epics/${epicIid}`,
+      );
+      return data;
+    } catch {
+      return null;
+    }
+  }
+
+  async createGroupEpic(
+    groupId: number,
+    params: {
+      title: string;
+      description?: string;
+      labels?: string;
+    },
+  ): Promise<GlEpic> {
+    const { data } = await this.request<GlEpic>(`/groups/${groupId}/epics`, {
+      method: 'POST',
+      body: JSON.stringify(params),
+    });
+    return data;
+  }
+
+  async updateGroupEpic(
+    groupId: number,
+    epicIid: number,
+    params: {
+      title?: string;
+      description?: string;
+      state_event?: 'close' | 'reopen';
+      labels?: string;
+    },
+  ): Promise<GlEpic> {
+    const { data } = await this.request<GlEpic>(
+      `/groups/${groupId}/epics/${epicIid}`,
+      { method: 'PUT', body: JSON.stringify(params) },
+    );
+    return data;
+  }
+
+  async listEpicIssues(groupId: number, epicIid: number): Promise<GlIssue[]> {
+    try {
+      return await this.paginate<GlIssue>(
+        `/groups/${groupId}/epics/${epicIid}/issues`,
+      );
+    } catch {
+      return [];
+    }
+  }
+
+  async listLabels(projectId: string | number): Promise<GlLabel[]> {
+    return this.paginate<GlLabel>(
+      `/projects/${this.encodeProject(projectId)}/labels`,
+    );
+  }
+}
+
+// GitLab API response types
+
+export interface GlProject {
+  id: number;
+  name: string;
+  path_with_namespace: string;
+  namespace: {
+    id: number;
+    kind: 'group' | 'user';
+    full_path: string;
+  };
+}
+
+export interface GlMilestone {
+  id: number;
+  iid: number;
+  title: string;
+  description: string | null;
+  state: 'active' | 'closed';
+  due_date: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface GlIssue {
+  id: number;
+  iid: number;
+  title: string;
+  description: string | null;
+  state: 'opened' | 'closed';
+  assignee: { id: number; username: string } | null;
+  labels: string[];
+  milestone: { id: number; iid: number; title: string } | null;
+  weight: number | null;
+  epic_iid: number | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface GlEpic {
+  id: number;
+  iid: number;
+  group_id: number;
+  title: string;
+  description: string | null;
+  state: 'opened' | 'closed';
+  labels: string[];
+  created_at: string;
+  updated_at: string;
+}
+
+export interface GlLabel {
+  id: number;
+  name: string;
+  color: string;
+  description: string | null;
+}

--- a/packages/sync-gitlab/src/config.ts
+++ b/packages/sync-gitlab/src/config.ts
@@ -1,0 +1,63 @@
+import { writeFile as fsWriteFile, mkdir, readFile } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
+import type { Result, Status } from '@gitpm/core';
+import YAML from 'yaml';
+import type { GitLabConfig } from './types.js';
+import { DEFAULT_EPIC_LABELS, DEFAULT_STATUS_MAPPING } from './types.js';
+
+export async function loadConfig(
+  metaDir: string,
+): Promise<Result<GitLabConfig>> {
+  try {
+    const configPath = join(metaDir, 'sync', 'gitlab-config.yaml');
+    const raw = await readFile(configPath, 'utf-8');
+    const config = YAML.parse(raw) as GitLabConfig;
+    return { ok: true, value: config };
+  } catch (err) {
+    return {
+      ok: false,
+      error: new Error(`Failed to load GitLab config: ${err}`),
+    };
+  }
+}
+
+export async function saveConfig(
+  metaDir: string,
+  config: GitLabConfig,
+): Promise<Result<void>> {
+  try {
+    const configPath = join(metaDir, 'sync', 'gitlab-config.yaml');
+    await mkdir(dirname(configPath), { recursive: true });
+    const content = YAML.stringify(config, { lineWidth: 0 });
+    await fsWriteFile(configPath, content, 'utf-8');
+    return { ok: true, value: undefined };
+  } catch (err) {
+    return {
+      ok: false,
+      error: new Error(`Failed to save GitLab config: ${err}`),
+    };
+  }
+}
+
+export function createDefaultConfig(
+  project: string,
+  projectId: number,
+  baseUrl: string,
+  groupId?: number,
+  statusMapping?: Record<string, Status>,
+): GitLabConfig {
+  return {
+    project,
+    project_id: projectId,
+    group_id: groupId,
+    base_url: baseUrl,
+    status_mapping: {
+      ...DEFAULT_STATUS_MAPPING,
+      ...statusMapping,
+    },
+    label_mapping: {
+      epic_labels: [...DEFAULT_EPIC_LABELS],
+    },
+    auto_sync: false,
+  };
+}

--- a/packages/sync-gitlab/src/conflict.ts
+++ b/packages/sync-gitlab/src/conflict.ts
@@ -1,0 +1,55 @@
+import type { ConflictStrategy, FieldConflict, Resolution } from './types.js';
+
+export function resolveConflicts(
+  conflicts: FieldConflict[],
+  strategy: ConflictStrategy,
+): Resolution[] {
+  if (strategy === 'local-wins') {
+    return conflicts.map((c) => ({
+      entityId: c.entityId,
+      field: c.field,
+      pick: 'local' as const,
+    }));
+  }
+
+  if (strategy === 'remote-wins') {
+    return conflicts.map((c) => ({
+      entityId: c.entityId,
+      field: c.field,
+      pick: 'remote' as const,
+    }));
+  }
+
+  // 'ask' strategy — return empty, CLI layer handles interactive prompting
+  return [];
+}
+
+export function applyResolutions(
+  localFields: Record<string, unknown>,
+  remoteFields: Record<string, unknown>,
+  conflicts: FieldConflict[],
+  resolutions: Resolution[],
+): Record<string, unknown> {
+  const result = { ...localFields };
+
+  // Apply non-conflicting remote changes
+  const conflictFields = new Set(conflicts.map((c) => c.field));
+  for (const [key, value] of Object.entries(remoteFields)) {
+    if (!conflictFields.has(key)) {
+      result[key] = value;
+    }
+  }
+
+  // Apply resolution picks
+  for (const resolution of resolutions) {
+    const conflict = conflicts.find((c) => c.field === resolution.field);
+    if (conflict) {
+      result[resolution.field] =
+        resolution.pick === 'local'
+          ? conflict.localValue
+          : conflict.remoteValue;
+    }
+  }
+
+  return result;
+}

--- a/packages/sync-gitlab/src/diff.ts
+++ b/packages/sync-gitlab/src/diff.ts
@@ -1,0 +1,176 @@
+import type { Epic, Milestone, ParsedEntity, Story } from '@gitpm/core';
+import type { GlIssue, GlMilestone } from './client.js';
+import type {
+  DiffResult,
+  FieldChange,
+  FieldConflict,
+  SyncStateEntry,
+} from './types.js';
+
+function localEntityFields(entity: ParsedEntity): Record<string, unknown> {
+  if (entity.type === 'story') {
+    return {
+      title: entity.title,
+      status: entity.status,
+      priority: entity.priority,
+      assignee: entity.assignee ?? null,
+      labels: [...(entity.labels ?? [])].sort(),
+      body: (entity.body ?? '').trim(),
+    };
+  }
+  if (entity.type === 'epic') {
+    return {
+      title: entity.title,
+      status: entity.status,
+      priority: entity.priority,
+      owner: entity.owner ?? null,
+      labels: [...(entity.labels ?? [])].sort(),
+      body: (entity.body ?? '').trim(),
+    };
+  }
+  if (entity.type === 'milestone') {
+    return {
+      title: entity.title,
+      status: entity.status,
+      target_date: entity.target_date ?? null,
+      body: (entity.body ?? '').trim(),
+    };
+  }
+  return { title: entity.title };
+}
+
+export function remoteIssueFields(gl: GlIssue): Record<string, unknown> {
+  const labels = gl.labels.filter((l) => l !== 'epic').sort();
+  const status = gl.state === 'closed' ? 'done' : 'todo';
+  return {
+    title: gl.title,
+    status,
+    labels,
+    assignee: gl.assignee?.username ?? null,
+    body: (gl.description ?? '').trim(),
+  };
+}
+
+export function remoteMilestoneFields(
+  gl: GlMilestone,
+): Record<string, unknown> {
+  const status = gl.state === 'closed' ? 'done' : 'in_progress';
+  return {
+    title: gl.title,
+    status,
+    target_date: gl.due_date ?? null,
+    body: (gl.description ?? '').trim(),
+  };
+}
+
+function diffFields(
+  baseFields: Record<string, unknown>,
+  currentFields: Record<string, unknown>,
+): FieldChange[] {
+  const changes: FieldChange[] = [];
+  const allKeys = new Set([
+    ...Object.keys(baseFields),
+    ...Object.keys(currentFields),
+  ]);
+
+  for (const key of allKeys) {
+    const base = baseFields[key];
+    const current = currentFields[key];
+    if (!fieldEquals(base, current)) {
+      changes.push({ field: key, oldValue: base, newValue: current });
+    }
+  }
+  return changes;
+}
+
+function fieldEquals(a: unknown, b: unknown): boolean {
+  if (a === b) return true;
+  if (a === null && b === undefined) return true;
+  if (a === undefined && b === null) return true;
+  if (Array.isArray(a) && Array.isArray(b)) {
+    if (a.length !== b.length) return false;
+    return a.every((v, i) => fieldEquals(v, b[i]));
+  }
+  if (typeof a === 'string' && typeof b === 'string') {
+    return a.trim() === b.trim();
+  }
+  return JSON.stringify(a) === JSON.stringify(b);
+}
+
+export function diffEntity(
+  local: ParsedEntity,
+  remoteFields: Record<string, unknown>,
+  baselineLocal: Record<string, unknown>,
+  baselineRemote: Record<string, unknown>,
+): DiffResult {
+  const currentLocal = localEntityFields(local);
+
+  const localChanges = diffFields(baselineLocal, currentLocal);
+  const remoteChanges = diffFields(baselineRemote, remoteFields);
+
+  const conflicts: FieldConflict[] = [];
+  const localChangedFields = new Set(localChanges.map((c) => c.field));
+  const remoteChangedFields = new Set(remoteChanges.map((c) => c.field));
+
+  for (const field of localChangedFields) {
+    if (remoteChangedFields.has(field)) {
+      const localChange = localChanges.find((c) => c.field === field);
+      const remoteChange = remoteChanges.find((c) => c.field === field);
+      if (
+        localChange &&
+        remoteChange &&
+        !fieldEquals(localChange.newValue, remoteChange.newValue)
+      ) {
+        const id = 'id' in local ? (local as { id: string }).id : '';
+        conflicts.push({
+          entityId: id,
+          entityTitle: local.title,
+          entityType: local.type,
+          field,
+          baseValue: localChange.oldValue,
+          localValue: localChange.newValue,
+          remoteValue: remoteChange.newValue,
+        });
+      }
+    }
+  }
+
+  const nonConflictLocalChanges = localChanges.filter(
+    (c) => !conflicts.some((conf) => conf.field === c.field),
+  );
+  const nonConflictRemoteChanges = remoteChanges.filter(
+    (c) => !conflicts.some((conf) => conf.field === c.field),
+  );
+
+  let status: DiffResult['status'];
+  if (conflicts.length > 0) {
+    status = 'conflict';
+  } else if (nonConflictLocalChanges.length > 0) {
+    status = 'local_changed';
+  } else if (nonConflictRemoteChanges.length > 0) {
+    status = 'remote_changed';
+  } else {
+    status = 'in_sync';
+  }
+
+  return {
+    status,
+    localChanges: nonConflictLocalChanges,
+    remoteChanges: nonConflictRemoteChanges,
+    conflicts,
+  };
+}
+
+export function diffByHash(
+  currentLocalHash: string,
+  currentRemoteHash: string,
+  stateEntry: SyncStateEntry,
+): 'in_sync' | 'local_changed' | 'remote_changed' | 'both_changed' {
+  const localChanged = currentLocalHash !== stateEntry.local_hash;
+  const remoteChanged = currentRemoteHash !== stateEntry.remote_hash;
+
+  if (!localChanged && !remoteChanged) return 'in_sync';
+  if (localChanged && !remoteChanged) return 'local_changed';
+  if (!localChanged && remoteChanged) return 'remote_changed';
+  return 'both_changed';
+}

--- a/packages/sync-gitlab/src/export.ts
+++ b/packages/sync-gitlab/src/export.ts
@@ -1,0 +1,280 @@
+import { join } from 'node:path';
+import type { Epic, Milestone, ParsedEntity, Result, Story } from '@gitpm/core';
+import { parseTree, writeFile } from '@gitpm/core';
+import { GitLabClient } from './client.js';
+import { loadConfig } from './config.js';
+import { entityToGlIssue, milestoneToGlMilestone } from './mapper.js';
+import { computeContentHash, loadState, saveState } from './state.js';
+import type {
+  ExportOptions,
+  ExportResult,
+  SyncState,
+  SyncStateEntry,
+} from './types.js';
+
+export async function exportToGitLab(
+  options: ExportOptions,
+): Promise<Result<ExportResult>> {
+  try {
+    const { token, project, metaDir, dryRun } = options;
+    const baseUrl = options.baseUrl ?? 'https://gitlab.com';
+
+    // 1. Load config to get project_id
+    const configResult = await loadConfig(metaDir);
+    if (!configResult.ok) {
+      return {
+        ok: false,
+        error: new Error('No GitLab config found. Run import first.'),
+      };
+    }
+    const config = configResult.value;
+    const projectId = options.projectId ?? config.project_id;
+
+    // 2. Parse local tree
+    const treeResult = await parseTree(metaDir);
+    if (!treeResult.ok) return treeResult;
+    const tree = treeResult.value;
+
+    // 3. Load sync state (may not exist for first export)
+    const stateResult = await loadState(metaDir);
+    const state: SyncState = stateResult.ok
+      ? stateResult.value
+      : {
+          project,
+          project_id: projectId,
+          last_sync: new Date().toISOString(),
+          entities: {},
+        };
+
+    const client = new GitLabClient(token, baseUrl);
+    const result: ExportResult = {
+      created: { milestones: 0, issues: 0 },
+      updated: { milestones: 0, issues: 0 },
+      totalChanges: 0,
+    };
+
+    // 4. Process milestones
+    for (const milestone of tree.milestones) {
+      const entityState = state.entities[milestone.id];
+
+      if (
+        !milestone.gitlab?.milestone_id &&
+        !entityState?.gitlab_milestone_id
+      ) {
+        // New milestone — create on GitLab
+        if (!dryRun) {
+          const params = milestoneToGlMilestone(milestone);
+          const created = await client.createMilestone(projectId, params);
+
+          milestone.gitlab = {
+            milestone_id: created.id,
+            project_id: projectId,
+            base_url: baseUrl,
+            last_sync_hash: computeContentHash(milestone),
+            synced_at: new Date().toISOString(),
+          };
+          const filePath = join(metaDir, '..', milestone.filePath);
+          await writeFile(milestone, filePath);
+
+          const hash = computeContentHash(milestone);
+          state.entities[milestone.id] = {
+            gitlab_milestone_id: created.id,
+            local_hash: hash,
+            remote_hash: hash,
+            synced_at: new Date().toISOString(),
+          };
+        }
+        result.created.milestones++;
+      } else {
+        // Existing milestone — check for local changes
+        const msId =
+          milestone.gitlab?.milestone_id ?? entityState?.gitlab_milestone_id;
+        if (!msId) continue;
+
+        const currentHash = computeContentHash(milestone);
+        if (entityState && currentHash !== entityState.local_hash) {
+          if (!dryRun) {
+            const params = milestoneToGlMilestone(milestone);
+            await client.updateMilestone(projectId, msId, params);
+
+            milestone.gitlab = {
+              ...milestone.gitlab,
+              milestone_id: msId,
+              project_id: projectId,
+              base_url: baseUrl,
+              last_sync_hash: currentHash,
+              synced_at: new Date().toISOString(),
+            };
+            const filePath = join(metaDir, '..', milestone.filePath);
+            await writeFile(milestone, filePath);
+
+            state.entities[milestone.id] = {
+              ...entityState,
+              gitlab_milestone_id: msId,
+              local_hash: currentHash,
+              remote_hash: currentHash,
+              synced_at: new Date().toISOString(),
+            };
+          }
+          result.updated.milestones++;
+        }
+      }
+    }
+
+    // 5. Process epics and stories
+    const allIssueEntities: (Epic | Story)[] = [...tree.epics, ...tree.stories];
+
+    // Build milestone ID → GitLab milestone ID map
+    const milestoneIdToGlId = new Map<string, number>();
+    for (const ms of tree.milestones) {
+      const num =
+        ms.gitlab?.milestone_id ?? state.entities[ms.id]?.gitlab_milestone_id;
+      if (num) {
+        milestoneIdToGlId.set(ms.id, num);
+      }
+    }
+
+    for (const entity of allIssueEntities) {
+      const entityState = state.entities[entity.id];
+      const issueIid =
+        entity.gitlab?.issue_iid ?? entityState?.gitlab_issue_iid;
+
+      if (!issueIid) {
+        // New entity — create issue on GitLab
+        if (!dryRun) {
+          const params = entityToGlIssue(entity);
+
+          // Resolve milestone for epics
+          if (entity.type === 'epic' && entity.milestone_ref?.id) {
+            const msGlId = milestoneIdToGlId.get(entity.milestone_ref.id);
+            if (msGlId) {
+              params.milestone_id = msGlId;
+            }
+          }
+
+          const created = await client.createIssue(projectId, {
+            title: params.title,
+            description: params.description,
+            labels: params.labels,
+            milestone_id: params.milestone_id,
+          });
+
+          // If issue should be closed, close it after creation
+          if (params.state_event === 'close') {
+            await client.updateIssue(projectId, created.iid, {
+              state_event: 'close',
+            });
+          }
+
+          entity.gitlab = {
+            issue_iid: created.iid,
+            project_id: projectId,
+            base_url: baseUrl,
+            last_sync_hash: computeContentHash(entity),
+            synced_at: new Date().toISOString(),
+          };
+          const filePath = join(metaDir, '..', entity.filePath);
+          await writeFile(entity, filePath);
+
+          const hash = computeContentHash(entity);
+          state.entities[entity.id] = {
+            gitlab_issue_iid: created.iid,
+            local_hash: hash,
+            remote_hash: hash,
+            synced_at: new Date().toISOString(),
+          };
+        }
+        result.created.issues++;
+      } else {
+        // Existing entity — check for local changes
+        const currentHash = computeContentHash(entity);
+        if (entityState && currentHash !== entityState.local_hash) {
+          if (!dryRun) {
+            const params = entityToGlIssue(entity);
+
+            if (entity.type === 'epic' && entity.milestone_ref?.id) {
+              const msGlId = milestoneIdToGlId.get(entity.milestone_ref.id);
+              if (msGlId) {
+                params.milestone_id = msGlId;
+              }
+            }
+
+            await client.updateIssue(projectId, issueIid, {
+              title: params.title,
+              description: params.description,
+              state_event: params.state_event,
+              labels: params.labels,
+              milestone_id: params.milestone_id,
+            });
+
+            entity.gitlab = {
+              ...entity.gitlab,
+              issue_iid: issueIid,
+              project_id: projectId,
+              base_url: baseUrl,
+              last_sync_hash: currentHash,
+              synced_at: new Date().toISOString(),
+            };
+            const filePath = join(metaDir, '..', entity.filePath);
+            await writeFile(entity, filePath);
+
+            state.entities[entity.id] = {
+              ...entityState,
+              gitlab_issue_iid: issueIid,
+              local_hash: currentHash,
+              remote_hash: currentHash,
+              synced_at: new Date().toISOString(),
+            };
+          }
+          result.updated.issues++;
+        }
+      }
+    }
+
+    // 6. Handle locally deleted entities
+    const currentEntityIds = new Set([
+      ...tree.milestones.map((m) => m.id),
+      ...tree.epics.map((e) => e.id),
+      ...tree.stories.map((s) => s.id),
+      ...tree.prds.map((p) => p.id),
+    ]);
+
+    for (const [entityId, entry] of Object.entries(state.entities)) {
+      if (!currentEntityIds.has(entityId)) {
+        if (!dryRun) {
+          if (entry.gitlab_issue_iid) {
+            await client.updateIssue(projectId, entry.gitlab_issue_iid, {
+              state_event: 'close',
+            });
+          }
+          if (entry.gitlab_milestone_id) {
+            await client.updateMilestone(projectId, entry.gitlab_milestone_id, {
+              state_event: 'close',
+            });
+          }
+        }
+        delete state.entities[entityId];
+        result.totalChanges++;
+      }
+    }
+
+    result.totalChanges +=
+      result.created.milestones +
+      result.created.issues +
+      result.updated.milestones +
+      result.updated.issues;
+
+    // 7. Save updated sync state
+    if (!dryRun) {
+      state.last_sync = new Date().toISOString();
+      await saveState(metaDir, state);
+    }
+
+    return { ok: true, value: result };
+  } catch (err) {
+    return {
+      ok: false,
+      error: err instanceof Error ? err : new Error(`Export failed: ${err}`),
+    };
+  }
+}

--- a/packages/sync-gitlab/src/import.ts
+++ b/packages/sync-gitlab/src/import.ts
@@ -1,0 +1,264 @@
+import { join } from 'node:path';
+import { toSlug, writeFile } from '@gitpm/core';
+import type {
+  EntityRef,
+  Epic,
+  Milestone,
+  Result,
+  Roadmap,
+  Story,
+} from '@gitpm/core';
+import { nanoid } from 'nanoid';
+import { GitLabClient } from './client.js';
+import { createDefaultConfig, saveConfig } from './config.js';
+import type { LinkContext } from './linker.js';
+import { resolveEpicLink } from './linker.js';
+import {
+  determineFilePath,
+  glEpicToEpic,
+  glIssueToEntity,
+  glMilestoneToMilestone,
+  isEpicIssue,
+} from './mapper.js';
+import { computeContentHash, createInitialState, saveState } from './state.js';
+import type {
+  GitLabConfig,
+  ImportOptions,
+  ImportResult,
+  LinkStrategy,
+} from './types.js';
+
+export async function importFromGitLab(
+  options: ImportOptions,
+): Promise<Result<ImportResult>> {
+  try {
+    const { token, project, metaDir, statusMapping } = options;
+    const baseUrl = options.baseUrl ?? 'https://gitlab.com';
+
+    // 1. Create GitLab client
+    const client = new GitLabClient(token, baseUrl);
+
+    // 2. Resolve project ID
+    let projectId = options.projectId;
+    let groupId = options.groupId;
+    if (!projectId) {
+      const glProject = await client.getProject(project);
+      projectId = glProject.id;
+      if (!groupId && glProject.namespace.kind === 'group') {
+        groupId = glProject.namespace.id;
+      }
+    }
+
+    // 3. Fetch milestones
+    const glMilestones = await client.listMilestones(projectId);
+
+    // 4. Fetch all issues
+    const glIssues = await client.listIssues(projectId, { state: 'all' });
+
+    // 5. Build config for label detection
+    const config: GitLabConfig = createDefaultConfig(
+      project,
+      projectId,
+      baseUrl,
+      groupId,
+      statusMapping,
+    );
+
+    // 6. Try fetching native GitLab epics (Premium feature)
+    const nativeEpics = groupId ? await client.listGroupEpics(groupId) : [];
+
+    // 7. Convert milestones — build id→entityId map
+    const milestones: Milestone[] = [];
+    const milestoneIdToEntityId = new Map<number, string>();
+    for (const glMs of glMilestones) {
+      const ms = glMilestoneToMilestone(glMs, projectId, baseUrl);
+      const hash = computeContentHash(ms);
+      if (ms.gitlab) {
+        ms.gitlab.last_sync_hash = hash;
+      }
+      milestones.push(ms);
+      milestoneIdToEntityId.set(glMs.id, ms.id);
+    }
+
+    // 8. Convert issues — separate epics and stories
+    const epics: Epic[] = [];
+    const stories: Story[] = [];
+    const issueIidToEntity = new Map<number, Epic | Story>();
+
+    // First pass: identify epics (either native or label-based)
+    // Add native epics first
+    for (const glEpic of nativeEpics) {
+      const epic = glEpicToEpic(glEpic, projectId, baseUrl);
+      const hash = computeContentHash(epic);
+      if (epic.gitlab) {
+        epic.gitlab.last_sync_hash = hash;
+      }
+      epics.push(epic);
+    }
+
+    // Process issues
+    for (const glIssue of glIssues) {
+      const entity = glIssueToEntity(glIssue, config, projectId, baseUrl);
+      issueIidToEntity.set(glIssue.iid, entity);
+
+      if (entity.type === 'epic') {
+        // Set milestone ref if issue has milestone
+        if (glIssue.milestone) {
+          const msEntityId = milestoneIdToEntityId.get(glIssue.milestone.id);
+          if (msEntityId) {
+            entity.milestone_ref = { id: msEntityId } as EntityRef;
+          }
+        }
+        epics.push(entity);
+      }
+    }
+
+    // Build epic issue IID → entity map for parent resolution
+    const epicIssueIidToEpic = new Map<number, Epic>();
+    for (const glIssue of glIssues) {
+      if (isEpicIssue(glIssue, config)) {
+        const entity = issueIidToEntity.get(glIssue.iid);
+        if (entity?.type === 'epic') {
+          epicIssueIidToEpic.set(glIssue.iid, entity);
+        }
+      }
+    }
+
+    // Fetch native epic→issue relationships
+    const linkStrategy: LinkStrategy = options.linkStrategy ?? 'all';
+    const nativeEpicIssueIids = new Map<number, number[]>();
+    if (
+      groupId &&
+      nativeEpics.length > 0 &&
+      (linkStrategy === 'native-epics' || linkStrategy === 'all')
+    ) {
+      for (const glEpic of nativeEpics) {
+        const epicIssues = await client.listEpicIssues(groupId, glEpic.iid);
+        nativeEpicIssueIids.set(
+          glEpic.iid,
+          epicIssues.map((i) => i.iid),
+        );
+      }
+    }
+
+    // Build link context for the linker
+    const linkCtx: LinkContext = {
+      glIssues,
+      issueIidToEntity,
+      epicIssueIidToEpic,
+      nativeEpicIssueIids,
+    };
+
+    // Second pass: stories — resolve epic refs
+    for (const glIssue of glIssues) {
+      const entity = issueIidToEntity.get(glIssue.iid);
+      if (!entity || entity.type !== 'story') continue;
+
+      let parentEpicSlug: string | undefined;
+
+      const linkResult = resolveEpicLink(
+        glIssue,
+        entity,
+        linkCtx,
+        linkStrategy,
+      );
+      if (linkResult) {
+        entity.epic_ref = linkResult.epicRef;
+        parentEpicSlug = linkResult.parentEpicSlug;
+      }
+
+      entity.filePath = determineFilePath(entity, parentEpicSlug);
+
+      const hash = computeContentHash(entity);
+      if (entity.gitlab) {
+        entity.gitlab.last_sync_hash = hash;
+      }
+
+      stories.push(entity);
+    }
+
+    // Update epic hashes after all refs are set
+    for (const epic of epics) {
+      epic.filePath = determineFilePath(epic);
+      const hash = computeContentHash(epic);
+      if (epic.gitlab) {
+        epic.gitlab.last_sync_hash = hash;
+      }
+    }
+
+    // 9. Build roadmap referencing all milestones
+    const roadmap: Roadmap = {
+      type: 'roadmap',
+      id: nanoid(12),
+      title: 'Roadmap',
+      description: `Imported from ${project}`,
+      milestones: milestones.map((ms) => ({ id: ms.id })),
+      updated_at: new Date().toISOString(),
+      filePath: '.meta/roadmap/roadmap.yaml',
+    };
+
+    // 10. Write all entities to disk
+    let totalFiles = 0;
+    const resolveEntityPath = (filePath: string) => {
+      const relative = filePath.replace(/^\.meta\//, '');
+      return join(metaDir, relative);
+    };
+
+    // Write roadmap
+    const roadmapPath = resolveEntityPath(roadmap.filePath);
+    const roadmapResult = await writeFile(roadmap, roadmapPath);
+    if (!roadmapResult.ok) return roadmapResult;
+    totalFiles++;
+
+    // Write milestones
+    for (const ms of milestones) {
+      const msPath = resolveEntityPath(ms.filePath);
+      const result = await writeFile(ms, msPath);
+      if (!result.ok) return result;
+      totalFiles++;
+    }
+
+    // Write epics
+    for (const epic of epics) {
+      const epicPath = resolveEntityPath(epic.filePath);
+      const result = await writeFile(epic, epicPath);
+      if (!result.ok) return result;
+      totalFiles++;
+    }
+
+    // Write stories
+    for (const story of stories) {
+      const storyPath = resolveEntityPath(story.filePath);
+      const result = await writeFile(story, storyPath);
+      if (!result.ok) return result;
+      totalFiles++;
+    }
+
+    // 11. Save config
+    const configResult = await saveConfig(metaDir, config);
+    if (!configResult.ok) return configResult;
+    totalFiles++;
+
+    // 12. Save initial sync state
+    const allEntities = [...milestones, ...epics, ...stories, roadmap];
+    const syncState = createInitialState(project, allEntities, projectId);
+    const stateResult = await saveState(metaDir, syncState);
+    if (!stateResult.ok) return stateResult;
+    totalFiles++;
+
+    return {
+      ok: true,
+      value: {
+        milestones: milestones.length,
+        epics: epics.length,
+        stories: stories.length,
+        totalFiles,
+      },
+    };
+  } catch (err) {
+    return {
+      ok: false,
+      error: err instanceof Error ? err : new Error(`Import failed: ${err}`),
+    };
+  }
+}

--- a/packages/sync-gitlab/src/index.ts
+++ b/packages/sync-gitlab/src/index.ts
@@ -1,0 +1,68 @@
+export { GitLabClient } from './client.js';
+export type {
+  GlMilestone,
+  GlIssue,
+  GlEpic,
+  GlProject,
+  GlLabel,
+} from './client.js';
+
+export {
+  glMilestoneToMilestone,
+  glIssueToEntity,
+  glEpicToEpic,
+  isEpicIssue,
+  determineFilePath,
+  milestoneToGlMilestone,
+  entityToGlIssue,
+} from './mapper.js';
+export type { CreateMilestoneParams, CreateIssueParams } from './mapper.js';
+
+export { importFromGitLab } from './import.js';
+export { exportToGitLab } from './export.js';
+export { syncWithGitLab } from './sync.js';
+
+export { resolveEpicLink } from './linker.js';
+export type { LinkContext, LinkResult } from './linker.js';
+
+export {
+  diffEntity,
+  diffByHash,
+  remoteIssueFields,
+  remoteMilestoneFields,
+} from './diff.js';
+
+export { resolveConflicts, applyResolutions } from './conflict.js';
+
+export {
+  loadState,
+  saveState,
+  computeContentHash,
+  createInitialState,
+} from './state.js';
+
+export { loadConfig, saveConfig, createDefaultConfig } from './config.js';
+
+export type {
+  ImportOptions,
+  ImportResult,
+  ExportOptions,
+  ExportResult,
+  SyncOptions,
+  SyncResult,
+  GitLabConfig,
+  SyncState,
+  SyncStateEntry,
+  ConflictStrategy,
+  FieldChange,
+  FieldConflict,
+  DiffResult,
+  DiffStatus,
+  Resolution,
+  LinkStrategy,
+} from './types.js';
+
+export {
+  DEFAULT_STATUS_MAPPING,
+  DEFAULT_EPIC_LABELS,
+} from './types.js';

--- a/packages/sync-gitlab/src/linker.ts
+++ b/packages/sync-gitlab/src/linker.ts
@@ -1,0 +1,151 @@
+import type { EntityRef, Epic, Story } from '@gitpm/core';
+import { toSlug } from '@gitpm/core';
+import type { GlIssue } from './client.js';
+import type { LinkStrategy } from './types.js';
+
+export interface LinkContext {
+  glIssues: GlIssue[];
+  issueIidToEntity: Map<number, Epic | Story>;
+  epicIssueIidToEpic: Map<number, Epic>;
+  /** Map of epic issue IID → issue IIDs linked via native GitLab epics */
+  nativeEpicIssueIids: Map<number, number[]>;
+}
+
+export interface LinkResult {
+  epicRef: EntityRef;
+  parentEpicSlug: string;
+}
+
+export function resolveEpicLink(
+  glIssue: GlIssue,
+  story: Story,
+  ctx: LinkContext,
+  strategy: LinkStrategy,
+): LinkResult | null {
+  if (strategy === 'all') {
+    const strategies: LinkStrategy[] = [
+      'body-refs',
+      'native-epics',
+      'milestone',
+      'labels',
+    ];
+    for (const s of strategies) {
+      const result = resolveEpicLink(glIssue, story, ctx, s);
+      if (result) return result;
+    }
+    return null;
+  }
+
+  switch (strategy) {
+    case 'body-refs':
+      return linkByBodyRefs(glIssue, ctx);
+    case 'native-epics':
+      return linkByNativeEpics(glIssue, ctx);
+    case 'milestone':
+      return linkByMilestone(glIssue, ctx);
+    case 'labels':
+      return linkByLabels(glIssue, ctx);
+    default:
+      return null;
+  }
+}
+
+function linkByBodyRefs(glIssue: GlIssue, ctx: LinkContext): LinkResult | null {
+  const body = glIssue.description ?? '';
+  const refPattern = /#(\d+)/g;
+  let match: RegExpExecArray | null;
+
+  while (true) {
+    match = refPattern.exec(body);
+    if (!match) break;
+    const refIid = Number(match[1]);
+    const epic = ctx.epicIssueIidToEpic.get(refIid);
+    if (epic) {
+      return {
+        epicRef: { id: epic.id },
+        parentEpicSlug: toSlug(epic.title),
+      };
+    }
+  }
+
+  return null;
+}
+
+function linkByNativeEpics(
+  glIssue: GlIssue,
+  ctx: LinkContext,
+): LinkResult | null {
+  // Check if this issue is linked to an epic via native GitLab epic relationship
+  for (const [epicIid, issueIids] of ctx.nativeEpicIssueIids.entries()) {
+    if (issueIids.includes(glIssue.iid)) {
+      const epic = ctx.epicIssueIidToEpic.get(epicIid);
+      if (epic) {
+        return {
+          epicRef: { id: epic.id },
+          parentEpicSlug: toSlug(epic.title),
+        };
+      }
+    }
+  }
+
+  // Also check the issue's epic_iid field (if present)
+  if (glIssue.epic_iid) {
+    // Look for an epic entity that was created from this native epic
+    for (const entity of ctx.issueIidToEntity.values()) {
+      if (
+        entity.type === 'epic' &&
+        entity.gitlab?.epic_iid === glIssue.epic_iid
+      ) {
+        return {
+          epicRef: { id: entity.id },
+          parentEpicSlug: toSlug(entity.title),
+        };
+      }
+    }
+  }
+
+  return null;
+}
+
+function linkByMilestone(
+  glIssue: GlIssue,
+  ctx: LinkContext,
+): LinkResult | null {
+  if (!glIssue.milestone) return null;
+
+  for (const [epicIid, epic] of ctx.epicIssueIidToEpic.entries()) {
+    const epicIssue = ctx.glIssues.find((i) => i.iid === epicIid);
+    if (
+      epicIssue?.milestone &&
+      epicIssue.milestone.id === glIssue.milestone.id
+    ) {
+      return {
+        epicRef: { id: epic.id },
+        parentEpicSlug: toSlug(epic.title),
+      };
+    }
+  }
+
+  return null;
+}
+
+function linkByLabels(glIssue: GlIssue, ctx: LinkContext): LinkResult | null {
+  const issueLabels = new Set(glIssue.labels.filter((l) => l !== 'epic'));
+
+  for (const [epicIid, epic] of ctx.epicIssueIidToEpic.entries()) {
+    const epicIssue = ctx.glIssues.find((i) => i.iid === epicIid);
+    if (!epicIssue) continue;
+
+    const epicLabels = epicIssue.labels.filter((l) => l !== 'epic');
+    const shared = epicLabels.filter((l) => issueLabels.has(l));
+
+    if (shared.length === 1) {
+      return {
+        epicRef: { id: epic.id },
+        parentEpicSlug: toSlug(epic.title),
+      };
+    }
+  }
+
+  return null;
+}

--- a/packages/sync-gitlab/src/mapper.ts
+++ b/packages/sync-gitlab/src/mapper.ts
@@ -1,0 +1,224 @@
+import type { Epic, GitLabSync, Milestone, Status, Story } from '@gitpm/core';
+import { toSlug } from '@gitpm/core';
+import { nanoid } from 'nanoid';
+import type { GlEpic, GlIssue, GlMilestone } from './client.js';
+import type { GitLabConfig } from './types.js';
+import { DEFAULT_EPIC_LABELS } from './types.js';
+
+export function glMilestoneToMilestone(
+  gl: GlMilestone,
+  projectId: number,
+  baseUrl: string,
+): Milestone {
+  const id = nanoid(12);
+  const slug = toSlug(gl.title);
+  const status: Status = gl.state === 'closed' ? 'done' : 'in_progress';
+  const now = new Date().toISOString();
+
+  const gitlab: GitLabSync = {
+    milestone_id: gl.id,
+    project_id: projectId,
+    base_url: baseUrl,
+    last_sync_hash: '',
+    synced_at: now,
+  };
+
+  return {
+    type: 'milestone',
+    id,
+    title: gl.title,
+    target_date: gl.due_date ?? undefined,
+    status,
+    body: gl.description ?? '',
+    gitlab,
+    created_at: gl.created_at,
+    updated_at: gl.updated_at,
+    filePath: `.meta/roadmap/milestones/${slug}.md`,
+  };
+}
+
+export function isEpicIssue(
+  gl: GlIssue,
+  config?: Pick<GitLabConfig, 'label_mapping'>,
+): boolean {
+  const epicLabels = config?.label_mapping?.epic_labels ?? DEFAULT_EPIC_LABELS;
+  return gl.labels.some((label) => epicLabels.includes(label));
+}
+
+function weightToPriority(
+  weight: number | null,
+): 'low' | 'medium' | 'high' | 'critical' {
+  if (weight === null || weight === 0) return 'medium';
+  if (weight <= 2) return 'low';
+  if (weight <= 4) return 'medium';
+  if (weight <= 6) return 'high';
+  return 'critical';
+}
+
+export function glIssueToEntity(
+  gl: GlIssue,
+  config?: Pick<GitLabConfig, 'label_mapping'>,
+  projectId?: number,
+  baseUrl?: string,
+): Story | Epic {
+  const pId = projectId ?? 0;
+  const bUrl = baseUrl ?? 'https://gitlab.com';
+  const isEpic = isEpicIssue(gl, config);
+  const id = nanoid(12);
+  const now = new Date().toISOString();
+  const labels = gl.labels.filter((l) => {
+    const epicLabels =
+      config?.label_mapping?.epic_labels ?? DEFAULT_EPIC_LABELS;
+    return !epicLabels.includes(l);
+  });
+
+  const gitlab: GitLabSync = {
+    issue_iid: gl.iid,
+    project_id: pId,
+    base_url: bUrl,
+    last_sync_hash: '',
+    synced_at: now,
+  };
+
+  const status: Status = gl.state === 'closed' ? 'done' : 'todo';
+  const priority = weightToPriority(gl.weight);
+
+  if (isEpic) {
+    const slug = toSlug(gl.title);
+    return {
+      type: 'epic',
+      id,
+      title: gl.title,
+      status,
+      priority,
+      owner: gl.assignee?.username ?? null,
+      labels,
+      milestone_ref: null,
+      gitlab,
+      body: gl.description ?? '',
+      created_at: gl.created_at,
+      updated_at: gl.updated_at,
+      filePath: `.meta/epics/${slug}/epic.md`,
+    } satisfies Epic;
+  }
+
+  return {
+    type: 'story',
+    id,
+    title: gl.title,
+    status,
+    priority,
+    assignee: gl.assignee?.username ?? null,
+    labels,
+    estimate: null,
+    epic_ref: null,
+    gitlab,
+    body: gl.description ?? '',
+    created_at: gl.created_at,
+    updated_at: gl.updated_at,
+    filePath: '', // determined later by determineFilePath
+  } satisfies Story;
+}
+
+export function glEpicToEpic(
+  gl: GlEpic,
+  projectId: number,
+  baseUrl: string,
+): Epic {
+  const id = nanoid(12);
+  const slug = toSlug(gl.title);
+  const now = new Date().toISOString();
+  const status: Status = gl.state === 'closed' ? 'done' : 'todo';
+
+  const gitlab: GitLabSync = {
+    epic_iid: gl.iid,
+    project_id: projectId,
+    base_url: baseUrl,
+    last_sync_hash: '',
+    synced_at: now,
+  };
+
+  return {
+    type: 'epic',
+    id,
+    title: gl.title,
+    status,
+    priority: 'medium',
+    owner: null,
+    labels: gl.labels,
+    milestone_ref: null,
+    gitlab,
+    body: gl.description ?? '',
+    created_at: gl.created_at,
+    updated_at: gl.updated_at,
+    filePath: `.meta/epics/${slug}/epic.md`,
+  };
+}
+
+export function determineFilePath(
+  entity: Story | Epic | Milestone,
+  parentEpicSlug?: string,
+): string {
+  if (entity.type === 'milestone') {
+    const slug = toSlug(entity.title);
+    return `.meta/roadmap/milestones/${slug}.md`;
+  }
+
+  if (entity.type === 'epic') {
+    const slug = toSlug(entity.title);
+    return `.meta/epics/${slug}/epic.md`;
+  }
+
+  // Story
+  const slug = toSlug(entity.title);
+  if (parentEpicSlug) {
+    return `.meta/epics/${parentEpicSlug}/stories/${slug}.md`;
+  }
+  return `.meta/stories/${slug}.md`;
+}
+
+export interface CreateMilestoneParams {
+  title: string;
+  description?: string;
+  due_date?: string;
+  state_event?: 'close' | 'activate';
+}
+
+export function milestoneToGlMilestone(
+  milestone: Milestone,
+): CreateMilestoneParams {
+  return {
+    title: milestone.title,
+    description: milestone.body || undefined,
+    due_date: milestone.target_date ?? undefined,
+    state_event:
+      milestone.status === 'done' || milestone.status === 'cancelled'
+        ? 'close'
+        : 'activate',
+  };
+}
+
+export interface CreateIssueParams {
+  title: string;
+  description?: string;
+  labels?: string;
+  milestone_id?: number;
+  state_event?: 'close' | 'reopen';
+}
+
+export function entityToGlIssue(entity: Story | Epic): CreateIssueParams {
+  const labels = [...(entity.labels ?? [])];
+  if (entity.type === 'epic') {
+    labels.push('epic');
+  }
+
+  return {
+    title: entity.title,
+    description: entity.body || undefined,
+    labels: labels.join(','),
+    state_event:
+      entity.status === 'done' || entity.status === 'cancelled'
+        ? 'close'
+        : 'reopen',
+  };
+}

--- a/packages/sync-gitlab/src/state.ts
+++ b/packages/sync-gitlab/src/state.ts
@@ -1,0 +1,130 @@
+import { createHash } from 'node:crypto';
+import { writeFile as fsWriteFile, mkdir, readFile } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
+import type { ParsedEntity, Result } from '@gitpm/core';
+import type { SyncState, SyncStateEntry } from './types.js';
+
+export async function loadState(metaDir: string): Promise<Result<SyncState>> {
+  try {
+    const statePath = join(metaDir, 'sync', 'gitlab-state.json');
+    const raw = await readFile(statePath, 'utf-8');
+    const state = JSON.parse(raw) as SyncState;
+    return { ok: true, value: state };
+  } catch (err) {
+    return {
+      ok: false,
+      error: new Error(`Failed to load sync state: ${err}`),
+    };
+  }
+}
+
+export async function saveState(
+  metaDir: string,
+  state: SyncState,
+): Promise<Result<void>> {
+  try {
+    const statePath = join(metaDir, 'sync', 'gitlab-state.json');
+    await mkdir(dirname(statePath), { recursive: true });
+    const json = JSON.stringify(state, null, 2);
+    await fsWriteFile(statePath, `${json}\n`, 'utf-8');
+    return { ok: true, value: undefined };
+  } catch (err) {
+    return {
+      ok: false,
+      error: new Error(`Failed to save sync state: ${err}`),
+    };
+  }
+}
+
+export function computeContentHash(entity: ParsedEntity): string {
+  const canonical = buildCanonicalObject(entity);
+  const json = JSON.stringify(canonical);
+  const hash = createHash('sha256').update(json).digest('hex');
+  return `sha256:${hash}`;
+}
+
+function buildCanonicalObject(entity: ParsedEntity): Record<string, unknown> {
+  const base: Record<string, unknown> = {
+    title: entity.title,
+  };
+
+  if (entity.type === 'story') {
+    base.status = entity.status;
+    base.priority = entity.priority;
+    base.assignee = entity.assignee ?? null;
+    base.labels = [...(entity.labels ?? [])].sort();
+    base.body = normalizeWhitespace(entity.body);
+  } else if (entity.type === 'epic') {
+    base.status = entity.status;
+    base.priority = entity.priority;
+    base.owner = entity.owner ?? null;
+    base.labels = [...(entity.labels ?? [])].sort();
+    base.body = normalizeWhitespace(entity.body);
+  } else if (entity.type === 'milestone') {
+    base.status = entity.status;
+    base.target_date = entity.target_date ?? null;
+    base.body = normalizeWhitespace(entity.body);
+  } else if (entity.type === 'prd') {
+    base.status = entity.status;
+    base.body = normalizeWhitespace(entity.body);
+  }
+
+  // Sort keys alphabetically
+  const sorted: Record<string, unknown> = {};
+  for (const key of Object.keys(base).sort()) {
+    sorted[key] = base[key];
+  }
+  return sorted;
+}
+
+function normalizeWhitespace(text: string): string {
+  return text
+    .replace(/\r\n/g, '\n')
+    .replace(/[ \t]+$/gm, '')
+    .trim();
+}
+
+export function createInitialState(
+  project: string,
+  entities: ParsedEntity[],
+  projectId?: number,
+): SyncState {
+  const now = new Date().toISOString();
+  const stateEntities: Record<string, SyncStateEntry> = {};
+
+  for (const entity of entities) {
+    if (entity.type === 'roadmap') continue;
+
+    const hash = computeContentHash(entity);
+    const id = 'id' in entity ? (entity as { id: string }).id : '';
+    if (!id) continue;
+
+    const entry: SyncStateEntry = {
+      local_hash: hash,
+      remote_hash: hash,
+      synced_at: now,
+    };
+
+    if (entity.type === 'milestone' && entity.gitlab?.milestone_id) {
+      entry.gitlab_milestone_id = entity.gitlab.milestone_id;
+    }
+    if (
+      (entity.type === 'story' || entity.type === 'epic') &&
+      entity.gitlab?.issue_iid
+    ) {
+      entry.gitlab_issue_iid = entity.gitlab.issue_iid;
+    }
+    if (entity.type === 'epic' && entity.gitlab?.epic_iid) {
+      entry.gitlab_epic_iid = entity.gitlab.epic_iid;
+    }
+
+    stateEntities[id] = entry;
+  }
+
+  return {
+    project,
+    project_id: projectId,
+    last_sync: now,
+    entities: stateEntities,
+  };
+}

--- a/packages/sync-gitlab/src/sync.ts
+++ b/packages/sync-gitlab/src/sync.ts
@@ -1,0 +1,449 @@
+import { createHash } from 'node:crypto';
+import { join } from 'node:path';
+import type { Epic, Milestone, Result, Story } from '@gitpm/core';
+import { parseTree, writeFile } from '@gitpm/core';
+import type { GlIssue, GlMilestone } from './client.js';
+import { GitLabClient } from './client.js';
+import { loadConfig } from './config.js';
+import { resolveConflicts } from './conflict.js';
+import {
+  diffByHash,
+  remoteIssueFields,
+  remoteMilestoneFields,
+} from './diff.js';
+import { entityToGlIssue, milestoneToGlMilestone } from './mapper.js';
+import { computeContentHash, loadState, saveState } from './state.js';
+import type {
+  FieldConflict,
+  SyncOptions,
+  SyncResult,
+  SyncState,
+} from './types.js';
+
+function computeRemoteIssueHash(gl: GlIssue): string {
+  const fields = remoteIssueFields(gl);
+  const json = JSON.stringify(fields);
+  return `sha256:${createHash('sha256').update(json).digest('hex')}`;
+}
+
+function computeRemoteMilestoneHash(gl: GlMilestone): string {
+  const fields = remoteMilestoneFields(gl);
+  const json = JSON.stringify(fields);
+  return `sha256:${createHash('sha256').update(json).digest('hex')}`;
+}
+
+export async function syncWithGitLab(
+  options: SyncOptions,
+): Promise<Result<SyncResult>> {
+  try {
+    const { token, project, metaDir, strategy = 'ask', dryRun } = options;
+    const baseUrl = options.baseUrl ?? 'https://gitlab.com';
+
+    // 1. Load config to get project_id
+    const configResult = await loadConfig(metaDir);
+    if (!configResult.ok) {
+      return {
+        ok: false,
+        error: new Error('No GitLab config found. Run import first.'),
+      };
+    }
+    const config = configResult.value;
+    const projectId = options.projectId ?? config.project_id;
+
+    // 2. Load sync state
+    const stateResult = await loadState(metaDir);
+    if (!stateResult.ok) {
+      return {
+        ok: false,
+        error: new Error('No sync state found. Run import or export first.'),
+      };
+    }
+    const state = stateResult.value;
+
+    // 3. Parse local tree
+    const treeResult = await parseTree(metaDir);
+    if (!treeResult.ok) return treeResult;
+    const tree = treeResult.value;
+
+    const client = new GitLabClient(token, baseUrl);
+    const result: SyncResult = {
+      pushed: { milestones: 0, issues: 0 },
+      pulled: { milestones: 0, issues: 0 },
+      conflicts: [],
+      resolved: 0,
+      skipped: 0,
+    };
+
+    // 4. Build entity lookup maps
+    const milestoneById = new Map(tree.milestones.map((m) => [m.id, m]));
+    const epicById = new Map(tree.epics.map((e) => [e.id, e]));
+    const storyById = new Map(tree.stories.map((s) => [s.id, s]));
+
+    // 5. Process each entity in sync state
+    for (const [entityId, entry] of Object.entries(state.entities)) {
+      const localEntity =
+        milestoneById.get(entityId) ??
+        epicById.get(entityId) ??
+        storyById.get(entityId);
+
+      // Handle local deletion
+      if (!localEntity) {
+        if (!dryRun) {
+          if (entry.gitlab_issue_iid) {
+            await client.updateIssue(projectId, entry.gitlab_issue_iid, {
+              state_event: 'close',
+            });
+          }
+          if (entry.gitlab_milestone_id) {
+            await client.updateMilestone(projectId, entry.gitlab_milestone_id, {
+              state_event: 'close',
+            });
+          }
+          delete state.entities[entityId];
+        }
+        result.pushed.issues++;
+        continue;
+      }
+
+      const currentLocalHash = computeContentHash(localEntity);
+
+      // Milestones
+      if (entry.gitlab_milestone_id && localEntity.type === 'milestone') {
+        const remoteMilestone = await client.getMilestone(
+          projectId,
+          entry.gitlab_milestone_id,
+        );
+
+        if (!remoteMilestone) {
+          if (!dryRun) {
+            localEntity.status = 'cancelled';
+            const filePath = join(metaDir, '..', localEntity.filePath);
+            await writeFile(localEntity, filePath);
+            const hash = computeContentHash(localEntity);
+            state.entities[entityId] = {
+              ...entry,
+              local_hash: hash,
+              remote_hash: hash,
+              synced_at: new Date().toISOString(),
+            };
+          }
+          result.pulled.milestones++;
+          continue;
+        }
+
+        const currentRemoteHash = computeRemoteMilestoneHash(remoteMilestone);
+        const direction = diffByHash(
+          currentLocalHash,
+          currentRemoteHash,
+          entry,
+        );
+
+        if (direction === 'in_sync') continue;
+
+        if (direction === 'local_changed') {
+          if (!dryRun) {
+            const params = milestoneToGlMilestone(localEntity);
+            await client.updateMilestone(
+              projectId,
+              entry.gitlab_milestone_id,
+              params,
+            );
+            state.entities[entityId] = {
+              ...entry,
+              local_hash: currentLocalHash,
+              remote_hash: currentLocalHash,
+              synced_at: new Date().toISOString(),
+            };
+          }
+          result.pushed.milestones++;
+        } else if (direction === 'remote_changed') {
+          if (!dryRun) {
+            applyRemoteMilestone(localEntity, remoteMilestone);
+            const filePath = join(metaDir, '..', localEntity.filePath);
+            await writeFile(localEntity, filePath);
+            const hash = computeContentHash(localEntity);
+            state.entities[entityId] = {
+              ...entry,
+              local_hash: hash,
+              remote_hash: currentRemoteHash,
+              synced_at: new Date().toISOString(),
+            };
+          }
+          result.pulled.milestones++;
+        } else {
+          // Both changed — conflict
+          const conflict: FieldConflict = {
+            entityId,
+            entityTitle: localEntity.title,
+            entityType: 'milestone',
+            field: '_all',
+            baseValue: null,
+            localValue: currentLocalHash,
+            remoteValue: currentRemoteHash,
+          };
+
+          const resolutions = resolveConflicts([conflict], strategy);
+          if (resolutions.length > 0) {
+            const pick = resolutions[0].pick;
+            if (!dryRun) {
+              if (pick === 'local') {
+                const params = milestoneToGlMilestone(localEntity);
+                await client.updateMilestone(
+                  projectId,
+                  entry.gitlab_milestone_id,
+                  params,
+                );
+                state.entities[entityId] = {
+                  ...entry,
+                  local_hash: currentLocalHash,
+                  remote_hash: currentLocalHash,
+                  synced_at: new Date().toISOString(),
+                };
+              } else {
+                applyRemoteMilestone(localEntity, remoteMilestone);
+                const filePath = join(metaDir, '..', localEntity.filePath);
+                await writeFile(localEntity, filePath);
+                const hash = computeContentHash(localEntity);
+                state.entities[entityId] = {
+                  ...entry,
+                  local_hash: hash,
+                  remote_hash: currentRemoteHash,
+                  synced_at: new Date().toISOString(),
+                };
+              }
+            }
+            result.resolved++;
+          } else {
+            result.conflicts.push(conflict);
+            result.skipped++;
+          }
+        }
+      } else if (entry.gitlab_issue_iid) {
+        // Issues (stories/epics)
+        const remoteIssue = await client.getIssue(
+          projectId,
+          entry.gitlab_issue_iid,
+        );
+
+        if (!remoteIssue) {
+          if (
+            !dryRun &&
+            (localEntity.type === 'story' || localEntity.type === 'epic')
+          ) {
+            localEntity.status = 'cancelled';
+            const filePath = join(metaDir, '..', localEntity.filePath);
+            await writeFile(localEntity, filePath);
+            const hash = computeContentHash(localEntity);
+            state.entities[entityId] = {
+              ...entry,
+              local_hash: hash,
+              remote_hash: hash,
+              synced_at: new Date().toISOString(),
+            };
+          }
+          result.pulled.issues++;
+          continue;
+        }
+
+        const currentRemoteHash = computeRemoteIssueHash(remoteIssue);
+        const direction = diffByHash(
+          currentLocalHash,
+          currentRemoteHash,
+          entry,
+        );
+
+        if (direction === 'in_sync') continue;
+
+        if (direction === 'local_changed') {
+          if (
+            !dryRun &&
+            (localEntity.type === 'story' || localEntity.type === 'epic')
+          ) {
+            const params = entityToGlIssue(localEntity);
+            await client.updateIssue(projectId, entry.gitlab_issue_iid, {
+              title: params.title,
+              description: params.description,
+              state_event: params.state_event,
+              labels: params.labels,
+            });
+            state.entities[entityId] = {
+              ...entry,
+              local_hash: currentLocalHash,
+              remote_hash: currentLocalHash,
+              synced_at: new Date().toISOString(),
+            };
+          }
+          result.pushed.issues++;
+        } else if (direction === 'remote_changed') {
+          if (
+            !dryRun &&
+            (localEntity.type === 'story' || localEntity.type === 'epic')
+          ) {
+            applyRemoteIssue(localEntity, remoteIssue);
+            const filePath = join(metaDir, '..', localEntity.filePath);
+            await writeFile(localEntity, filePath);
+            const hash = computeContentHash(localEntity);
+            state.entities[entityId] = {
+              ...entry,
+              local_hash: hash,
+              remote_hash: currentRemoteHash,
+              synced_at: new Date().toISOString(),
+            };
+          }
+          result.pulled.issues++;
+        } else {
+          // Both changed — conflict
+          const conflict: FieldConflict = {
+            entityId,
+            entityTitle: localEntity.title,
+            entityType: localEntity.type,
+            field: '_all',
+            baseValue: null,
+            localValue: currentLocalHash,
+            remoteValue: currentRemoteHash,
+          };
+
+          const resolutions = resolveConflicts([conflict], strategy);
+          if (resolutions.length > 0) {
+            const pick = resolutions[0].pick;
+            if (
+              !dryRun &&
+              (localEntity.type === 'story' || localEntity.type === 'epic')
+            ) {
+              if (pick === 'local') {
+                const params = entityToGlIssue(localEntity);
+                await client.updateIssue(projectId, entry.gitlab_issue_iid, {
+                  title: params.title,
+                  description: params.description,
+                  state_event: params.state_event,
+                  labels: params.labels,
+                });
+                state.entities[entityId] = {
+                  ...entry,
+                  local_hash: currentLocalHash,
+                  remote_hash: currentLocalHash,
+                  synced_at: new Date().toISOString(),
+                };
+              } else {
+                applyRemoteIssue(localEntity, remoteIssue);
+                const filePath = join(metaDir, '..', localEntity.filePath);
+                await writeFile(localEntity, filePath);
+                const hash = computeContentHash(localEntity);
+                state.entities[entityId] = {
+                  ...entry,
+                  local_hash: hash,
+                  remote_hash: currentRemoteHash,
+                  synced_at: new Date().toISOString(),
+                };
+              }
+            }
+            result.resolved++;
+          } else {
+            result.conflicts.push(conflict);
+            result.skipped++;
+          }
+        }
+      }
+    }
+
+    // 6. Handle new local entities (not in sync state)
+    const syncedIds = new Set(Object.keys(state.entities));
+    const newEntities: (Epic | Story | Milestone)[] = [
+      ...tree.milestones.filter((m) => !syncedIds.has(m.id)),
+      ...tree.epics.filter((e) => !syncedIds.has(e.id)),
+      ...tree.stories.filter((s) => !syncedIds.has(s.id)),
+    ];
+
+    for (const entity of newEntities) {
+      if (entity.type === 'milestone') {
+        if (!dryRun) {
+          const params = milestoneToGlMilestone(entity);
+          const created = await client.createMilestone(projectId, params);
+          entity.gitlab = {
+            milestone_id: created.id,
+            project_id: projectId,
+            base_url: baseUrl,
+            last_sync_hash: computeContentHash(entity),
+            synced_at: new Date().toISOString(),
+          };
+          const filePath = join(metaDir, '..', entity.filePath);
+          await writeFile(entity, filePath);
+          const hash = computeContentHash(entity);
+          state.entities[entity.id] = {
+            gitlab_milestone_id: created.id,
+            local_hash: hash,
+            remote_hash: hash,
+            synced_at: new Date().toISOString(),
+          };
+        }
+        result.pushed.milestones++;
+      } else {
+        if (!dryRun) {
+          const params = entityToGlIssue(entity);
+          const created = await client.createIssue(projectId, {
+            title: params.title,
+            description: params.description,
+            labels: params.labels,
+          });
+
+          if (params.state_event === 'close') {
+            await client.updateIssue(projectId, created.iid, {
+              state_event: 'close',
+            });
+          }
+
+          entity.gitlab = {
+            issue_iid: created.iid,
+            project_id: projectId,
+            base_url: baseUrl,
+            last_sync_hash: computeContentHash(entity),
+            synced_at: new Date().toISOString(),
+          };
+          const filePath = join(metaDir, '..', entity.filePath);
+          await writeFile(entity, filePath);
+          const hash = computeContentHash(entity);
+          state.entities[entity.id] = {
+            gitlab_issue_iid: created.iid,
+            local_hash: hash,
+            remote_hash: hash,
+            synced_at: new Date().toISOString(),
+          };
+        }
+        result.pushed.issues++;
+      }
+    }
+
+    // 7. Save state
+    if (!dryRun) {
+      state.last_sync = new Date().toISOString();
+      await saveState(metaDir, state);
+    }
+
+    return { ok: true, value: result };
+  } catch (err) {
+    return {
+      ok: false,
+      error: err instanceof Error ? err : new Error(`Sync failed: ${err}`),
+    };
+  }
+}
+
+function applyRemoteMilestone(local: Milestone, remote: GlMilestone): void {
+  local.title = remote.title;
+  local.status = remote.state === 'closed' ? 'done' : 'in_progress';
+  local.target_date = remote.due_date ?? undefined;
+  local.body = remote.description ?? '';
+}
+
+function applyRemoteIssue(local: Story | Epic, remote: GlIssue): void {
+  local.title = remote.title;
+  local.status = remote.state === 'closed' ? 'done' : 'todo';
+  local.body = remote.description ?? '';
+  local.labels = remote.labels.filter((l) => l !== 'epic');
+
+  if (local.type === 'story') {
+    local.assignee = remote.assignee?.username ?? null;
+  } else {
+    local.owner = remote.assignee?.username ?? null;
+  }
+}

--- a/packages/sync-gitlab/src/types.ts
+++ b/packages/sync-gitlab/src/types.ts
@@ -1,0 +1,136 @@
+import type { EntityId, Status } from '@gitpm/core';
+
+export type LinkStrategy =
+  | 'body-refs'
+  | 'native-epics'
+  | 'milestone'
+  | 'labels'
+  | 'all';
+
+export interface ImportOptions {
+  token: string;
+  project: string; // "namespace/project"
+  projectId?: number;
+  groupId?: number;
+  baseUrl?: string; // default: "https://gitlab.com"
+  metaDir: string;
+  statusMapping?: Record<string, Status>;
+  linkStrategy?: LinkStrategy;
+}
+
+export interface ImportResult {
+  milestones: number;
+  epics: number;
+  stories: number;
+  totalFiles: number;
+}
+
+export interface GitLabConfig {
+  project: string;
+  project_id: number;
+  group_id?: number;
+  base_url: string;
+  status_mapping: Record<string, Status>;
+  label_mapping: {
+    epic_labels: string[];
+  };
+  auto_sync: boolean;
+}
+
+export interface SyncStateEntry {
+  gitlab_issue_iid?: number;
+  gitlab_milestone_id?: number;
+  gitlab_epic_iid?: number;
+  local_hash: string;
+  remote_hash: string;
+  synced_at: string;
+}
+
+export interface SyncState {
+  project: string;
+  project_id?: number;
+  last_sync: string;
+  entities: Record<EntityId, SyncStateEntry>;
+}
+
+export const DEFAULT_STATUS_MAPPING: Record<string, Status> = {
+  Todo: 'todo',
+  'In Progress': 'in_progress',
+  'In Review': 'in_review',
+  Done: 'done',
+  Backlog: 'backlog',
+};
+
+export const DEFAULT_EPIC_LABELS = ['epic'];
+
+export interface ExportOptions {
+  token: string;
+  project: string; // "namespace/project"
+  projectId?: number;
+  groupId?: number;
+  baseUrl?: string;
+  metaDir: string;
+  dryRun?: boolean;
+}
+
+export interface ExportResult {
+  created: { milestones: number; issues: number };
+  updated: { milestones: number; issues: number };
+  totalChanges: number;
+}
+
+export interface SyncOptions {
+  token: string;
+  project: string;
+  projectId?: number;
+  groupId?: number;
+  baseUrl?: string;
+  metaDir: string;
+  strategy?: ConflictStrategy;
+  dryRun?: boolean;
+}
+
+export type ConflictStrategy = 'local-wins' | 'remote-wins' | 'ask';
+
+export interface SyncResult {
+  pushed: { milestones: number; issues: number };
+  pulled: { milestones: number; issues: number };
+  conflicts: FieldConflict[];
+  resolved: number;
+  skipped: number;
+}
+
+export interface FieldChange {
+  field: string;
+  oldValue: unknown;
+  newValue: unknown;
+}
+
+export interface FieldConflict {
+  entityId: string;
+  entityTitle: string;
+  entityType: string;
+  field: string;
+  baseValue: unknown;
+  localValue: unknown;
+  remoteValue: unknown;
+}
+
+export type DiffStatus =
+  | 'in_sync'
+  | 'local_changed'
+  | 'remote_changed'
+  | 'conflict';
+
+export interface DiffResult {
+  status: DiffStatus;
+  localChanges: FieldChange[];
+  remoteChanges: FieldChange[];
+  conflicts: FieldConflict[];
+}
+
+export interface Resolution {
+  entityId: string;
+  field: string;
+  pick: 'local' | 'remote';
+}

--- a/packages/sync-gitlab/tsconfig.json
+++ b/packages/sync-gitlab/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src"]
+}

--- a/packages/sync-gitlab/tsup.config.ts
+++ b/packages/sync-gitlab/tsup.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['esm'],
+  dts: true,
+  clean: true,
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,7 +17,8 @@
     "paths": {
       "@gitpm/core": ["./packages/core/src"],
       "@gitpm/sync-github": ["./packages/sync-github/src"],
-      "@gitpm/sync-jira": ["./packages/sync-jira/src"]
+      "@gitpm/sync-jira": ["./packages/sync-jira/src"],
+      "@gitpm/sync-gitlab": ["./packages/sync-gitlab/src"]
     }
   },
   "exclude": ["node_modules", "dist"]


### PR DESCRIPTION
Implement bidirectional sync between .meta/ and GitLab Issues/Milestones/Epics,
mirroring the existing @gitpm/sync-github adapter pattern. This addresses the
GitLab Integration epic (#12) with all three stories.

Changes:
- Add GitLabSync schema to @gitpm/core (gitlab field on Story, Epic, Milestone)
- New @gitpm/sync-gitlab package with full import/export/sync flows
- GitLab REST API v4 client using plain fetch (no external SDK)
- Graceful Premium epics fallback (403 → label-based detection)
- Self-hosted GitLab support via configurable base_url
- Weight-to-priority mapping for GitLab issue weights
- CLI integration: --source gitlab on import, auto-detect on push/pull/sync
- 30 new tests with fixture data, all 197 tests passing

https://claude.ai/code/session_01UUQi3Wm88PPDQUrVTDGMe6