### PR TITLE
test(ui): add e2e coverage for routes beyond the kanban board

### DIFF
--- a/packages/ui/e2e/entity-editor.spec.ts
+++ b/packages/ui/e2e/entity-editor.spec.ts
@@ -1,0 +1,262 @@
+import type { APIRequestContext, Page } from '@playwright/test';
+import { expect, test } from '@playwright/test';
+
+/**
+ * End-to-end tests for the Entity Editor (routes/entity-editor.tsx).
+ *
+ * Every test creates its own fresh story via the API and deletes it at the
+ * end, so they are independent of each other and of the other spec files.
+ * This is important: entity-editor.spec.ts runs FIRST in the alphabetical
+ * order Playwright uses for serial runs, and any leftover entity here would
+ * show up in the fixture state the later spec files observe.
+ *
+ * The editor is reached at `/#/entity/:id`. Fields displayed depend on the
+ * entity type; we use `story` throughout.
+ */
+
+interface CreatedEntity {
+  id: string;
+  title: string;
+  filePath: string;
+}
+
+async function createStory(
+  request: APIRequestContext,
+  title: string,
+): Promise<CreatedEntity> {
+  const res = await request.post('/api/entity', {
+    data: {
+      type: 'story',
+      title,
+      status: 'todo',
+      priority: 'medium',
+      assignee: 'tester',
+      labels: ['e2e'],
+      body: '# Hello\n\nOriginal body text.',
+    },
+  });
+  expect(res.status(), 'create story succeeded').toBe(201);
+  return (await res.json()) as CreatedEntity;
+}
+
+async function deleteEntity(
+  request: APIRequestContext,
+  id: string,
+): Promise<void> {
+  // Best-effort cleanup: if a test already deleted it via the UI, ignore 404s.
+  const res = await request.delete(`/api/entity/${id}`);
+  if (res.status() !== 204 && res.status() !== 404) {
+    throw new Error(`cleanup delete failed: ${res.status()}`);
+  }
+}
+
+async function openEditor(page: Page, id: string): Promise<void> {
+  await page.goto(`/#/entity/${id}`);
+  // The editor header (type icon + title heading) confirms the entity loaded.
+  await expect(page.getByRole('heading', { level: 2 })).toBeVisible();
+  await expect(page.getByRole('button', { name: 'Save' })).toBeVisible();
+}
+
+test.describe('Entity Editor', () => {
+  test('loads an entity and populates title, status, priority', async ({
+    page,
+    request,
+  }) => {
+    const created = await createStory(request, 'Editor Loads Fields');
+    try {
+      await openEditor(page, created.id);
+
+      // Heading reflects the title.
+      await expect(
+        page.getByRole('heading', { name: 'Editor Loads Fields', level: 2 }),
+      ).toBeVisible();
+
+      // Title <input> is pre-filled with the entity title.
+      const titleInput = page.locator('input[type="text"]').first();
+      await expect(titleInput).toHaveValue('Editor Loads Fields');
+
+      // Status and priority selects are present and match the fixture.
+      const statusSelect = page.locator('main').locator('select').nth(0);
+      await expect(statusSelect).toHaveValue('todo');
+      const prioritySelect = page.locator('main').locator('select').nth(1);
+      await expect(prioritySelect).toHaveValue('medium');
+
+      // Sidebar metadata shows the entity's relative file path.
+      await expect(page.locator('main').getByText(/File: /)).toContainText(
+        /\.md$/,
+      );
+    } finally {
+      await deleteEntity(request, created.id);
+    }
+  });
+
+  test('editing the title and clicking Save persists the change', async ({
+    page,
+    request,
+  }) => {
+    const created = await createStory(request, 'Editor Title Before');
+    try {
+      await openEditor(page, created.id);
+
+      const titleInput = page.locator('input[type="text"]').first();
+      await titleInput.fill('Editor Title After');
+
+      // Wait for the PUT to land before reloading.
+      const putRequest = page.waitForResponse(
+        (res) =>
+          res.url().includes(`/api/entity/${created.id}`) &&
+          res.request().method() === 'PUT' &&
+          res.status() === 200,
+      );
+      await page.getByRole('button', { name: 'Save' }).click();
+      await putRequest;
+
+      // Success toast.
+      await expect(page.getByText('Saved successfully')).toBeVisible();
+
+      // Reload and verify the new title sticks.
+      await page.reload();
+      await expect(
+        page.getByRole('heading', { name: 'Editor Title After', level: 2 }),
+      ).toBeVisible();
+    } finally {
+      await deleteEntity(request, created.id);
+    }
+  });
+
+  test('adding a label via Enter and removing it via the x button', async ({
+    page,
+    request,
+  }) => {
+    const created = await createStory(request, 'Editor Labels');
+    try {
+      await openEditor(page, created.id);
+
+      // Add a new label via the "Add label..." input + Enter.
+      const labelInput = page.getByPlaceholder('Add label...');
+      await labelInput.fill('playwright-label');
+      await labelInput.press('Enter');
+
+      const labelChip = page
+        .locator('main')
+        .locator('span.inline-flex', { hasText: 'playwright-label' });
+      await expect(labelChip).toBeVisible();
+
+      // Save and confirm the label is persisted via reload.
+      const putRequest = page.waitForResponse(
+        (res) =>
+          res.url().includes(`/api/entity/${created.id}`) &&
+          res.request().method() === 'PUT' &&
+          res.status() === 200,
+      );
+      await page.getByRole('button', { name: 'Save' }).click();
+      await putRequest;
+
+      await page.reload();
+      await expect(labelChip).toBeVisible();
+
+      // Remove the label by clicking its adjacent "x" button.
+      await labelChip.getByRole('button', { name: 'x' }).click();
+      await expect(labelChip).toHaveCount(0);
+    } finally {
+      await deleteEntity(request, created.id);
+    }
+  });
+
+  test('toggling Preview renders the markdown body', async ({
+    page,
+    request,
+  }) => {
+    const created = await createStory(request, 'Editor Preview');
+    try {
+      await openEditor(page, created.id);
+
+      // Replace the body with a known markdown snippet.
+      const bodyTextarea = page.locator('textarea');
+      await bodyTextarea.fill('# Heading one\n\n**Bold text** in a paragraph.');
+
+      // Switch to preview mode.
+      await page.getByRole('button', { name: 'Preview' }).click();
+
+      const preview = page.locator('.markdown-preview');
+      await expect(preview).toBeVisible();
+      await expect(preview.locator('h1')).toHaveText('Heading one');
+      await expect(preview.locator('strong')).toHaveText('Bold text');
+    } finally {
+      await deleteEntity(request, created.id);
+    }
+  });
+
+  test('Delete opens a confirm dialog that can be cancelled', async ({
+    page,
+    request,
+  }) => {
+    const created = await createStory(request, 'Editor Cancel Delete');
+    try {
+      await openEditor(page, created.id);
+
+      // Click Delete → confirm dialog appears with the entity title.
+      await page.getByRole('button', { name: 'Delete' }).click();
+      const dialog = page
+        .locator('.fixed.inset-0 >> text=Delete Entity')
+        .first();
+      await expect(dialog).toBeVisible();
+      await expect(
+        page.locator('.fixed.inset-0 p.text-sm.text-gray-600'),
+      ).toContainText('Editor Cancel Delete');
+
+      // Cancel dismisses the dialog; the entity still exists.
+      await page.getByRole('button', { name: 'Cancel' }).click();
+      await expect(dialog).toHaveCount(0);
+
+      // Page still shows the same entity after cancel.
+      await expect(
+        page.getByRole('heading', { name: 'Editor Cancel Delete', level: 2 }),
+      ).toBeVisible();
+
+      // Confirm via API that the entity still exists.
+      const getRes = await request.get(`/api/entity/${created.id}`);
+      expect(getRes.status()).toBe(200);
+    } finally {
+      await deleteEntity(request, created.id);
+    }
+  });
+
+  test('confirming Delete removes the entity and navigates to tree browser', async ({
+    page,
+    request,
+  }) => {
+    const created = await createStory(request, 'Editor Confirm Delete');
+    let alreadyDeleted = false;
+    try {
+      await openEditor(page, created.id);
+
+      await page.getByRole('button', { name: 'Delete' }).click();
+      // The dialog's confirm button is labelled "Delete" (same as the header
+      // button). Select it by scoping to the dialog root.
+      const deleteRequest = page.waitForResponse(
+        (res) =>
+          res.url().includes(`/api/entity/${created.id}`) &&
+          res.request().method() === 'DELETE' &&
+          res.status() === 204,
+      );
+      await page
+        .locator('.fixed.inset-0')
+        .getByRole('button', { name: 'Delete', exact: true })
+        .click();
+      await deleteRequest;
+      alreadyDeleted = true;
+
+      // Navigation lands on the tree browser (index route).
+      await expect(page).toHaveURL(/#\/$/);
+
+      // Entity no longer fetchable.
+      const getRes = await request.get(`/api/entity/${created.id}`);
+      expect(getRes.status()).toBe(404);
+    } finally {
+      if (!alreadyDeleted) {
+        await deleteEntity(request, created.id);
+      }
+    }
+  });
+});

--- a/packages/ui/e2e/navigation.spec.ts
+++ b/packages/ui/e2e/navigation.spec.ts
@@ -1,0 +1,91 @@
+import { expect, test } from '@playwright/test';
+
+/**
+ * End-to-end tests for the global layout in App.tsx — the fixed sidebar with
+ * primary navigation links and the top bar with breadcrumbs.
+ *
+ * The kanban spec runs earlier (alphabetical order) and mutates story-1-todo,
+ * but the assertions here are route- and count-based, not status-based.
+ */
+
+test.describe('Global layout', () => {
+  test('sidebar lists all primary navigation links', async ({ page }) => {
+    await page.goto('/#/');
+
+    const sidebar = page.locator('aside');
+    for (const label of [
+      'Tree Browser',
+      'Board',
+      'Roadmap',
+      'Sync Dashboard',
+    ]) {
+      await expect(
+        sidebar.getByRole('link', { name: new RegExp(label) }),
+      ).toBeVisible();
+    }
+  });
+
+  test('sidebar shows entity counts in the "s / e / m" format', async ({
+    page,
+  }) => {
+    await page.goto('/#/');
+    // The format is `<stories>s / <epics>e / <milestones>m`. Values depend on
+    // how many entities exist at the time this test runs (earlier mutations
+    // can bump the stories count), so the assertion is format-only.
+    await expect(page.locator('aside').locator('p.text-xs').first()).toHaveText(
+      /^\d+s \/ \d+e \/ \d+m$/,
+    );
+  });
+
+  test('clicking sidebar navigation updates route and breadcrumbs', async ({
+    page,
+  }) => {
+    await page.goto('/#/');
+    const sidebar = page.locator('aside');
+
+    // Tree Browser → Board
+    await sidebar.getByRole('link', { name: /Board/ }).click();
+    await expect(page).toHaveURL(/#\/board$/);
+    await expect(page.getByTestId('kanban-board')).toBeVisible();
+    await expect(
+      page.locator('header').getByRole('link', { name: 'Board' }),
+    ).toBeVisible();
+
+    // Board → Roadmap
+    await sidebar.getByRole('link', { name: /Roadmap/ }).click();
+    await expect(page).toHaveURL(/#\/roadmap$/);
+    await expect(
+      page.getByRole('heading', { name: 'Roadmap Timeline' }),
+    ).toBeVisible();
+    await expect(
+      page.locator('header').getByRole('link', { name: 'Roadmap' }),
+    ).toBeVisible();
+
+    // Roadmap → Sync
+    await sidebar.getByRole('link', { name: /Sync Dashboard/ }).click();
+    await expect(page).toHaveURL(/#\/sync$/);
+    // The breadcrumb "Sync" link collides with the top-bar "Sync Now" pill
+    // that also matches `{ name: 'Sync' }`, so match exactly.
+    await expect(
+      page.locator('header').getByRole('link', { name: 'Sync', exact: true }),
+    ).toBeVisible();
+
+    // Sync → Tree Browser (index)
+    await sidebar.getByRole('link', { name: /Tree Browser/ }).click();
+    await expect(page).toHaveURL(/#\/$/);
+    await expect(
+      page.locator('header').getByRole('link', { name: 'Tree' }),
+    ).toBeVisible();
+  });
+
+  test('validate button shows a result after clicking', async ({ page }) => {
+    await page.goto('/#/');
+    const validateButton = page.getByRole('button', { name: /Validate/ });
+    await validateButton.click();
+
+    // The result paragraph is the only one rendered with `text-center` in
+    // the sidebar — either "All valid" (ok) or "N error(s)" (zod errors).
+    const result = page.locator('aside p.text-center');
+    await expect(result).toHaveText(/All valid|error\(s\)/);
+  });
+});

--- a/packages/ui/e2e/roadmap.spec.ts
+++ b/packages/ui/e2e/roadmap.spec.ts
@@ -1,0 +1,67 @@
+import { expect, test } from '@playwright/test';
+
+/**
+ * End-to-end tests for the Roadmap view (routes/roadmap.tsx).
+ *
+ * The roadmap renders a single SVG timeline with a diamond marker per
+ * milestone and a horizontal bar per linked epic. Only milestones with a
+ * populated `target_date` field are rendered.
+ *
+ * Fixture milestones (see e2e/fixtures/.meta/roadmap/milestones/v1.md):
+ *   e2e-milestone-v1  target_date=2026-06-30  linked: epic-alpha, epic-beta
+ */
+
+const ROADMAP_PATH = '/#/roadmap';
+
+test.describe('Roadmap timeline', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto(ROADMAP_PATH);
+    await expect(
+      page.getByRole('heading', { name: 'Roadmap Timeline' }),
+    ).toBeVisible();
+  });
+
+  test('renders the timeline SVG with month markers', async ({ page }) => {
+    const svg = page.getByRole('img', { name: 'Roadmap Timeline' });
+    await expect(svg).toBeVisible();
+
+    // At least a handful of month grid lines (the component pads minDate /
+    // maxDate by one month, so at minimum 3 month labels appear).
+    const monthLabels = svg.locator('text[fill="#6b7280"]');
+    expect(await monthLabels.count()).toBeGreaterThan(2);
+  });
+
+  test('renders the fixture milestone title in the SVG', async ({ page }) => {
+    const svg = page.getByRole('img', { name: 'Roadmap Timeline' });
+    // Milestone titles are rendered as <text> elements with the dark heading
+    // color. Match by text content.
+    await expect(
+      svg.locator('text', { hasText: 'v1.0 Fixture Milestone' }),
+    ).toBeVisible();
+  });
+
+  test('renders a bar for each epic linked to a milestone', async ({
+    page,
+  }) => {
+    const svg = page.getByRole('img', { name: 'Roadmap Timeline' });
+    // Epic labels are truncated at 18 chars + "..." — the fixture epic names
+    // are 10 characters ("Epic Alpha"/"Epic Beta") and fit without truncation.
+    await expect(svg.locator('text', { hasText: /Epic Alpha/ })).toBeVisible();
+    await expect(svg.locator('text', { hasText: /Epic Beta/ })).toBeVisible();
+  });
+
+  test('renders the status color legend', async ({ page }) => {
+    // The legend below the SVG renders a StatusBadge for every status color.
+    // The Badge renders labels "Backlog", "Todo", etc.
+    const legend = page.locator('main').locator('.flex.items-center.gap-4');
+    for (const label of [
+      'Backlog',
+      'Todo',
+      'In Progress',
+      'In Review',
+      'Done',
+    ]) {
+      await expect(legend.getByText(label, { exact: true })).toBeVisible();
+    }
+  });
+});

--- a/packages/ui/e2e/sync-dashboard.spec.ts
+++ b/packages/ui/e2e/sync-dashboard.spec.ts
@@ -1,0 +1,55 @@
+import { expect, test } from '@playwright/test';
+
+/**
+ * End-to-end tests for the Sync Dashboard (routes/sync-dashboard.tsx).
+ *
+ * The fixture does NOT ship a `.meta/sync/github-config.yaml`, so
+ * `/api/sync/status` returns `{ configured: false }` and the dashboard falls
+ * back to the "no GitHub sync configured" empty state. Wiring up a real
+ * configured state would require mocking `loadConfig`, which is out of scope
+ * for a UI-level e2e test.
+ */
+
+const SYNC_PATH = '/#/sync';
+
+test.describe('Sync Dashboard', () => {
+  test('shows the not-configured empty state when no sync config exists', async ({
+    page,
+  }) => {
+    await page.goto(SYNC_PATH);
+
+    // The empty-state message from routes/sync-dashboard.tsx.
+    await expect(page.getByText(/No GitHub sync configured/i)).toBeVisible();
+
+    // Push / Pull / Full Sync buttons should NOT be rendered in the empty
+    // state — they only appear after sync is configured.
+    await expect(
+      page.getByRole('button', { name: 'Push', exact: true }),
+    ).toHaveCount(0);
+    await expect(
+      page.getByRole('button', { name: 'Pull', exact: true }),
+    ).toHaveCount(0);
+    await expect(
+      page.getByRole('button', { name: 'Full Sync', exact: true }),
+    ).toHaveCount(0);
+  });
+
+  test('top bar renders "Sync Now" link but hides the sync indicator', async ({
+    page,
+  }) => {
+    await page.goto('/#/');
+
+    // The "Sync Now" pill renders whenever the app is not in demo mode.
+    const syncNow = page.getByRole('link', { name: 'Sync Now' });
+    await expect(syncNow).toBeVisible();
+
+    // The "Synced X ago" indicator only renders when syncStatus.configured is
+    // true, so it should be absent in the fixture.
+    await expect(page.getByText(/^Synced \d/)).toHaveCount(0);
+    await expect(page.getByText('Not synced')).toHaveCount(0);
+
+    // Clicking "Sync Now" navigates to the sync route.
+    await syncNow.click();
+    await expect(page).toHaveURL(/#\/sync$/);
+  });
+});

--- a/packages/ui/e2e/tree-browser.spec.ts
+++ b/packages/ui/e2e/tree-browser.spec.ts
@@ -1,0 +1,185 @@
+import { expect, test } from '@playwright/test';
+
+/**
+ * End-to-end tests for the Tree Browser (routes/tree-browser.tsx).
+ *
+ * Runs against the same fixture tree as kanban.spec.ts. The tree browser is
+ * the app index route, accessible at `/#/`.
+ *
+ * Important ordering note: Playwright runs spec files alphabetically with
+ * `workers: 1` and `fullyParallel: false`. This file runs AFTER kanban.spec.ts,
+ * which mutates story-1-todo's status (todo → in_progress). These tests
+ * therefore avoid asserting on story-1-todo's status column.
+ *
+ * Creation is the last test in this file and bumps the stories count by one.
+ * No spec file runs after tree-browser.spec.ts alphabetically, so the mutation
+ * has no downstream effect.
+ */
+
+const INDEX_PATH = '/#/';
+
+test.describe('Tree Browser', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto(INDEX_PATH);
+    // Wait for the table to render (tree loaded).
+    await expect(page.getByRole('table')).toBeVisible();
+  });
+
+  // The sidebar renders its own <Link> for every entity, so bare role-based
+  // lookups like `getByRole('link', { name: 'Epic Alpha' })` are ambiguous.
+  // Scope entity-link assertions to the main content area.
+  function tableLink(
+    page: import('@playwright/test').Page,
+    name: string | RegExp,
+  ) {
+    return page
+      .locator('main')
+      .getByRole('link', { name, exact: typeof name === 'string' });
+  }
+
+  test('sidebar shows GitPM brand and entity counts', async ({ page }) => {
+    await expect(
+      page.getByRole('heading', { name: 'GitPM', level: 1 }),
+    ).toBeVisible();
+    // Counts format: `<stories>s / <epics>e / <milestones>m`.
+    // Fixture has 6 stories, 2 epics, 1 milestone. Tree-browser is the LAST
+    // spec file (alphabetically) so earlier tests haven't added entities yet
+    // when this assertion runs in the beforeEach-refreshed page. But the
+    // create test in this file runs last, so keep the assertion loose.
+    const counts = page.locator('aside p.text-xs').first();
+    await expect(counts).toContainText(/\d+s \/ \d+e \/ \d+m/);
+  });
+
+  test('hierarchical view renders milestones, epics, and orphan stories', async ({
+    page,
+  }) => {
+    // Default view (no filters) is hierarchical. The current hierarchical
+    // composition (see tree-browser.tsx) emits:
+    //   - every milestone and its linked epics
+    //   - orphan epics (no milestone_ref) and their resolvedStories
+    //   - orphan stories (no epic_ref)
+    //   - prds + roadmaps
+    // Fixture epics are all linked to a milestone, so the top-level story
+    // rows only include story-6-orphan and the roadmap/milestone rows.
+    const rows = page.locator('main table tbody tr');
+    await expect(rows).not.toHaveCount(0);
+
+    // Milestone, both epics, and the roadmap are present.
+    await expect(tableLink(page, 'v1.0 Fixture Milestone')).toBeVisible();
+    await expect(tableLink(page, 'Epic Alpha')).toBeVisible();
+    await expect(tableLink(page, 'Epic Beta')).toBeVisible();
+    await expect(tableLink(page, 'E2E Fixture Roadmap')).toBeVisible();
+
+    // The orphan story is the only story that renders in hierarchical mode.
+    await expect(tableLink(page, /Story 6 — Orphan Alice/)).toBeVisible();
+  });
+
+  test('search filter narrows rows to matching titles', async ({ page }) => {
+    const search = page.getByPlaceholder('Search entities...');
+    await search.fill('orphan');
+
+    // Only story-6-orphan matches.
+    await expect(tableLink(page, /Story 6 — Orphan Alice/)).toBeVisible();
+    await expect(tableLink(page, 'Epic Alpha')).toHaveCount(0);
+    await expect(tableLink(page, 'v1.0 Fixture Milestone')).toHaveCount(0);
+
+    // Clearing the search restores the full hierarchical view.
+    await search.fill('');
+    await expect(tableLink(page, 'Epic Alpha')).toBeVisible();
+  });
+
+  test('type filter narrows rows to the selected entity type', async ({
+    page,
+  }) => {
+    // The type filter is the second <select> in the filter bar. The first
+    // select is the status filter. Select only `milestone`.
+    const typeSelect = page.locator('select[multiple]').nth(1);
+    await typeSelect.selectOption(['milestone']);
+
+    // Only the milestone row should remain.
+    await expect(tableLink(page, 'v1.0 Fixture Milestone')).toBeVisible();
+    await expect(tableLink(page, 'Epic Alpha')).toHaveCount(0);
+    await expect(tableLink(page, /Story 6 — Orphan Alice/)).toHaveCount(0);
+
+    // Switch to epics-only filter.
+    await typeSelect.selectOption(['epic']);
+    await expect(tableLink(page, 'Epic Alpha')).toBeVisible();
+    await expect(tableLink(page, 'Epic Beta')).toBeVisible();
+    await expect(tableLink(page, 'v1.0 Fixture Milestone')).toHaveCount(0);
+  });
+
+  test('status filter narrows rows to the selected statuses', async ({
+    page,
+  }) => {
+    // Filter by `backlog`. Only story-4-backlog has this status (epics and
+    // milestones in the fixture use in_progress/todo, not backlog).
+    const statusSelect = page.locator('select[multiple]').first();
+    await statusSelect.selectOption(['backlog']);
+
+    await expect(tableLink(page, /Story 4 — Backlog Carol/)).toBeVisible();
+    // Other stories/epics should be hidden.
+    await expect(tableLink(page, /Story 6 — Orphan Alice/)).toHaveCount(0);
+    await expect(tableLink(page, 'Epic Alpha')).toHaveCount(0);
+  });
+
+  test('sorting by title toggles ascending and descending', async ({
+    page,
+  }) => {
+    // Enter a filter that produces a flat list so the sort is observable.
+    // Type=story gives us 6 titled rows, sorted by `type` then toggled to
+    // `title` below.
+    const typeSelect = page.locator('select[multiple]').nth(1);
+    await typeSelect.selectOption(['story']);
+
+    const titleHeader = page
+      .locator('main')
+      .getByRole('columnheader', { name: /^Title/ });
+    await titleHeader.click(); // set sort key to 'title' (asc)
+
+    const firstTitle = page
+      .locator('main table tbody tr')
+      .first()
+      .getByRole('link');
+    // Story-1-todo may have been renamed/mutated by entity-editor.spec.ts
+    // (which runs earlier in alphabetical order), so allow any leading story.
+    await expect(firstTitle).toHaveText(/^Story/);
+
+    await titleHeader.click(); // toggle to desc
+    await expect(firstTitle).toHaveText(/Story 6/);
+  });
+
+  test('clicking an entity title navigates to the entity editor', async ({
+    page,
+  }) => {
+    await tableLink(page, 'Epic Alpha').click();
+    await expect(page).toHaveURL(/#\/entity\/epic-alpha$/);
+  });
+
+  test('create form adds a new story and it appears in the table', async ({
+    page,
+  }) => {
+    await page.getByRole('button', { name: '+ New Entity' }).click();
+
+    const uniqueTitle = `E2E Tree Create ${Date.now()}`;
+    // Type defaults to "story", title is the visible text input inside the
+    // create form panel.
+    await page.getByPlaceholder('Entity title...').fill(uniqueTitle);
+
+    // Wait for the POST /api/entity to land so we know the file was written
+    // and the tree refetch has data before we assert.
+    const createRequest = page.waitForResponse(
+      (res) =>
+        res.url().includes('/api/entity') &&
+        res.request().method() === 'POST' &&
+        res.status() === 201,
+    );
+    await page.getByRole('button', { name: 'Create', exact: true }).click();
+    await createRequest;
+
+    // Success toast confirms the mutation.
+    await expect(page.getByText(/Created story:/)).toBeVisible();
+
+    // The newly created story appears in the table.
+    await expect(tableLink(page, uniqueTitle)).toBeVisible();
+  });
+});


### PR DESCRIPTION
Extend Playwright coverage from kanban-only to the full set of UI routes
introduced on master. Five new spec files exercise the tree browser,
roadmap timeline, entity editor, sync dashboard, and global layout against
the existing fixture tree and dev server.

- tree-browser.spec.ts — hierarchical view, search/status/type filters,
  title sort toggle, create-entity form (POST /api/entity), navigation to
  the entity editor.
- roadmap.spec.ts — SVG timeline markers, milestone/epic labels, status
  legend.
- entity-editor.spec.ts — per-test story scaffolded via the API, field
  load, title save roundtrip, label add + persist + remove, markdown
  preview toggle, delete confirm dialog (cancel and confirm paths).
- sync-dashboard.spec.ts — not-configured empty state, top-bar "Sync Now"
  pill navigation.
- navigation.spec.ts — sidebar links, entity counts format, breadcrumbs
  across routes, validate button result.

Alphabetical ordering matters: entity-editor runs first and isolates its
mutations via create/delete pairs; kanban still mutates story-1-todo, so
downstream specs avoid asserting on that story's status.