### PR TITLE
fix: npm publish prep — files field, CLI rename, OIDC

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,18 +51,18 @@ jobs:
       - name: Publish @gitpm/sync-gitlab
         run: npm publish --provenance --access public
         working-directory: packages/sync-gitlab
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Publish @gitpm/sync-jira
         run: npm publish --provenance --access public
         working-directory: packages/sync-jira
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
-      - name: Publish gitpm (CLI)
+      - name: Publish @gitpm/cli
         run: npm publish --provenance --access public
         working-directory: packages/cli
+
+      - name: Publish @gitpm/ui
+        run: npm publish --provenance --access public
+        working-directory: packages/ui
 
       - name: Generate changelog
         id: changelog

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,10 +1,11 @@
 {
-  "name": "gitpm",
+  "name": "@gitpm/cli",
   "version": "0.1.0",
   "type": "module",
   "bin": {
     "gitpm": "./dist/index.js"
   },
+  "files": ["dist"],
   "scripts": {
     "build": "tsup"
   },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -10,6 +10,7 @@
       "types": "./dist/index.d.ts"
     }
   },
+  "files": ["dist"],
   "scripts": {
     "build": "tsup"
   },

--- a/packages/sync-github/package.json
+++ b/packages/sync-github/package.json
@@ -10,6 +10,7 @@
       "types": "./dist/index.d.ts"
     }
   },
+  "files": ["dist"],
   "scripts": {
     "build": "tsup"
   },

--- a/packages/sync-gitlab/package.json
+++ b/packages/sync-gitlab/package.json
@@ -10,6 +10,7 @@
       "types": "./dist/index.d.ts"
     }
   },
+  "files": ["dist"],
   "scripts": {
     "build": "tsup"
   },

--- a/packages/sync-jira/package.json
+++ b/packages/sync-jira/package.json
@@ -10,6 +10,7 @@
       "types": "./dist/index.d.ts"
     }
   },
+  "files": ["dist"],
   "scripts": {
     "build": "tsup"
   },

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -2,6 +2,7 @@
   "name": "@gitpm/ui",
   "version": "0.1.0",
   "type": "module",
+  "files": ["dist"],
   "scripts": {
     "build": "vite build",
     "dev": "tsx src/dev.ts",


### PR DESCRIPTION
## Summary
- Add `"files": ["dist"]` to all 6 packages so `npm publish` only ships built output (not source, tests, fixtures)
- Rename CLI package from `gitpm` to `@gitpm/cli` — the unscoped name is already taken on npm (v1.7.2)
- Remove stale `NODE_AUTH_TOKEN` env vars from sync-gitlab/sync-jira publish steps (all packages use OIDC via Trusted Publishing now)
- Add `@gitpm/ui` publish step to release workflow

## Test plan
- [x] CI checks pass
- [x] Run `npm pack --dry-run` in each package dir to verify only `dist/` files are included
- [x] Verify `bun install` still resolves workspace deps after CLI rename

https://claude.ai/code/session_01JRuepZu49o1XqHwhjSS4gt