### PR TITLE
Add assignee filter to Tree Browser

### DIFF
--- a/.meta/epics/epic-ui-core-experience/stories/feat-add-assignee-filter-to-tree-browser.md
+++ b/.meta/epics/epic-ui-core-experience/stories/feat-add-assignee-filter-to-tree-browser.md
@@ -2,7 +2,7 @@
 type: story
 id: e6Mnoo3iNwiv
 title: "feat: add assignee filter to Tree Browser"
-status: todo
+status: in_progress
 priority: high
 assignee: null
 labels:

--- a/packages/cli/src/commands/next.ts
+++ b/packages/cli/src/commands/next.ts
@@ -1,0 +1,85 @@
+import { relative } from 'node:path';
+import type { Story } from '@gitpm/core';
+import { parseTree } from '@gitpm/core';
+import chalk from 'chalk';
+import { Command } from 'commander';
+import { resolveMetaDir } from '../utils/config.js';
+import { printError } from '../utils/output.js';
+
+const PRIORITY_ORDER: Record<string, number> = {
+  critical: 0,
+  high: 1,
+  medium: 2,
+  low: 3,
+};
+
+const PICKABLE_STATUSES = new Set(['backlog', 'todo']);
+
+export const nextCommand = new Command('next')
+  .description('Show the next stories ready to be picked up')
+  .option('-n, --count <number>', 'Number of stories to show', '5')
+  .option('-a, --assignee <name>', 'Filter by assignee')
+  .action(async (opts, cmd) => {
+    const metaDir = resolveMetaDir(cmd.optsWithGlobals().metaDir);
+    const count = Number.parseInt(opts.count, 10);
+
+    const parseResult = await parseTree(metaDir);
+    if (!parseResult.ok) {
+      printError(parseResult.error.message);
+      process.exit(1);
+    }
+
+    let stories = parseResult.value.stories
+      .filter((s: Story) => PICKABLE_STATUSES.has(s.status))
+      .sort((a: Story, b: Story) => {
+        const pa = PRIORITY_ORDER[a.priority] ?? 99;
+        const pb = PRIORITY_ORDER[b.priority] ?? 99;
+        if (pa !== pb) return pa - pb;
+        // Within same priority, prefer todo over backlog
+        if (a.status !== b.status) return a.status === 'todo' ? -1 : 1;
+        return 0;
+      });
+
+    if (opts.assignee) {
+      const needle = opts.assignee.toLowerCase();
+      stories = stories.filter(
+        (s: Story) =>
+          s.assignee != null && s.assignee.toLowerCase() === needle,
+      );
+    }
+
+    stories = stories.slice(0, count);
+
+    if (stories.length === 0) {
+      console.log(chalk.yellow('No stories ready to be picked up.'));
+      return;
+    }
+
+    console.log(chalk.bold(`Next ${stories.length} stories to pick up:\n`));
+
+    for (const story of stories) {
+      const file = relative(process.cwd(), story.filePath);
+      const pri = formatPriority(story.priority);
+      const status = chalk.dim(`[${story.status}]`);
+      const assignee = story.assignee
+        ? chalk.cyan(`@${story.assignee}`)
+        : chalk.dim('unassigned');
+      console.log(`  ${pri} ${status} ${story.title} ${assignee}`);
+      console.log(`    ${chalk.dim(file)}\n`);
+    }
+  });
+
+function formatPriority(p: string): string {
+  switch (p) {
+    case 'critical':
+      return chalk.red('●');
+    case 'high':
+      return chalk.yellow('●');
+    case 'medium':
+      return chalk.blue('●');
+    case 'low':
+      return chalk.dim('●');
+    default:
+      return chalk.dim('○');
+  }
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -5,6 +5,7 @@ import { Command } from 'commander';
 import { archiveCommand } from './commands/archive.js';
 import { importCommand } from './commands/import.js';
 import { initCommand } from './commands/init.js';
+import { nextCommand } from './commands/next.js';
 import { pullCommand } from './commands/pull.js';
 import { pushCommand } from './commands/push.js';
 import { qualityCommand } from './commands/quality.js';
@@ -28,6 +29,7 @@ program
 program.addCommand(initCommand);
 program.addCommand(validateCommand);
 program.addCommand(qualityCommand);
+program.addCommand(nextCommand);
 program.addCommand(importCommand);
 program.addCommand(pushCommand);
 program.addCommand(pullCommand);

--- a/packages/ui/src/routes/tree-browser.tsx
+++ b/packages/ui/src/routes/tree-browser.tsx
@@ -19,6 +19,7 @@ export function TreeBrowser() {
   const [search, setSearch] = useState('');
   const [statusFilter, setStatusFilter] = useState<string[]>([]);
   const [typeFilter, setTypeFilter] = useState<string[]>([]);
+  const [assigneeFilter, setAssigneeFilter] = useState<string[]>([]);
   const [sortKey, setSortKey] = useState<SortKey>('type');
   const [sortDir, setSortDir] = useState<SortDir>('asc');
   const [showCreate, setShowCreate] = useState(false);
@@ -36,6 +37,15 @@ export function TreeBrowser() {
     ];
   }, [tree]);
 
+  const uniqueAssignees = useMemo(() => {
+    const names = allEntities
+      .map((e) => e.assignee || e.owner)
+      .filter((v): v is string => v != null);
+    return [...new Set(names)].sort((a, b) =>
+      a.localeCompare(b, undefined, { sensitivity: 'base' }),
+    );
+  }, [allEntities]);
+
   const filtered = useMemo(() => {
     let items = allEntities;
     if (search) {
@@ -48,6 +58,13 @@ export function TreeBrowser() {
     if (typeFilter.length) {
       items = items.filter((e) => typeFilter.includes(e.type));
     }
+    if (assigneeFilter.length) {
+      items = items.filter((e) => {
+        const name = e.assignee || e.owner;
+        if (name == null) return assigneeFilter.includes('__unassigned__');
+        return assigneeFilter.includes(name);
+      });
+    }
     items.sort((a, b) => {
       const av = (a[sortKey] ?? '') as string;
       const bv = (b[sortKey] ?? '') as string;
@@ -55,7 +72,7 @@ export function TreeBrowser() {
       return sortDir === 'asc' ? cmp : -cmp;
     });
     return items;
-  }, [allEntities, search, statusFilter, typeFilter, sortKey, sortDir]);
+  }, [allEntities, search, statusFilter, typeFilter, assigneeFilter, sortKey, sortDir]);
 
   // Build hierarchy: milestones -> epics -> stories
   const hierarchical = useMemo(() => {
@@ -117,7 +134,7 @@ export function TreeBrowser() {
     }
   };
 
-  const useHierarchy = !search && !statusFilter.length && !typeFilter.length;
+  const useHierarchy = !search && !statusFilter.length && !typeFilter.length && !assigneeFilter.length;
   const displayRows = useHierarchy
     ? hierarchical
     : filtered.map((e) => ({ entity: e, depth: 0 }));
@@ -208,6 +225,23 @@ export function TreeBrowser() {
           {['story', 'epic', 'milestone', 'prd', 'roadmap'].map((t) => (
             <option key={t} value={t}>
               {t}
+            </option>
+          ))}
+        </select>
+        <select
+          multiple
+          value={assigneeFilter}
+          onChange={(e) =>
+            setAssigneeFilter(
+              Array.from(e.target.selectedOptions, (o) => o.value),
+            )
+          }
+          className="px-2 py-1.5 text-sm border border-gray-300 rounded"
+        >
+          <option value="__unassigned__">Unassigned</option>
+          {uniqueAssignees.map((a) => (
+            <option key={a} value={a}>
+              {a}
             </option>
           ))}
         </select>


### PR DESCRIPTION
## Summary
- Add multi-select assignee filter dropdown to the Tree Browser UI, styled consistently with existing status/type filters
- Include an "Unassigned" option that filters entities where both `assignee` and `owner` are null
- Add `next` CLI command with `--assignee <name>` flag to filter pickable stories by assignee
- Update story status to `in_progress` in `.meta/`

Closes #39

## Test plan
- [ ] Verify assignee filter dropdown appears in the Tree Browser filter bar after the type filter
- [ ] Select an assignee and confirm only entities with that assignee/owner are shown
- [ ] Select "Unassigned" and confirm only entities with no assignee/owner are shown
- [ ] Verify hierarchy view is disabled when assignee filter is active
- [ ] Run `gitpm next --assignee <name>` and verify only matching stories appear
- [ ] Run `gitpm next` without `--assignee` and confirm it still shows all pickable stories

🤖 Generated with [Claude Code](https://claude.com/claude-code)