### PR TITLE
Add comprehensive test suite for CLI commands

### DIFF
--- a/packages/cli/src/__tests__/import.test.ts
+++ b/packages/cli/src/__tests__/import.test.ts
@@ -1,0 +1,220 @@
+import { Command } from 'commander';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// --- Mocks ---
+
+const mockImportFromGitHub = vi.fn();
+const mockImportFromGitLab = vi.fn();
+const mockResolveToken = vi.fn();
+
+vi.mock('@gitpm/sync-github', () => ({
+  importFromGitHub: (...args: unknown[]) => mockImportFromGitHub(...args),
+}));
+
+vi.mock('@gitpm/sync-gitlab', () => ({
+  importFromGitLab: (...args: unknown[]) => mockImportFromGitLab(...args),
+}));
+
+vi.mock('../utils/auth.js', () => ({
+  resolveToken: (...args: unknown[]) => mockResolveToken(...args),
+}));
+
+vi.mock('ora', () => ({
+  default: () => ({
+    start: vi.fn().mockReturnThis(),
+    succeed: vi.fn().mockReturnThis(),
+    fail: vi.fn().mockReturnThis(),
+    stop: vi.fn().mockReturnThis(),
+  }),
+}));
+
+let logSpy: ReturnType<typeof vi.spyOn>;
+let errorSpy: ReturnType<typeof vi.spyOn>;
+let exitSpy: ReturnType<typeof vi.spyOn>;
+
+async function run(...args: string[]) {
+  const { importCommand } = await import('../commands/import.js');
+  const program = new Command();
+  program.option('--meta-dir <path>', 'Path to .meta directory', '.meta');
+  program.addCommand(importCommand);
+  await program.parseAsync(['node', 'gitpm', 'import', ...args]);
+}
+
+const importSummary = {
+  milestones: 2,
+  epics: 3,
+  stories: 5,
+  totalFiles: 10,
+};
+
+// --- Tests ---
+
+describe('gitpm import', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.resetAllMocks();
+    logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => {
+      throw new Error('process.exit');
+    }) as never);
+    mockResolveToken.mockResolvedValue('mock-token');
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  // --- GitHub ---
+
+  it('imports from GitHub successfully', async () => {
+    mockImportFromGitHub.mockResolvedValue({ ok: true, value: importSummary });
+
+    await run('--repo', 'owner/repo', '--meta-dir', '/tmp/meta');
+
+    expect(mockImportFromGitHub).toHaveBeenCalledWith(
+      expect.objectContaining({
+        token: 'mock-token',
+        repo: 'owner/repo',
+        metaDir: '/tmp/meta',
+      }),
+    );
+    expect(exitSpy).not.toHaveBeenCalled();
+    const allOutput = logSpy.mock.calls.map((c) => c.join(' ')).join('\n');
+    expect(allOutput).toContain('Milestones: 2');
+    expect(allOutput).toContain('Epics:      3');
+    expect(allOutput).toContain('Stories:    5');
+  });
+
+  it('exits with code 1 when --repo is missing', async () => {
+    await expect(run('--meta-dir', '/tmp/meta')).rejects.toThrow(
+      'process.exit',
+    );
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    const errOutput = errorSpy.mock.calls.map((c) => c.join(' ')).join('\n');
+    expect(errOutput).toContain('--repo is required');
+  });
+
+  it('exits with code 1 when --repo format is invalid', async () => {
+    await expect(
+      run('--repo', 'badformat', '--meta-dir', '/tmp/meta'),
+    ).rejects.toThrow('process.exit');
+    expect(exitSpy).toHaveBeenCalledWith(1);
+  });
+
+  it('passes --link-strategy to importFromGitHub', async () => {
+    mockImportFromGitHub.mockResolvedValue({ ok: true, value: importSummary });
+
+    await run(
+      '--repo',
+      'owner/repo',
+      '--link-strategy',
+      'labels',
+      '--meta-dir',
+      '/tmp/meta',
+    );
+
+    expect(mockImportFromGitHub).toHaveBeenCalledWith(
+      expect.objectContaining({ linkStrategy: 'labels' }),
+    );
+  });
+
+  it('exits with code 1 for invalid link strategy', async () => {
+    await expect(
+      run(
+        '--repo',
+        'owner/repo',
+        '--link-strategy',
+        'invalid-strat',
+        '--meta-dir',
+        '/tmp/meta',
+      ),
+    ).rejects.toThrow('process.exit');
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    const errOutput = errorSpy.mock.calls.map((c) => c.join(' ')).join('\n');
+    expect(errOutput).toContain('Invalid link strategy');
+  });
+
+  it('exits with code 1 when import fails', async () => {
+    mockImportFromGitHub.mockResolvedValue({
+      ok: false,
+      error: { message: 'API rate limit exceeded' },
+    });
+
+    await expect(
+      run('--repo', 'owner/repo', '--meta-dir', '/tmp/meta'),
+    ).rejects.toThrow('process.exit');
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    const errOutput = errorSpy.mock.calls.map((c) => c.join(' ')).join('\n');
+    expect(errOutput).toContain('API rate limit exceeded');
+  });
+
+  it('exits with code 1 when token resolution fails', async () => {
+    mockResolveToken.mockRejectedValue(new Error('No GitHub token found'));
+
+    await expect(
+      run('--repo', 'owner/repo', '--meta-dir', '/tmp/meta'),
+    ).rejects.toThrow('process.exit');
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    const errOutput = errorSpy.mock.calls.map((c) => c.join(' ')).join('\n');
+    expect(errOutput).toContain('No GitHub token found');
+  });
+
+  // --- GitLab ---
+
+  it('imports from GitLab successfully', async () => {
+    mockImportFromGitLab.mockResolvedValue({ ok: true, value: importSummary });
+
+    await run(
+      '--source',
+      'gitlab',
+      '--project',
+      'group/proj',
+      '--token',
+      'gl-tok',
+      '--meta-dir',
+      '/tmp/meta',
+    );
+
+    expect(mockImportFromGitLab).toHaveBeenCalledWith(
+      expect.objectContaining({ token: 'gl-tok', project: 'group/proj' }),
+    );
+    expect(exitSpy).not.toHaveBeenCalled();
+  });
+
+  it('exits with code 1 when GitLab project is missing', async () => {
+    await expect(
+      run('--source', 'gitlab', '--token', 'gl-tok', '--meta-dir', '/tmp/meta'),
+    ).rejects.toThrow('process.exit');
+    expect(exitSpy).toHaveBeenCalledWith(1);
+  });
+
+  it('exits with code 1 when GitLab token is missing', async () => {
+    const originalEnv = process.env.GITLAB_TOKEN;
+    // biome-ignore lint/performance/noDelete: must remove env var, not set to "undefined" string
+    delete process.env.GITLAB_TOKEN;
+
+    await expect(
+      run(
+        '--source',
+        'gitlab',
+        '--project',
+        'group/proj',
+        '--meta-dir',
+        '/tmp/meta',
+      ),
+    ).rejects.toThrow('process.exit');
+    expect(exitSpy).toHaveBeenCalledWith(1);
+
+    process.env.GITLAB_TOKEN = originalEnv;
+  });
+
+  it('exits with code 1 for unknown source', async () => {
+    await expect(
+      run('--source', 'bitbucket', '--meta-dir', '/tmp/meta'),
+    ).rejects.toThrow('process.exit');
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    const errOutput = errorSpy.mock.calls.map((c) => c.join(' ')).join('\n');
+    expect(errOutput).toContain('Unknown source');
+  });
+});

--- a/packages/cli/src/__tests__/init.test.ts
+++ b/packages/cli/src/__tests__/init.test.ts
@@ -1,0 +1,112 @@
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { Command } from 'commander';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// --- Mocks ---
+
+const mockScaffoldMeta = vi.fn();
+const mockInput = vi.fn();
+
+vi.mock('@gitpm/core', () => ({
+  scaffoldMeta: (...args: unknown[]) => mockScaffoldMeta(...args),
+}));
+
+vi.mock('@inquirer/prompts', () => ({
+  input: (...args: unknown[]) => mockInput(...args),
+}));
+
+let logSpy: ReturnType<typeof vi.spyOn>;
+let errorSpy: ReturnType<typeof vi.spyOn>;
+let exitSpy: ReturnType<typeof vi.spyOn>;
+
+async function run(...args: string[]) {
+  const { initCommand } = await import('../commands/init.js');
+  const program = new Command();
+  program.option('--meta-dir <path>', 'Path to .meta directory', '.meta');
+  program.addCommand(initCommand);
+  await program.parseAsync(['node', 'gitpm', 'init', ...args]);
+}
+
+// --- Tests ---
+
+describe('gitpm init', () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    vi.resetModules();
+    vi.resetAllMocks();
+    tmpDir = await mkdtemp(join(tmpdir(), 'gitpm-cli-init-'));
+    logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => {
+      throw new Error('process.exit');
+    }) as never);
+  });
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    await rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it('creates .meta structure with project name argument', async () => {
+    const metaDir = join(tmpDir, '.meta');
+    mockScaffoldMeta.mockResolvedValue({ ok: true, value: undefined });
+
+    // scaffoldMeta is mocked, so collectFiles will read from an empty dir.
+    // We need to create at least one file so the readdir doesn't fail.
+    const { mkdir, writeFile } = await import('node:fs/promises');
+    await mkdir(metaDir, { recursive: true });
+    await writeFile(join(metaDir, 'roadmap.yaml'), '');
+
+    await run('my-project', '--meta-dir', metaDir);
+
+    expect(mockScaffoldMeta).toHaveBeenCalledWith(metaDir, 'my-project');
+    expect(mockInput).not.toHaveBeenCalled();
+    expect(exitSpy).not.toHaveBeenCalled();
+  });
+
+  it('prompts for project name when not provided', async () => {
+    const metaDir = join(tmpDir, '.meta');
+    mockInput.mockResolvedValue('prompted-name');
+    mockScaffoldMeta.mockResolvedValue({ ok: true, value: undefined });
+
+    const { mkdir, writeFile } = await import('node:fs/promises');
+    await mkdir(metaDir, { recursive: true });
+    await writeFile(join(metaDir, 'roadmap.yaml'), '');
+
+    await run('--meta-dir', metaDir);
+
+    expect(mockInput).toHaveBeenCalled();
+    expect(mockScaffoldMeta).toHaveBeenCalledWith(metaDir, 'prompted-name');
+  });
+
+  it('exits with code 1 when scaffoldMeta fails', async () => {
+    const metaDir = join(tmpDir, '.meta');
+    mockScaffoldMeta.mockResolvedValue({
+      ok: false,
+      error: { message: 'directory already exists' },
+    });
+
+    await expect(run('my-project', '--meta-dir', metaDir)).rejects.toThrow(
+      'process.exit',
+    );
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    const errOutput = errorSpy.mock.calls.map((c) => c.join(' ')).join('\n');
+    expect(errOutput).toContain('directory already exists');
+  });
+
+  it('respects --meta-dir option', async () => {
+    const customDir = join(tmpDir, 'custom-meta');
+    mockScaffoldMeta.mockResolvedValue({ ok: true, value: undefined });
+
+    const { mkdir, writeFile } = await import('node:fs/promises');
+    await mkdir(customDir, { recursive: true });
+    await writeFile(join(customDir, 'roadmap.yaml'), '');
+
+    await run('test-proj', '--meta-dir', customDir);
+
+    expect(mockScaffoldMeta).toHaveBeenCalledWith(customDir, 'test-proj');
+  });
+});

--- a/packages/cli/src/__tests__/pull.test.ts
+++ b/packages/cli/src/__tests__/pull.test.ts
@@ -1,0 +1,225 @@
+import { Command } from 'commander';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// --- Mocks ---
+
+const mockLoadGitHubConfig = vi.fn();
+const mockSyncWithGitHub = vi.fn();
+const mockLoadGitLabConfig = vi.fn();
+const mockSyncWithGitLab = vi.fn();
+const mockResolveToken = vi.fn();
+const mockPromptConflictResolution = vi.fn();
+
+vi.mock('@gitpm/sync-github', () => ({
+  loadConfig: (...args: unknown[]) => mockLoadGitHubConfig(...args),
+  syncWithGitHub: (...args: unknown[]) => mockSyncWithGitHub(...args),
+}));
+
+vi.mock('@gitpm/sync-gitlab', () => ({
+  loadConfig: (...args: unknown[]) => mockLoadGitLabConfig(...args),
+  syncWithGitLab: (...args: unknown[]) => mockSyncWithGitLab(...args),
+}));
+
+vi.mock('../utils/auth.js', () => ({
+  resolveToken: (...args: unknown[]) => mockResolveToken(...args),
+}));
+
+vi.mock('../utils/conflict-ui.js', () => ({
+  promptConflictResolution: (...args: unknown[]) =>
+    mockPromptConflictResolution(...args),
+}));
+
+vi.mock('ora', () => ({
+  default: () => ({
+    start: vi.fn().mockReturnThis(),
+    succeed: vi.fn().mockReturnThis(),
+    fail: vi.fn().mockReturnThis(),
+    stop: vi.fn().mockReturnThis(),
+  }),
+}));
+
+let logSpy: ReturnType<typeof vi.spyOn>;
+let errorSpy: ReturnType<typeof vi.spyOn>;
+let exitSpy: ReturnType<typeof vi.spyOn>;
+
+async function run(...args: string[]) {
+  const { pullCommand } = await import('../commands/pull.js');
+  const program = new Command();
+  program.option('--meta-dir <path>', 'Path to .meta directory', '.meta');
+  program.addCommand(pullCommand);
+  await program.parseAsync(['node', 'gitpm', 'pull', ...args]);
+}
+
+const pullResult = {
+  pulled: { milestones: 1, issues: 3 },
+  conflicts: [],
+  resolved: 0,
+  skipped: 0,
+};
+
+// --- Tests ---
+
+describe('gitpm pull', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.resetAllMocks();
+    logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => {
+      throw new Error('process.exit');
+    }) as never);
+    mockResolveToken.mockResolvedValue('mock-token');
+    mockLoadGitHubConfig.mockResolvedValue({
+      ok: true,
+      value: { repo: 'owner/repo' },
+    });
+    mockLoadGitLabConfig.mockResolvedValue({
+      ok: false,
+      error: { message: 'not found' },
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('pulls from GitHub successfully with remote-wins', async () => {
+    mockSyncWithGitHub.mockResolvedValue({ ok: true, value: pullResult });
+
+    await run('--meta-dir', '/tmp/meta');
+
+    expect(mockSyncWithGitHub).toHaveBeenCalledWith(
+      expect.objectContaining({ strategy: 'remote-wins' }),
+    );
+    expect(exitSpy).not.toHaveBeenCalled();
+    const allOutput = logSpy.mock.calls.map((c) => c.join(' ')).join('\n');
+    expect(allOutput).toContain('Pull Summary');
+    expect(allOutput).toContain('4 changes');
+  });
+
+  it('prompts for conflict resolution with ask strategy', async () => {
+    const conflicts = [
+      {
+        entityId: 'e1',
+        entityTitle: 'Story 1',
+        entityType: 'story',
+        field: 'title',
+        localValue: 'Local Title',
+        remoteValue: 'Remote Title',
+      },
+    ];
+    mockSyncWithGitHub.mockResolvedValue({
+      ok: true,
+      value: { ...pullResult, conflicts, resolved: 0 },
+    });
+    mockPromptConflictResolution.mockResolvedValue([
+      { entityId: 'e1', field: 'title', pick: 'local' },
+    ]);
+
+    await run('--strategy', 'ask', '--meta-dir', '/tmp/meta');
+
+    expect(mockPromptConflictResolution).toHaveBeenCalledWith(conflicts);
+    expect(exitSpy).not.toHaveBeenCalled();
+  });
+
+  it('does not prompt for conflicts with local-wins', async () => {
+    mockSyncWithGitHub.mockResolvedValue({ ok: true, value: pullResult });
+
+    await run('--strategy', 'local-wins', '--meta-dir', '/tmp/meta');
+
+    expect(mockPromptConflictResolution).not.toHaveBeenCalled();
+    expect(mockSyncWithGitHub).toHaveBeenCalledWith(
+      expect.objectContaining({ strategy: 'local-wins' }),
+    );
+  });
+
+  it('exits with code 1 when pull fails', async () => {
+    mockSyncWithGitHub.mockResolvedValue({
+      ok: false,
+      error: { message: 'sync error' },
+    });
+
+    await expect(run('--meta-dir', '/tmp/meta')).rejects.toThrow(
+      'process.exit',
+    );
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    const errOutput = errorSpy.mock.calls.map((c) => c.join(' ')).join('\n');
+    expect(errOutput).toContain('sync error');
+  });
+
+  it('exits with code 1 when no sync config found', async () => {
+    mockLoadGitHubConfig.mockResolvedValue({
+      ok: false,
+      error: { message: 'not found' },
+    });
+    mockLoadGitLabConfig.mockResolvedValue({
+      ok: false,
+      error: { message: 'not found' },
+    });
+
+    await expect(run('--meta-dir', '/tmp/meta')).rejects.toThrow(
+      'process.exit',
+    );
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    const errOutput = errorSpy.mock.calls.map((c) => c.join(' ')).join('\n');
+    expect(errOutput).toContain('No sync config found');
+  });
+
+  it('exits with code 1 when token resolution fails', async () => {
+    mockResolveToken.mockRejectedValue(new Error('No GitHub token found'));
+
+    await expect(run('--meta-dir', '/tmp/meta')).rejects.toThrow(
+      'process.exit',
+    );
+    expect(exitSpy).toHaveBeenCalledWith(1);
+  });
+
+  it('pulls from GitLab when GitLab config is found', async () => {
+    mockLoadGitHubConfig.mockResolvedValue({
+      ok: false,
+      error: { message: 'not found' },
+    });
+    mockLoadGitLabConfig.mockResolvedValue({
+      ok: true,
+      value: {
+        project: 'group/proj',
+        project_id: 42,
+        base_url: 'https://gitlab.com',
+      },
+    });
+    mockSyncWithGitLab.mockResolvedValue({ ok: true, value: pullResult });
+
+    await run('--token', 'gl-tok', '--meta-dir', '/tmp/meta');
+
+    expect(mockSyncWithGitLab).toHaveBeenCalledWith(
+      expect.objectContaining({ token: 'gl-tok', project: 'group/proj' }),
+    );
+    expect(exitSpy).not.toHaveBeenCalled();
+  });
+
+  it('exits with code 1 when GitLab token is missing', async () => {
+    const originalEnv = process.env.GITLAB_TOKEN;
+    // biome-ignore lint/performance/noDelete: must remove env var, not set to "undefined" string
+    delete process.env.GITLAB_TOKEN;
+
+    mockLoadGitHubConfig.mockResolvedValue({
+      ok: false,
+      error: { message: 'not found' },
+    });
+    mockLoadGitLabConfig.mockResolvedValue({
+      ok: true,
+      value: {
+        project: 'group/proj',
+        project_id: 42,
+        base_url: 'https://gitlab.com',
+      },
+    });
+
+    await expect(run('--meta-dir', '/tmp/meta')).rejects.toThrow(
+      'process.exit',
+    );
+    expect(exitSpy).toHaveBeenCalledWith(1);
+
+    process.env.GITLAB_TOKEN = originalEnv;
+  });
+});

--- a/packages/cli/src/__tests__/push.test.ts
+++ b/packages/cli/src/__tests__/push.test.ts
@@ -1,0 +1,242 @@
+import { Command } from 'commander';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// --- Mocks ---
+
+const mockLoadGitHubConfig = vi.fn();
+const mockExportToGitHub = vi.fn();
+const mockLoadGitLabConfig = vi.fn();
+const mockExportToGitLab = vi.fn();
+const mockResolveToken = vi.fn();
+const mockConfirm = vi.fn();
+
+vi.mock('@gitpm/sync-github', () => ({
+  loadConfig: (...args: unknown[]) => mockLoadGitHubConfig(...args),
+  exportToGitHub: (...args: unknown[]) => mockExportToGitHub(...args),
+}));
+
+vi.mock('@gitpm/sync-gitlab', () => ({
+  loadConfig: (...args: unknown[]) => mockLoadGitLabConfig(...args),
+  exportToGitLab: (...args: unknown[]) => mockExportToGitLab(...args),
+}));
+
+vi.mock('../utils/auth.js', () => ({
+  resolveToken: (...args: unknown[]) => mockResolveToken(...args),
+}));
+
+vi.mock('@inquirer/prompts', () => ({
+  confirm: (...args: unknown[]) => mockConfirm(...args),
+}));
+
+vi.mock('ora', () => ({
+  default: () => ({
+    start: vi.fn().mockReturnThis(),
+    succeed: vi.fn().mockReturnThis(),
+    fail: vi.fn().mockReturnThis(),
+    stop: vi.fn().mockReturnThis(),
+  }),
+}));
+
+let logSpy: ReturnType<typeof vi.spyOn>;
+let errorSpy: ReturnType<typeof vi.spyOn>;
+let exitSpy: ReturnType<typeof vi.spyOn>;
+
+async function run(...args: string[]) {
+  const { pushCommand } = await import('../commands/push.js');
+  const program = new Command();
+  program.option('--meta-dir <path>', 'Path to .meta directory', '.meta');
+  program.addCommand(pushCommand);
+  await program.parseAsync(['node', 'gitpm', 'push', ...args]);
+}
+
+const exportResult = {
+  created: { milestones: 1, issues: 2 },
+  updated: { milestones: 0, issues: 1 },
+  totalChanges: 4,
+};
+
+const noChangesResult = {
+  created: { milestones: 0, issues: 0 },
+  updated: { milestones: 0, issues: 0 },
+  totalChanges: 0,
+};
+
+// --- Tests ---
+
+describe('gitpm push', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.resetAllMocks();
+    logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => {
+      throw new Error('process.exit');
+    }) as never);
+    mockResolveToken.mockResolvedValue('mock-token');
+    // Default: GitHub config found, GitLab not
+    mockLoadGitHubConfig.mockResolvedValue({
+      ok: true,
+      value: { repo: 'owner/repo' },
+    });
+    mockLoadGitLabConfig.mockResolvedValue({
+      ok: false,
+      error: { message: 'not found' },
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('prints preview in dry-run mode', async () => {
+    mockExportToGitHub.mockResolvedValue({ ok: true, value: exportResult });
+
+    await run('--dry-run', '--meta-dir', '/tmp/meta');
+
+    expect(mockExportToGitHub).toHaveBeenCalledWith(
+      expect.objectContaining({ dryRun: true }),
+    );
+    expect(mockConfirm).not.toHaveBeenCalled();
+    expect(exitSpy).not.toHaveBeenCalled();
+    const allOutput = logSpy.mock.calls.map((c) => c.join(' ')).join('\n');
+    expect(allOutput).toContain('New issues:     2');
+  });
+
+  it('pushes when user confirms', async () => {
+    mockExportToGitHub
+      .mockResolvedValueOnce({ ok: true, value: exportResult }) // preview
+      .mockResolvedValueOnce({ ok: true, value: exportResult }); // actual push
+    mockConfirm.mockResolvedValue(true);
+
+    await run('--meta-dir', '/tmp/meta');
+
+    expect(mockExportToGitHub).toHaveBeenCalledTimes(2);
+    expect(mockConfirm).toHaveBeenCalled();
+    expect(exitSpy).not.toHaveBeenCalled();
+  });
+
+  it('cancels push when user declines', async () => {
+    mockExportToGitHub.mockResolvedValue({ ok: true, value: exportResult });
+    mockConfirm.mockResolvedValue(false);
+
+    await run('--meta-dir', '/tmp/meta');
+
+    // Only called once for preview, not for actual push
+    expect(mockExportToGitHub).toHaveBeenCalledTimes(1);
+    const allOutput = logSpy.mock.calls.map((c) => c.join(' ')).join('\n');
+    expect(allOutput).toContain('Push cancelled');
+  });
+
+  it('skips confirmation with --yes', async () => {
+    mockExportToGitHub
+      .mockResolvedValueOnce({ ok: true, value: exportResult })
+      .mockResolvedValueOnce({ ok: true, value: exportResult });
+
+    await run('--yes', '--meta-dir', '/tmp/meta');
+
+    expect(mockConfirm).not.toHaveBeenCalled();
+    expect(mockExportToGitHub).toHaveBeenCalledTimes(2);
+  });
+
+  it('prints nothing-to-push when totalChanges is 0', async () => {
+    mockExportToGitHub.mockResolvedValue({ ok: true, value: noChangesResult });
+
+    await run('--meta-dir', '/tmp/meta');
+
+    expect(mockConfirm).not.toHaveBeenCalled();
+    const allOutput = logSpy.mock.calls.map((c) => c.join(' ')).join('\n');
+    expect(allOutput).toContain('Nothing to push');
+  });
+
+  it('exits with code 1 when push fails', async () => {
+    mockExportToGitHub
+      .mockResolvedValueOnce({ ok: true, value: exportResult }) // preview ok
+      .mockResolvedValueOnce({ ok: false, error: { message: 'push error' } });
+    mockConfirm.mockResolvedValue(true);
+
+    await expect(run('--meta-dir', '/tmp/meta')).rejects.toThrow(
+      'process.exit',
+    );
+    expect(exitSpy).toHaveBeenCalledWith(1);
+  });
+
+  it('exits with code 1 when no sync config found', async () => {
+    mockLoadGitHubConfig.mockResolvedValue({
+      ok: false,
+      error: { message: 'not found' },
+    });
+    mockLoadGitLabConfig.mockResolvedValue({
+      ok: false,
+      error: { message: 'not found' },
+    });
+
+    await expect(run('--meta-dir', '/tmp/meta')).rejects.toThrow(
+      'process.exit',
+    );
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    const errOutput = errorSpy.mock.calls.map((c) => c.join(' ')).join('\n');
+    expect(errOutput).toContain('No sync config found');
+  });
+
+  it('exits with code 1 when token resolution fails', async () => {
+    mockResolveToken.mockRejectedValue(new Error('No GitHub token found'));
+
+    await expect(run('--meta-dir', '/tmp/meta')).rejects.toThrow(
+      'process.exit',
+    );
+    expect(exitSpy).toHaveBeenCalledWith(1);
+  });
+
+  it('pushes to GitLab when GitLab config is found', async () => {
+    mockLoadGitHubConfig.mockResolvedValue({
+      ok: false,
+      error: { message: 'not found' },
+    });
+    mockLoadGitLabConfig.mockResolvedValue({
+      ok: true,
+      value: {
+        project: 'group/proj',
+        project_id: 42,
+        base_url: 'https://gitlab.com',
+      },
+    });
+    mockExportToGitLab.mockResolvedValue({ ok: true, value: exportResult });
+
+    await run('--dry-run', '--token', 'gl-tok', '--meta-dir', '/tmp/meta');
+
+    expect(mockExportToGitLab).toHaveBeenCalledWith(
+      expect.objectContaining({
+        token: 'gl-tok',
+        project: 'group/proj',
+        dryRun: true,
+      }),
+    );
+    expect(exitSpy).not.toHaveBeenCalled();
+  });
+
+  it('exits with code 1 when GitLab token is missing', async () => {
+    const originalEnv = process.env.GITLAB_TOKEN;
+    // biome-ignore lint/performance/noDelete: must remove env var, not set to "undefined" string
+    delete process.env.GITLAB_TOKEN;
+
+    mockLoadGitHubConfig.mockResolvedValue({
+      ok: false,
+      error: { message: 'not found' },
+    });
+    mockLoadGitLabConfig.mockResolvedValue({
+      ok: true,
+      value: {
+        project: 'group/proj',
+        project_id: 42,
+        base_url: 'https://gitlab.com',
+      },
+    });
+
+    await expect(run('--meta-dir', '/tmp/meta')).rejects.toThrow(
+      'process.exit',
+    );
+    expect(exitSpy).toHaveBeenCalledWith(1);
+
+    process.env.GITLAB_TOKEN = originalEnv;
+  });
+});

--- a/packages/cli/src/__tests__/sync.test.ts
+++ b/packages/cli/src/__tests__/sync.test.ts
@@ -1,0 +1,264 @@
+import { Command } from 'commander';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// --- Mocks ---
+
+const mockLoadGitHubConfig = vi.fn();
+const mockSyncWithGitHub = vi.fn();
+const mockLoadGitLabConfig = vi.fn();
+const mockSyncWithGitLab = vi.fn();
+const mockResolveToken = vi.fn();
+const mockConfirm = vi.fn();
+const mockPromptConflictResolution = vi.fn();
+
+vi.mock('@gitpm/sync-github', () => ({
+  loadConfig: (...args: unknown[]) => mockLoadGitHubConfig(...args),
+  syncWithGitHub: (...args: unknown[]) => mockSyncWithGitHub(...args),
+}));
+
+vi.mock('@gitpm/sync-gitlab', () => ({
+  loadConfig: (...args: unknown[]) => mockLoadGitLabConfig(...args),
+  syncWithGitLab: (...args: unknown[]) => mockSyncWithGitLab(...args),
+}));
+
+vi.mock('../utils/auth.js', () => ({
+  resolveToken: (...args: unknown[]) => mockResolveToken(...args),
+}));
+
+vi.mock('../utils/conflict-ui.js', () => ({
+  promptConflictResolution: (...args: unknown[]) =>
+    mockPromptConflictResolution(...args),
+}));
+
+vi.mock('@inquirer/prompts', () => ({
+  confirm: (...args: unknown[]) => mockConfirm(...args),
+}));
+
+vi.mock('ora', () => ({
+  default: () => ({
+    start: vi.fn().mockReturnThis(),
+    succeed: vi.fn().mockReturnThis(),
+    fail: vi.fn().mockReturnThis(),
+    stop: vi.fn().mockReturnThis(),
+  }),
+}));
+
+let logSpy: ReturnType<typeof vi.spyOn>;
+let errorSpy: ReturnType<typeof vi.spyOn>;
+let exitSpy: ReturnType<typeof vi.spyOn>;
+
+async function run(...args: string[]) {
+  const { syncCommand } = await import('../commands/sync.js');
+  const program = new Command();
+  program.option('--meta-dir <path>', 'Path to .meta directory', '.meta');
+  program.addCommand(syncCommand);
+  await program.parseAsync(['node', 'gitpm', 'sync', ...args]);
+}
+
+const syncResult = {
+  pushed: { milestones: 1, issues: 2 },
+  pulled: { milestones: 0, issues: 3 },
+  conflicts: [],
+  resolved: 0,
+  skipped: 0,
+};
+
+// --- Tests ---
+
+describe('gitpm sync', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.resetAllMocks();
+    logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => {
+      throw new Error('process.exit');
+    }) as never);
+    mockResolveToken.mockResolvedValue('mock-token');
+    mockLoadGitHubConfig.mockResolvedValue({
+      ok: true,
+      value: { repo: 'owner/repo' },
+    });
+    mockLoadGitLabConfig.mockResolvedValue({
+      ok: false,
+      error: { message: 'not found' },
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('prints summary in dry-run mode', async () => {
+    mockSyncWithGitHub.mockResolvedValue({ ok: true, value: syncResult });
+
+    await run('--dry-run', '--meta-dir', '/tmp/meta');
+
+    expect(mockSyncWithGitHub).toHaveBeenCalledWith(
+      expect.objectContaining({ dryRun: true }),
+    );
+    expect(mockConfirm).not.toHaveBeenCalled();
+    expect(exitSpy).not.toHaveBeenCalled();
+    const allOutput = logSpy.mock.calls.map((c) => c.join(' ')).join('\n');
+    expect(allOutput).toContain('Sync Complete');
+  });
+
+  it('syncs when user confirms', async () => {
+    mockSyncWithGitHub.mockResolvedValue({ ok: true, value: syncResult });
+    mockConfirm.mockResolvedValue(true);
+
+    await run('--meta-dir', '/tmp/meta');
+
+    expect(mockConfirm).toHaveBeenCalled();
+    expect(mockSyncWithGitHub).toHaveBeenCalled();
+    expect(exitSpy).not.toHaveBeenCalled();
+  });
+
+  it('cancels sync when user declines', async () => {
+    mockConfirm.mockResolvedValue(false);
+
+    await run('--meta-dir', '/tmp/meta');
+
+    expect(mockSyncWithGitHub).not.toHaveBeenCalled();
+    const allOutput = logSpy.mock.calls.map((c) => c.join(' ')).join('\n');
+    expect(allOutput).toContain('Sync cancelled');
+  });
+
+  it('skips confirmation with --yes', async () => {
+    mockSyncWithGitHub.mockResolvedValue({ ok: true, value: syncResult });
+
+    await run('--yes', '--meta-dir', '/tmp/meta');
+
+    expect(mockConfirm).not.toHaveBeenCalled();
+    expect(mockSyncWithGitHub).toHaveBeenCalled();
+  });
+
+  it('prompts for conflict resolution with ask strategy', async () => {
+    const conflicts = [
+      {
+        entityId: 'e1',
+        entityTitle: 'Story 1',
+        entityType: 'story',
+        field: 'status',
+        localValue: 'in_progress',
+        remoteValue: 'done',
+      },
+    ];
+    mockSyncWithGitHub.mockResolvedValue({
+      ok: true,
+      value: { ...syncResult, conflicts, resolved: 0 },
+    });
+    mockConfirm.mockResolvedValue(true);
+    mockPromptConflictResolution.mockResolvedValue([
+      { entityId: 'e1', field: 'status', pick: 'remote' },
+    ]);
+
+    await run('--strategy', 'ask', '--meta-dir', '/tmp/meta');
+
+    expect(mockPromptConflictResolution).toHaveBeenCalledWith(conflicts);
+  });
+
+  it('does not prompt for conflicts with local-wins', async () => {
+    mockSyncWithGitHub.mockResolvedValue({ ok: true, value: syncResult });
+    mockConfirm.mockResolvedValue(true);
+
+    await run('--strategy', 'local-wins', '--meta-dir', '/tmp/meta');
+
+    expect(mockPromptConflictResolution).not.toHaveBeenCalled();
+    expect(mockSyncWithGitHub).toHaveBeenCalledWith(
+      expect.objectContaining({ strategy: 'local-wins' }),
+    );
+  });
+
+  it('does not prompt for conflicts with remote-wins', async () => {
+    mockSyncWithGitHub.mockResolvedValue({ ok: true, value: syncResult });
+    mockConfirm.mockResolvedValue(true);
+
+    await run('--strategy', 'remote-wins', '--meta-dir', '/tmp/meta');
+
+    expect(mockPromptConflictResolution).not.toHaveBeenCalled();
+    expect(mockSyncWithGitHub).toHaveBeenCalledWith(
+      expect.objectContaining({ strategy: 'remote-wins' }),
+    );
+  });
+
+  it('exits with code 1 when sync fails', async () => {
+    mockSyncWithGitHub.mockResolvedValue({
+      ok: false,
+      error: { message: 'sync failed' },
+    });
+    mockConfirm.mockResolvedValue(true);
+
+    await expect(run('--meta-dir', '/tmp/meta')).rejects.toThrow(
+      'process.exit',
+    );
+    expect(exitSpy).toHaveBeenCalledWith(1);
+  });
+
+  it('exits with code 1 when no sync config found', async () => {
+    mockLoadGitHubConfig.mockResolvedValue({
+      ok: false,
+      error: { message: 'not found' },
+    });
+    mockLoadGitLabConfig.mockResolvedValue({
+      ok: false,
+      error: { message: 'not found' },
+    });
+
+    await expect(run('--meta-dir', '/tmp/meta')).rejects.toThrow(
+      'process.exit',
+    );
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    const errOutput = errorSpy.mock.calls.map((c) => c.join(' ')).join('\n');
+    expect(errOutput).toContain('No sync config found');
+  });
+
+  it('syncs with GitLab in dry-run mode', async () => {
+    mockLoadGitHubConfig.mockResolvedValue({
+      ok: false,
+      error: { message: 'not found' },
+    });
+    mockLoadGitLabConfig.mockResolvedValue({
+      ok: true,
+      value: {
+        project: 'group/proj',
+        project_id: 42,
+        base_url: 'https://gitlab.com',
+      },
+    });
+    mockSyncWithGitLab.mockResolvedValue({ ok: true, value: syncResult });
+
+    await run('--dry-run', '--token', 'gl-tok', '--meta-dir', '/tmp/meta');
+
+    expect(mockSyncWithGitLab).toHaveBeenCalledWith(
+      expect.objectContaining({ dryRun: true, token: 'gl-tok' }),
+    );
+    expect(exitSpy).not.toHaveBeenCalled();
+  });
+
+  it('exits with code 1 when GitLab token is missing', async () => {
+    const originalEnv = process.env.GITLAB_TOKEN;
+    // biome-ignore lint/performance/noDelete: must remove env var, not set to "undefined" string
+    delete process.env.GITLAB_TOKEN;
+
+    mockLoadGitHubConfig.mockResolvedValue({
+      ok: false,
+      error: { message: 'not found' },
+    });
+    mockLoadGitLabConfig.mockResolvedValue({
+      ok: true,
+      value: {
+        project: 'group/proj',
+        project_id: 42,
+        base_url: 'https://gitlab.com',
+      },
+    });
+
+    await expect(run('--meta-dir', '/tmp/meta')).rejects.toThrow(
+      'process.exit',
+    );
+    expect(exitSpy).toHaveBeenCalledWith(1);
+
+    process.env.GITLAB_TOKEN = originalEnv;
+  });
+});

--- a/packages/cli/src/__tests__/validate.test.ts
+++ b/packages/cli/src/__tests__/validate.test.ts
@@ -1,0 +1,178 @@
+import { Command } from 'commander';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// --- Mocks ---
+
+const mockParseTree = vi.fn();
+const mockResolveRefs = vi.fn();
+const mockValidateTree = vi.fn();
+
+vi.mock('@gitpm/core', () => ({
+  parseTree: (...args: unknown[]) => mockParseTree(...args),
+  resolveRefs: (...args: unknown[]) => mockResolveRefs(...args),
+  validateTree: (...args: unknown[]) => mockValidateTree(...args),
+}));
+
+let logSpy: ReturnType<typeof vi.spyOn>;
+let errorSpy: ReturnType<typeof vi.spyOn>;
+let warnSpy: ReturnType<typeof vi.spyOn>;
+let exitSpy: ReturnType<typeof vi.spyOn>;
+
+async function run(...args: string[]) {
+  const { validateCommand } = await import('../commands/validate.js');
+  const program = new Command();
+  program.option('--meta-dir <path>', 'Path to .meta directory', '.meta');
+  program.addCommand(validateCommand);
+  await program.parseAsync(['node', 'gitpm', 'validate', ...args]);
+}
+
+// --- Helpers ---
+
+function makeTree(
+  overrides?: Partial<{
+    stories: unknown[];
+    epics: unknown[];
+    milestones: unknown[];
+    roadmaps: unknown[];
+    prds: unknown[];
+    errors: unknown[];
+  }>,
+) {
+  return {
+    stories: [],
+    epics: [],
+    milestones: [],
+    roadmaps: [],
+    prds: [],
+    errors: [],
+    ...overrides,
+  };
+}
+
+// --- Tests ---
+
+describe('gitpm validate', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.resetAllMocks();
+    logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => {
+      throw new Error('process.exit');
+    }) as never);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('prints success for a valid tree with no warnings', async () => {
+    const tree = makeTree({
+      stories: [{ id: 's1' }, { id: 's2' }],
+      epics: [{ id: 'e1' }],
+    });
+    mockParseTree.mockResolvedValue({ ok: true, value: tree });
+    mockResolveRefs.mockReturnValue({ ok: true, value: { resolved: true } });
+    mockValidateTree.mockReturnValue({ valid: true, errors: [], warnings: [] });
+
+    await run('--meta-dir', '/tmp/test-meta');
+
+    expect(exitSpy).not.toHaveBeenCalled();
+    const allOutput = logSpy.mock.calls.map((c) => c.join(' ')).join('\n');
+    expect(allOutput).toContain('3 entities');
+  });
+
+  it('prints warnings but does not exit for a valid tree with warnings', async () => {
+    const tree = makeTree({ stories: [{ id: 's1' }] });
+    mockParseTree.mockResolvedValue({ ok: true, value: tree });
+    mockResolveRefs.mockReturnValue({ ok: true, value: {} });
+    mockValidateTree.mockReturnValue({
+      valid: true,
+      errors: [],
+      warnings: [
+        {
+          filePath: '/tmp/test.md',
+          entityId: 'w1',
+          code: 'WARN_01',
+          message: 'something fishy',
+        },
+      ],
+    });
+
+    await run('--meta-dir', '/tmp/test-meta');
+
+    expect(exitSpy).not.toHaveBeenCalled();
+    const warnOutput = warnSpy.mock.calls.map((c) => c.join(' ')).join('\n');
+    expect(warnOutput).toContain('1 warning(s)');
+  });
+
+  it('exits with code 1 for an invalid tree', async () => {
+    const tree = makeTree();
+    mockParseTree.mockResolvedValue({ ok: true, value: tree });
+    mockResolveRefs.mockReturnValue({ ok: true, value: {} });
+    mockValidateTree.mockReturnValue({
+      valid: false,
+      errors: [
+        {
+          filePath: '/tmp/bad.md',
+          entityId: 'e1',
+          code: 'ERR_01',
+          message: 'bad entity',
+        },
+      ],
+      warnings: [],
+    });
+
+    await expect(run('--meta-dir', '/tmp/test-meta')).rejects.toThrow(
+      'process.exit',
+    );
+    expect(exitSpy).toHaveBeenCalledWith(1);
+  });
+
+  it('exits with code 1 when parseTree fails', async () => {
+    mockParseTree.mockResolvedValue({
+      ok: false,
+      error: { message: 'cannot read .meta' },
+    });
+
+    await expect(run('--meta-dir', '/tmp/test-meta')).rejects.toThrow(
+      'process.exit',
+    );
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    const errOutput = errorSpy.mock.calls.map((c) => c.join(' ')).join('\n');
+    expect(errOutput).toContain('cannot read .meta');
+  });
+
+  it('exits with code 1 when resolveRefs fails', async () => {
+    const tree = makeTree();
+    mockParseTree.mockResolvedValue({ ok: true, value: tree });
+    mockResolveRefs.mockReturnValue({
+      ok: false,
+      error: { message: 'broken ref' },
+    });
+
+    await expect(run('--meta-dir', '/tmp/test-meta')).rejects.toThrow(
+      'process.exit',
+    );
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    const errOutput = errorSpy.mock.calls.map((c) => c.join(' ')).join('\n');
+    expect(errOutput).toContain('broken ref');
+  });
+
+  it('prints parse errors from the tree', async () => {
+    const tree = makeTree({
+      errors: [
+        { filePath: '/tmp/bad-story.md', message: 'invalid frontmatter' },
+      ],
+    });
+    mockParseTree.mockResolvedValue({ ok: true, value: tree });
+    mockResolveRefs.mockReturnValue({ ok: true, value: {} });
+    mockValidateTree.mockReturnValue({ valid: true, errors: [], warnings: [] });
+
+    await run('--meta-dir', '/tmp/test-meta');
+
+    const allOutput = logSpy.mock.calls.map((c) => c.join(' ')).join('\n');
+    expect(allOutput).toContain('invalid frontmatter');
+  });
+});


### PR DESCRIPTION
## Summary
This PR adds a complete test suite for the gitpm CLI commands, covering all major command flows including initialization, validation, importing, pushing, pulling, and syncing with both GitHub and GitLab.

## Key Changes
- **init.test.ts**: Tests for project initialization, including scaffolding with explicit project names and interactive prompts
- **validate.test.ts**: Tests for metadata validation, covering parse errors, reference resolution, and validation warnings/errors
- **import.test.ts**: Tests for importing from GitHub and GitLab, including token resolution, repository validation, and link strategy configuration
- **push.test.ts**: Tests for pushing changes to remote platforms, including dry-run mode, user confirmation flow, and handling of no-changes scenarios
- **pull.test.ts**: Tests for pulling changes from remote platforms, including conflict resolution strategies and platform detection
- **sync.test.ts**: Tests for bidirectional synchronization, including conflict resolution with multiple strategies (ask, local-wins, remote-wins) and dry-run mode

## Notable Implementation Details
- All tests use comprehensive mocking of external dependencies (@gitpm/sync-github, @gitpm/sync-gitlab, @gitpm/core, etc.)
- Tests verify both success and failure paths, including proper exit codes and error messages
- User interaction flows are tested (confirmation prompts, conflict resolution)
- Platform detection logic is validated (GitHub vs GitLab config loading)
- Token resolution and environment variable handling are tested
- Dry-run mode behavior is verified separately from actual execution
- Tests use spy functions to verify console output and process.exit calls

https://claude.ai/code/session_01RRezmjArBdZf48maYFGjck