### PR TITLE
feat(ui): add public GitHub Pages demo deployment

### DIFF
--- a/.github/workflows/deploy-demo.yml
+++ b/.github/workflows/deploy-demo.yml
@@ -1,0 +1,65 @@
+name: Deploy Demo
+
+# Build the UI in demo mode (VITE_DEMO_MODE=1, VITE_BASE=/gitpm/) and publish
+# it to GitHub Pages so we have a public no-auth demo of the gitpm UI.
+#
+# Triggered on UI release tags (release-please publishes these when
+# `packages/ui` bumps) so the demo redeploys exactly when the UI ships. Also
+# supports manual runs via workflow_dispatch for the first setup and for
+# seeding between releases.
+#
+# Setup requirement (one-time, by a maintainer): enable GitHub Pages in repo
+# Settings → Pages → Build and deployment → Source: "GitHub Actions".
+
+on:
+  push:
+    tags:
+      - 'ui-v*'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    name: Build demo site
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install
+
+      - name: Build @gitpm/core
+        run: bun run --filter '@gitpm/core' build
+
+      - name: Build UI demo bundle
+        working-directory: packages/ui
+        run: bun run build:demo
+
+      - uses: actions/configure-pages@v5
+
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: packages/ui/dist
+
+  deploy:
+    name: Deploy to GitHub Pages
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ coverage
 /.claude/settings.local.json
 packages/ui/playwright-report
 packages/ui/test-results
+packages/ui/public-demo/

--- a/biome.json
+++ b/biome.json
@@ -38,7 +38,8 @@
       "!**/dist",
       "!**/coverage",
       "!**/playwright-report",
-      "!**/test-results"
+      "!**/test-results",
+      "!**/public-demo"
     ]
   },
   "overrides": [

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -25,6 +25,7 @@
   ],
   "scripts": {
     "build": "vite build",
+    "build:demo": "tsx scripts/bundle-demo-data.ts && VITE_DEMO_MODE=1 VITE_BASE=/gitpm/ vite build",
     "dev": "tsx src/dev.ts",
     "capture": "tsx scripts/capture.ts",
     "test:e2e": "playwright test",

--- a/packages/ui/scripts/bundle-demo-data.ts
+++ b/packages/ui/scripts/bundle-demo-data.ts
@@ -1,0 +1,90 @@
+#!/usr/bin/env tsx
+/**
+ * Bundles the repo's .meta/ tree into a static JSON payload consumed by the
+ * public GitHub Pages demo build. Uses the same parseTree + resolveRefs
+ * pipeline as packages/ui/src/server/index.ts so the shape is identical to
+ * `GET /api/tree`.
+ */
+import { mkdir, writeFile } from 'node:fs/promises';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { parseTree, resolveRefs } from '@gitpm/core';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(__dirname, '../../..');
+const metaDir = resolve(repoRoot, '.meta');
+const outPath = resolve(__dirname, '../public-demo/demo-data.json');
+
+console.log(`[bundle-demo-data] Parsing ${metaDir}`);
+
+const parseResult = await parseTree(metaDir);
+if (!parseResult.ok) {
+  console.error('[bundle-demo-data] Parse failed:', parseResult.error);
+  process.exit(1);
+}
+
+const resolveResult = resolveRefs(parseResult.value);
+if (!resolveResult.ok) {
+  console.error('[bundle-demo-data] Resolve failed:', resolveResult.error);
+  process.exit(1);
+}
+
+const tree = resolveResult.value;
+
+// Strip absolute filesystem paths so the public JSON doesn't leak CI runner
+// directory layouts. Keep the .meta/-relative portion for debuggability.
+function sanitizePaths<T>(obj: T): T {
+  if (Array.isArray(obj)) return obj.map(sanitizePaths) as unknown as T;
+  if (obj && typeof obj === 'object') {
+    const result: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(obj as Record<string, unknown>)) {
+      if (k === 'filePath' && typeof v === 'string') {
+        const idx = v.indexOf('.meta/');
+        result[k] = idx >= 0 ? v.slice(idx) : v;
+      } else {
+        result[k] = sanitizePaths(v);
+      }
+    }
+    return result as T;
+  }
+  return obj;
+}
+
+const sanitized = sanitizePaths(tree) as typeof tree;
+
+// Drop parse errors entirely. Their messages embed absolute filesystem paths
+// that would leak CI runner internals to the public demo, and the demo UI
+// reports validation as clean via `demoApi.ts` anyway.
+sanitized.errors = [];
+
+const payload = {
+  ...sanitized,
+  counts: {
+    stories: sanitized.stories.length,
+    epics: sanitized.epics.length,
+    milestones: sanitized.milestones.length,
+    roadmaps: sanitized.roadmaps.length,
+    prds: sanitized.prds.length,
+    errors: 0,
+  },
+};
+
+const json = JSON.stringify(payload);
+
+await mkdir(dirname(outPath), { recursive: true });
+await writeFile(outPath, json);
+
+const bytes = json.length;
+const kb = bytes / 1024;
+const mb = kb / 1024;
+
+console.log(
+  `[bundle-demo-data] Wrote ${outPath} (${kb.toFixed(1)} KB, ${payload.counts.stories} stories, ${payload.counts.epics} epics, ${payload.counts.milestones} milestones, ${payload.counts.prds} prds)`,
+);
+
+if (mb > 1) {
+  console.error(
+    `[bundle-demo-data] ERROR: demo-data.json is ${mb.toFixed(2)} MB (> 1 MB limit). Refusing to bundle.`,
+  );
+  process.exit(1);
+}

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -10,6 +10,7 @@ import {
   useRouterState,
 } from '@tanstack/react-router';
 import { useState } from 'react';
+import { DemoBanner } from './components/DemoBanner.js';
 import { Spinner } from './components/Spinner.js';
 import { ToastProvider } from './components/Toast.js';
 import { TypeIcon } from './components/TypeIcon.js';
@@ -24,6 +25,8 @@ import { EntityEditor } from './routes/entity-editor.js';
 import { RoadmapView } from './routes/roadmap.js';
 import { SyncDashboard } from './routes/sync-dashboard.js';
 import { TreeBrowser } from './routes/tree-browser.js';
+
+const DEMO_MODE = import.meta.env.VITE_DEMO_MODE === '1';
 
 const queryClient = new QueryClient({
   defaultOptions: { queries: { staleTime: 5000 } },
@@ -44,7 +47,13 @@ function Sidebar() {
   ];
 
   return (
-    <aside className="w-64 bg-gray-900 text-gray-200 flex flex-col h-screen fixed left-0 top-0">
+    <aside
+      className="w-64 bg-gray-900 text-gray-200 flex flex-col fixed left-0"
+      style={{
+        top: DEMO_MODE ? '2rem' : 0,
+        height: DEMO_MODE ? 'calc(100vh - 2rem)' : '100vh',
+      }}
+    >
       <div className="p-4 border-b border-gray-700">
         <h1 className="text-lg font-bold text-white">GitPM</h1>
         {tree && (
@@ -171,12 +180,14 @@ function TopBar() {
             </span>
           </div>
         )}
-        <Link
-          to="/sync"
-          className="px-2.5 py-1 text-xs bg-gray-100 hover:bg-gray-200 rounded font-medium"
-        >
-          Sync Now
-        </Link>
+        {!DEMO_MODE && (
+          <Link
+            to="/sync"
+            className="px-2.5 py-1 text-xs bg-gray-100 hover:bg-gray-200 rounded font-medium"
+          >
+            Sync Now
+          </Link>
+        )}
       </div>
     </header>
   );
@@ -185,6 +196,7 @@ function TopBar() {
 function Layout() {
   return (
     <div className="min-h-screen">
+      <DemoBanner />
       <Sidebar />
       <div className="ml-64 flex flex-col min-h-screen">
         <TopBar />

--- a/packages/ui/src/components/DemoBanner.tsx
+++ b/packages/ui/src/components/DemoBanner.tsx
@@ -1,0 +1,26 @@
+/**
+ * Persistent strip shown at the top of the app when VITE_DEMO_MODE=1 so that
+ * visitors to the public GitHub Pages demo understand their changes are
+ * sandboxed to their own browser tab and will be lost on refresh.
+ */
+export function DemoBanner() {
+  if (import.meta.env.VITE_DEMO_MODE !== '1') return null;
+
+  return (
+    <div className="h-8 flex items-center justify-center bg-amber-300 text-amber-950 text-xs sm:text-sm px-4 border-b border-amber-500 font-medium">
+      <span className="mr-1">Demo mode</span>
+      <span className="opacity-80 hidden sm:inline">
+        — changes are local to your browser session and reset on refresh.
+      </span>
+      <span className="opacity-80 sm:hidden">— changes reset on refresh.</span>
+      <a
+        href="https://github.com/yevheniidehtiar/gitpm"
+        target="_blank"
+        rel="noopener noreferrer"
+        className="ml-2 underline hover:no-underline"
+      >
+        Source
+      </a>
+    </div>
+  );
+}

--- a/packages/ui/src/lib/api.ts
+++ b/packages/ui/src/lib/api.ts
@@ -1,8 +1,12 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { DEMO_MODE, demoFetch } from './demoApi.js';
 
 const BASE = '/api';
 
 async function fetchJson<T>(url: string, init?: RequestInit): Promise<T> {
+  if (DEMO_MODE) {
+    return demoFetch<T>(url, init);
+  }
   const res = await fetch(`${BASE}${url}`, {
     ...init,
     headers: { 'Content-Type': 'application/json', ...init?.headers },

--- a/packages/ui/src/lib/demoApi.ts
+++ b/packages/ui/src/lib/demoApi.ts
@@ -1,0 +1,207 @@
+/**
+ * In-memory demo API used when VITE_DEMO_MODE=1 (public GitHub Pages demo).
+ *
+ * - Reads come from a single bundled `demo-data.json` file fetched on first
+ *   use and cached in a module-scoped variable.
+ * - Writes mutate that in-memory clone only. No persistence — a page refresh
+ *   re-fetches the JSON and rebuilds the module, wiping any changes.
+ * - Sync routes are rejected with a friendly error so the real server's
+ *   `/api/sync/*` handlers never run.
+ *
+ * This is the "guardrail" for the public demo: because nothing is shared
+ * across visitors and nothing persists, there is no state anyone can destroy.
+ */
+import type {
+  Entity,
+  SyncStatusResponse,
+  TreeResponse,
+  ValidationResponse,
+} from './api.js';
+
+export const DEMO_MODE = import.meta.env.VITE_DEMO_MODE === '1';
+
+let treeState: TreeResponse | null = null;
+let loadPromise: Promise<TreeResponse> | null = null;
+
+async function loadInitial(): Promise<TreeResponse> {
+  if (treeState) return treeState;
+  if (!loadPromise) {
+    const base = import.meta.env.BASE_URL || '/';
+    const url = `${base}demo-data.json`.replace(/\/+/g, '/');
+    loadPromise = fetch(url)
+      .then((res) => {
+        if (!res.ok) {
+          throw new Error(`Failed to load demo data: ${res.status}`);
+        }
+        return res.json() as Promise<TreeResponse>;
+      })
+      .then((data) => {
+        treeState = data;
+        return data;
+      });
+  }
+  return loadPromise;
+}
+
+type EntityListKey = 'stories' | 'epics' | 'milestones' | 'roadmaps' | 'prds';
+const ENTITY_LIST_KEYS: EntityListKey[] = [
+  'stories',
+  'epics',
+  'milestones',
+  'roadmaps',
+  'prds',
+];
+
+function findEntity(
+  tree: TreeResponse,
+  id: string,
+): { list: Entity[]; index: number; entity: Entity } | null {
+  for (const key of ENTITY_LIST_KEYS) {
+    const list = tree[key] as Entity[];
+    const index = list.findIndex((e) => e.id === id);
+    if (index >= 0) {
+      return { list, index, entity: list[index] as Entity };
+    }
+  }
+  return null;
+}
+
+function recalcCounts(tree: TreeResponse): void {
+  tree.counts = {
+    stories: tree.stories.length,
+    epics: tree.epics.length,
+    milestones: tree.milestones.length,
+    roadmaps: tree.roadmaps.length,
+    prds: tree.prds.length,
+    errors: tree.errors.length,
+  };
+}
+
+function typeToListKey(type: string): EntityListKey | null {
+  switch (type) {
+    case 'story':
+      return 'stories';
+    case 'epic':
+      return 'epics';
+    case 'milestone':
+      return 'milestones';
+    case 'roadmap':
+      return 'roadmaps';
+    case 'prd':
+      return 'prds';
+    default:
+      return null;
+  }
+}
+
+function generateId(type: string): string {
+  const ts = Date.now().toString(36);
+  const rand = Math.random().toString(36).slice(2, 6);
+  return `${type}-demo-${ts}${rand}`;
+}
+
+export async function demoFetch<T>(
+  url: string,
+  init?: RequestInit,
+): Promise<T> {
+  const method = (init?.method ?? 'GET').toUpperCase();
+  const body =
+    init?.body && typeof init.body === 'string' ? JSON.parse(init.body) : null;
+
+  const tree = await loadInitial();
+
+  // GET /tree
+  if (method === 'GET' && url === '/tree') {
+    return tree as T;
+  }
+
+  // Entity CRUD
+  if (url === '/entity' && method === 'POST') {
+    const { type, title, ...rest } = (body ?? {}) as {
+      type?: string;
+      title?: string;
+      [key: string]: unknown;
+    };
+    if (!type || !title) {
+      throw new Error('type and title are required');
+    }
+    const listKey = typeToListKey(type);
+    if (!listKey) {
+      throw new Error(`Unknown type: ${type}`);
+    }
+    const now = new Date().toISOString();
+    const newEntity: Entity = {
+      type,
+      id: generateId(type),
+      title,
+      body: typeof rest.body === 'string' ? rest.body : '',
+      filePath: `.meta/${listKey}/demo-${Date.now()}.md`,
+      created_at: now,
+      updated_at: now,
+      status: (rest.status as string) ?? 'backlog',
+      priority: (rest.priority as string) ?? 'medium',
+      labels: (rest.labels as string[]) ?? [],
+      ...(rest as Partial<Entity>),
+    };
+    (tree[listKey] as Entity[]).push(newEntity);
+    recalcCounts(tree);
+    return newEntity as T;
+  }
+
+  const entityIdMatch = url.match(/^\/entity\/(.+)$/);
+  if (entityIdMatch) {
+    const id = decodeURIComponent(entityIdMatch[1] as string);
+    const found = findEntity(tree, id);
+
+    if (method === 'GET') {
+      if (!found) throw new Error('Not found');
+      return found.entity as T;
+    }
+
+    if (method === 'PUT') {
+      if (!found) throw new Error('Not found');
+      const updates = (body ?? {}) as Partial<Entity>;
+      const merged: Entity = {
+        ...found.entity,
+        ...updates,
+        id: found.entity.id,
+        type: found.entity.type,
+        updated_at: new Date().toISOString(),
+      };
+      found.list[found.index] = merged;
+      return merged as T;
+    }
+
+    if (method === 'DELETE') {
+      if (!found) throw new Error('Not found');
+      found.list.splice(found.index, 1);
+      recalcCounts(tree);
+      return undefined as T;
+    }
+  }
+
+  // Validation — always clean in demo mode
+  if (method === 'GET' && url === '/validate') {
+    const response: ValidationResponse = {
+      valid: true,
+      errors: [],
+      warnings: [],
+    };
+    return response as T;
+  }
+
+  // Sync — disabled
+  if (method === 'GET' && url === '/sync/status') {
+    const response: SyncStatusResponse = {
+      configured: false,
+      message: 'Demo mode — GitHub sync is disabled',
+    };
+    return response as T;
+  }
+
+  if (method === 'POST' && url.startsWith('/sync/')) {
+    throw new Error('Sync is disabled in the public demo');
+  }
+
+  throw new Error(`Demo API: unhandled route ${method} ${url}`);
+}

--- a/packages/ui/vite.config.ts
+++ b/packages/ui/vite.config.ts
@@ -2,7 +2,14 @@ import tailwindcss from '@tailwindcss/vite';
 import react from '@vitejs/plugin-react';
 import { defineConfig } from 'vite';
 
+const isDemo = process.env.VITE_DEMO_MODE === '1';
+
 export default defineConfig({
+  base: process.env.VITE_BASE ?? '/',
+  // Use a separate publicDir for the demo build so `public/` stays empty for
+  // npm-published builds and `public-demo/demo-data.json` only affects the
+  // GitHub Pages demo.
+  publicDir: isDemo ? 'public-demo' : 'public',
   plugins: [react(), tailwindcss()],
   resolve: {
     alias: {


### PR DESCRIPTION
Build the UI with VITE_DEMO_MODE=1 on every ui-v* tag and publish to GitHub
Pages. The demo bundles a snapshot of the repo's .meta/ tree as static JSON
and routes every /api/* call through an in-memory mock so each visitor gets
their own sandboxed copy that resets on page refresh — no shared state, so
nothing public visitors can destroy.

https://claude.ai/code/session_01HavrCi3BwsFQMq7ueBsTjD