### PR TITLE
Reconstruct sync state from entity frontmatter on startup

### DIFF
--- a/.meta/epics/epic-sync-reliability/stories/feat-reconstruct-sync-state-from-entity-frontmatter-on-start.md
+++ b/.meta/epics/epic-sync-reliability/stories/feat-reconstruct-sync-state-from-entity-frontmatter-on-start.md
@@ -2,7 +2,7 @@
 type: story
 id: uSwxALv1JDgu
 title: "feat: reconstruct sync state from entity frontmatter on startup"
-status: todo
+status: in_progress
 priority: high
 assignee: null
 labels:

--- a/packages/sync-github/src/__tests__/state.test.ts
+++ b/packages/sync-github/src/__tests__/state.test.ts
@@ -2,11 +2,13 @@ import { mkdtemp, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import type { Epic, Milestone, Story } from '@gitpm/core';
+import { writeFile } from '@gitpm/core';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import {
   computeContentHash,
   createInitialState,
   loadState,
+  reconstructState,
   saveState,
 } from '../state.js';
 
@@ -204,8 +206,232 @@ describe('saveState / loadState', () => {
     }
   });
 
-  it('returns error when state file does not exist', async () => {
-    const result = await loadState(join(tmpDir, 'nonexistent'));
-    expect(result.ok).toBe(false);
+  it('returns empty state when JSON missing and no entities exist', async () => {
+    const emptyDir = await mkdtemp(join(tmpdir(), 'gitpm-empty-'));
+    try {
+      const result = await loadState(emptyDir);
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.value.repo).toBe('');
+        expect(Object.keys(result.value.entities)).toHaveLength(0);
+      }
+    } finally {
+      await rm(emptyDir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('reconstructState', () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await mkdtemp(join(tmpdir(), 'gitpm-reconstruct-'));
+  });
+
+  afterEach(async () => {
+    await rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it('builds correct entries from entity frontmatter', async () => {
+    const story: Story = {
+      type: 'story',
+      id: 'story-abc',
+      title: 'A synced story',
+      status: 'in_progress',
+      priority: 'high',
+      assignee: null,
+      labels: ['bug'],
+      estimate: null,
+      epic_ref: null,
+      github: {
+        issue_number: 42,
+        repo: 'owner/repo',
+        last_sync_hash: 'sha256:aaa111',
+        synced_at: '2026-03-01T00:00:00Z',
+      },
+      body: 'Some body.',
+      created_at: '2026-01-01T00:00:00Z',
+      updated_at: '2026-01-01T00:00:00Z',
+      filePath: join(tmpDir, 'stories', 'story-abc.md'),
+    };
+
+    const epic: Epic = {
+      type: 'epic',
+      id: 'epic-xyz',
+      title: 'A synced epic',
+      status: 'todo',
+      priority: 'medium',
+      owner: null,
+      labels: [],
+      milestone_ref: null,
+      github: {
+        issue_number: 10,
+        project_item_id: 'PVTI_123',
+        repo: 'owner/repo',
+        last_sync_hash: 'sha256:bbb222',
+        synced_at: '2026-03-02T00:00:00Z',
+      },
+      body: 'Epic body.',
+      created_at: '2026-01-01T00:00:00Z',
+      updated_at: '2026-01-01T00:00:00Z',
+      filePath: join(tmpDir, 'epics', 'epic-xyz', 'epic.md'),
+    };
+
+    const milestone: Milestone = {
+      type: 'milestone',
+      id: 'ms-001',
+      title: 'Q3 Release',
+      status: 'in_progress',
+      target_date: '2026-09-30',
+      github: {
+        milestone_id: 5,
+        repo: 'owner/repo',
+        last_sync_hash: 'sha256:ccc333',
+        synced_at: '2026-03-03T00:00:00Z',
+      },
+      body: 'Milestone body.',
+      created_at: '2026-01-01T00:00:00Z',
+      updated_at: '2026-01-01T00:00:00Z',
+      filePath: join(tmpDir, 'roadmap', 'milestones', 'ms-001.md'),
+    };
+
+    await writeFile(story, story.filePath);
+    await writeFile(epic, epic.filePath);
+    await writeFile(milestone, milestone.filePath);
+
+    const result = await reconstructState(tmpDir);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+
+    const state = result.value;
+    expect(state.repo).toBe('owner/repo');
+    expect(Object.keys(state.entities)).toHaveLength(3);
+
+    // Story entry
+    const storyEntry = state.entities['story-abc'];
+    expect(storyEntry).toBeDefined();
+    expect(storyEntry.local_hash).toBe('sha256:aaa111');
+    expect(storyEntry.remote_hash).toBe('sha256:aaa111');
+    expect(storyEntry.github_issue_number).toBe(42);
+    // YAML round-trip may normalize ISO timestamps (e.g. adding .000Z)
+    expect(new Date(storyEntry.synced_at).toISOString()).toBe(
+      new Date('2026-03-01T00:00:00Z').toISOString(),
+    );
+
+    // Epic entry
+    const epicEntry = state.entities['epic-xyz'];
+    expect(epicEntry).toBeDefined();
+    expect(epicEntry.local_hash).toBe('sha256:bbb222');
+    expect(epicEntry.remote_hash).toBe('sha256:bbb222');
+    expect(epicEntry.github_issue_number).toBe(10);
+    expect(epicEntry.github_project_item_id).toBe('PVTI_123');
+
+    // Milestone entry
+    const msEntry = state.entities['ms-001'];
+    expect(msEntry).toBeDefined();
+    expect(msEntry.local_hash).toBe('sha256:ccc333');
+    expect(msEntry.remote_hash).toBe('sha256:ccc333');
+    expect(msEntry.github_milestone_number).toBe(5);
+  });
+
+  it('loadState returns reconstructed state when JSON missing but entities have github metadata', async () => {
+    const story: Story = {
+      type: 'story',
+      id: 'recon-story',
+      title: 'Reconstructed story',
+      status: 'done',
+      priority: 'low',
+      assignee: 'bob',
+      labels: [],
+      estimate: null,
+      epic_ref: null,
+      github: {
+        issue_number: 99,
+        repo: 'test/repo',
+        last_sync_hash: 'sha256:ddd444',
+        synced_at: '2026-04-01T00:00:00Z',
+      },
+      body: 'Body text.',
+      created_at: '2026-01-01T00:00:00Z',
+      updated_at: '2026-01-01T00:00:00Z',
+      filePath: join(tmpDir, 'stories', 'recon-story.md'),
+    };
+
+    await writeFile(story, story.filePath);
+
+    // loadState should reconstruct since github-state.json doesn't exist
+    const result = await loadState(tmpDir);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+
+    expect(result.value.repo).toBe('test/repo');
+    expect(result.value.entities['recon-story']).toBeDefined();
+    expect(result.value.entities['recon-story'].github_issue_number).toBe(99);
+    expect(result.value.entities['recon-story'].local_hash).toBe(
+      'sha256:ddd444',
+    );
+  });
+
+  it('returns empty state when entities have no github metadata', async () => {
+    const story: Story = {
+      type: 'story',
+      id: 'no-gh-story',
+      title: 'No github metadata',
+      status: 'todo',
+      priority: 'medium',
+      assignee: null,
+      labels: [],
+      estimate: null,
+      epic_ref: null,
+      github: null,
+      body: 'Body.',
+      created_at: '2026-01-01T00:00:00Z',
+      updated_at: '2026-01-01T00:00:00Z',
+      filePath: join(tmpDir, 'stories', 'no-gh-story.md'),
+    };
+
+    await writeFile(story, story.filePath);
+
+    const result = await reconstructState(tmpDir);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+
+    expect(result.value.repo).toBe('');
+    expect(Object.keys(result.value.entities)).toHaveLength(0);
+  });
+
+  it('persists reconstructed state as github-state.json', async () => {
+    const story: Story = {
+      type: 'story',
+      id: 'persist-story',
+      title: 'Persisted story',
+      status: 'todo',
+      priority: 'high',
+      assignee: null,
+      labels: [],
+      estimate: null,
+      epic_ref: null,
+      github: {
+        issue_number: 7,
+        repo: 'org/proj',
+        last_sync_hash: 'sha256:eee555',
+        synced_at: '2026-02-01T00:00:00Z',
+      },
+      body: '',
+      created_at: '2026-01-01T00:00:00Z',
+      updated_at: '2026-01-01T00:00:00Z',
+      filePath: join(tmpDir, 'stories', 'persist-story.md'),
+    };
+
+    await writeFile(story, story.filePath);
+    await reconstructState(tmpDir);
+
+    // Second call should load from the persisted JSON file
+    const result = await loadState(tmpDir);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+
+    expect(result.value.repo).toBe('org/proj');
+    expect(result.value.entities['persist-story']).toBeDefined();
   });
 });

--- a/packages/sync-github/src/index.ts
+++ b/packages/sync-github/src/index.ts
@@ -33,6 +33,7 @@ export {
   computeContentHash,
   createInitialState,
   loadState,
+  reconstructState,
   saveState,
 } from './state.js';
 export { syncWithGitHub } from './sync.js';

--- a/packages/sync-github/src/state.ts
+++ b/packages/sync-github/src/state.ts
@@ -1,12 +1,25 @@
 import { createHash } from 'node:crypto';
-import { writeFile as fsWriteFile, mkdir, readFile } from 'node:fs/promises';
+import {
+  access,
+  writeFile as fsWriteFile,
+  mkdir,
+  readFile,
+} from 'node:fs/promises';
 import { dirname, join } from 'node:path';
 import type { ParsedEntity, Result } from '@gitpm/core';
+import { parseTree } from '@gitpm/core';
 import type { SyncState, SyncStateEntry } from './types.js';
 
 export async function loadState(metaDir: string): Promise<Result<SyncState>> {
+  const statePath = join(metaDir, 'sync', 'github-state.json');
   try {
-    const statePath = join(metaDir, 'sync', 'github-state.json');
+    await access(statePath);
+  } catch {
+    // JSON file doesn't exist — try to reconstruct from entity frontmatter
+    return reconstructState(metaDir);
+  }
+
+  try {
     const raw = await readFile(statePath, 'utf-8');
     const state = JSON.parse(raw) as SyncState;
     return { ok: true, value: state };
@@ -16,6 +29,97 @@ export async function loadState(metaDir: string): Promise<Result<SyncState>> {
       error: new Error(`Failed to load sync state: ${err}`),
     };
   }
+}
+
+/**
+ * Reconstruct sync state from entity `github:` frontmatter blocks.
+ * Called when `github-state.json` is missing but entities may already
+ * contain sync metadata from a previous export/import cycle.
+ */
+export async function reconstructState(
+  metaDir: string,
+): Promise<Result<SyncState>> {
+  const treeResult = await parseTree(metaDir);
+  if (!treeResult.ok) {
+    return {
+      ok: false,
+      error: new Error(
+        `Failed to reconstruct sync state: ${treeResult.error.message}`,
+      ),
+    };
+  }
+
+  const tree = treeResult.value;
+  const allEntities: ParsedEntity[] = [
+    ...tree.stories,
+    ...tree.epics,
+    ...tree.milestones,
+    ...tree.prds,
+  ];
+
+  // Find repo from any entity with github metadata
+  let repo = '';
+  for (const entity of allEntities) {
+    if ('github' in entity && entity.github?.repo) {
+      repo = entity.github.repo;
+      break;
+    }
+  }
+
+  // If no entity has github metadata, return an empty state
+  if (!repo) {
+    const emptyState: SyncState = {
+      repo: '',
+      last_sync: new Date().toISOString(),
+      entities: {},
+    };
+    return { ok: true, value: emptyState };
+  }
+
+  const entries: Record<string, SyncStateEntry> = {};
+
+  for (const entity of allEntities) {
+    if (entity.type === 'roadmap') continue;
+
+    const id = 'id' in entity ? (entity as { id: string }).id : '';
+    if (!id) continue;
+
+    const gh = 'github' in entity ? entity.github : undefined;
+    if (!gh) continue;
+
+    const entry: SyncStateEntry = {
+      local_hash: gh.last_sync_hash,
+      remote_hash: gh.last_sync_hash,
+      synced_at: gh.synced_at,
+    };
+
+    if (entity.type === 'milestone' && gh.milestone_id) {
+      entry.github_milestone_number = gh.milestone_id;
+    }
+    if (
+      (entity.type === 'story' || entity.type === 'epic') &&
+      gh.issue_number
+    ) {
+      entry.github_issue_number = gh.issue_number;
+    }
+    if (entity.type !== 'prd' && gh.project_item_id) {
+      entry.github_project_item_id = gh.project_item_id;
+    }
+
+    entries[id] = entry;
+  }
+
+  const now = new Date().toISOString();
+  const state: SyncState = {
+    repo,
+    last_sync: now,
+    entities: entries,
+  };
+
+  // Persist the reconstructed state so future loads are fast
+  await saveState(metaDir, state);
+
+  return { ok: true, value: state };
 }
 
 export async function saveState(


### PR DESCRIPTION
## Summary
- When `github-state.json` is missing (fresh clone, gitignored), `loadState()` now falls back to `reconstructState()` instead of returning an error
- `reconstructState()` walks the `.meta/` tree via `parseTree()`, extracts `github:` frontmatter blocks from all entities, and rebuilds `SyncState` entries using `last_sync_hash` (for both `local_hash` and `remote_hash`) and `synced_at`
- The reconstructed state is automatically persisted to `github-state.json` so subsequent loads are fast
- Adds 5 new tests covering: reconstruction from frontmatter, loadState fallback, empty state when no github metadata, persistence of reconstructed state, and empty directory handling

Closes #36

## Test plan
- [x] `reconstructState` builds correct entries from story/epic/milestone frontmatter
- [x] `loadState` returns reconstructed state when JSON is missing but entities have github metadata
- [x] Returns empty state when entities have no github metadata
- [x] Persists reconstructed state as `github-state.json` for fast subsequent loads
- [x] Returns empty state when directory has no entities at all
- [x] All 368 existing tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)