### PR TITLE
Add `next` command to show pickable stories

### DIFF
--- a/packages/cli/src/commands/next.ts
+++ b/packages/cli/src/commands/next.ts
@@ -1,6 +1,6 @@
 import { relative } from 'node:path';
-import { parseTree } from '@gitpm/core';
 import type { Story } from '@gitpm/core';
+import { parseTree } from '@gitpm/core';
 import chalk from 'chalk';
 import { Command } from 'commander';
 import { resolveMetaDir } from '../utils/config.js';

--- a/packages/cli/src/commands/next.ts
+++ b/packages/cli/src/commands/next.ts
@@ -1,0 +1,72 @@
+import { relative } from 'node:path';
+import { parseTree } from '@gitpm/core';
+import type { Story } from '@gitpm/core';
+import chalk from 'chalk';
+import { Command } from 'commander';
+import { resolveMetaDir } from '../utils/config.js';
+import { printError } from '../utils/output.js';
+
+const PRIORITY_ORDER: Record<string, number> = {
+  critical: 0,
+  high: 1,
+  medium: 2,
+  low: 3,
+};
+
+const PICKABLE_STATUSES = new Set(['backlog', 'todo']);
+
+export const nextCommand = new Command('next')
+  .description('Show the next stories ready to be picked up')
+  .option('-n, --count <number>', 'Number of stories to show', '5')
+  .action(async (opts, cmd) => {
+    const metaDir = resolveMetaDir(cmd.optsWithGlobals().metaDir);
+    const count = Number.parseInt(opts.count, 10);
+
+    const parseResult = await parseTree(metaDir);
+    if (!parseResult.ok) {
+      printError(parseResult.error.message);
+      process.exit(1);
+    }
+
+    const stories = parseResult.value.stories
+      .filter((s: Story) => PICKABLE_STATUSES.has(s.status))
+      .sort((a: Story, b: Story) => {
+        const pa = PRIORITY_ORDER[a.priority] ?? 99;
+        const pb = PRIORITY_ORDER[b.priority] ?? 99;
+        if (pa !== pb) return pa - pb;
+        // Within same priority, prefer todo over backlog
+        if (a.status !== b.status) return a.status === 'todo' ? -1 : 1;
+        return 0;
+      })
+      .slice(0, count);
+
+    if (stories.length === 0) {
+      console.log(chalk.yellow('No stories ready to be picked up.'));
+      return;
+    }
+
+    console.log(chalk.bold(`Next ${stories.length} stories to pick up:\n`));
+
+    for (const story of stories) {
+      const file = relative(process.cwd(), story.filePath);
+      const pri = formatPriority(story.priority);
+      const status = chalk.dim(`[${story.status}]`);
+      console.log(`  ${pri} ${status} ${story.title}`);
+      console.log(`    ${chalk.dim(file)}\n`);
+    }
+  });
+
+function formatPriority(p: string): string {
+  switch (p) {
+    case 'critical':
+      return chalk.red('●');
+    case 'high':
+      return chalk.yellow('●');
+    case 'medium':
+      return chalk.blue('●');
+    case 'low':
+      return chalk.dim('●');
+    default:
+      return chalk.dim('○');
+  }
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -5,6 +5,7 @@ import { Command } from 'commander';
 import { archiveCommand } from './commands/archive.js';
 import { importCommand } from './commands/import.js';
 import { initCommand } from './commands/init.js';
+import { nextCommand } from './commands/next.js';
 import { pullCommand } from './commands/pull.js';
 import { pushCommand } from './commands/push.js';
 import { qualityCommand } from './commands/quality.js';
@@ -28,6 +29,7 @@ program
 program.addCommand(initCommand);
 program.addCommand(validateCommand);
 program.addCommand(qualityCommand);
+program.addCommand(nextCommand);
 program.addCommand(importCommand);
 program.addCommand(pushCommand);
 program.addCommand(pullCommand);


### PR DESCRIPTION
## Summary
- Adds `gitpm next` command that lists stories with `backlog` or `todo` status, sorted by priority (critical → high → medium → low), then by status (todo before backlog)
- Defaults to 5 stories; configurable via `-n <count>`
- Shows priority indicator, status, title, and file path for each story

## Test plan
- [x] `gitpm next` returns top 5 pickable stories
- [x] `gitpm next -n 10` returns up to 10 stories
- [x] Empty `.meta/` shows "No stories ready to be picked up"

🤖 Generated with [Claude Code](https://claude.com/claude-code)