### PR TITLE
Add assignee filter to Tree Browser and next CLI command

### DIFF
--- a/.meta/epics/epic-ui-core-experience/stories/feat-add-assignee-filter-to-tree-browser.md
+++ b/.meta/epics/epic-ui-core-experience/stories/feat-add-assignee-filter-to-tree-browser.md
@@ -2,7 +2,7 @@
 type: story
 id: e6Mnoo3iNwiv
 title: "feat: add assignee filter to Tree Browser"
-status: todo
+status: in_progress
 priority: high
 assignee: null
 labels:

--- a/packages/cli/src/commands/next.ts
+++ b/packages/cli/src/commands/next.ts
@@ -18,6 +18,7 @@ const PICKABLE_STATUSES = new Set(['backlog', 'todo']);
 export const nextCommand = new Command('next')
   .description('Show the next stories ready to be picked up')
   .option('-n, --count <number>', 'Number of stories to show', '5')
+  .option('-a, --assignee <name>', 'Filter by assignee')
   .action(async (opts, cmd) => {
     const metaDir = resolveMetaDir(cmd.optsWithGlobals().metaDir);
     const count = Number.parseInt(opts.count, 10);
@@ -28,7 +29,7 @@ export const nextCommand = new Command('next')
       process.exit(1);
     }
 
-    const stories = parseResult.value.stories
+    let stories = parseResult.value.stories
       .filter((s: Story) => PICKABLE_STATUSES.has(s.status))
       .sort((a: Story, b: Story) => {
         const pa = PRIORITY_ORDER[a.priority] ?? 99;
@@ -37,8 +38,16 @@ export const nextCommand = new Command('next')
         // Within same priority, prefer todo over backlog
         if (a.status !== b.status) return a.status === 'todo' ? -1 : 1;
         return 0;
-      })
-      .slice(0, count);
+      });
+
+    if (opts.assignee) {
+      const needle = opts.assignee.toLowerCase();
+      stories = stories.filter(
+        (s: Story) => s.assignee != null && s.assignee.toLowerCase() === needle,
+      );
+    }
+
+    stories = stories.slice(0, count);
 
     if (stories.length === 0) {
       console.log(chalk.yellow('No stories ready to be picked up.'));
@@ -51,7 +60,10 @@ export const nextCommand = new Command('next')
       const file = relative(process.cwd(), story.filePath);
       const pri = formatPriority(story.priority);
       const status = chalk.dim(`[${story.status}]`);
-      console.log(`  ${pri} ${status} ${story.title}`);
+      const assignee = story.assignee
+        ? chalk.cyan(`@${story.assignee}`)
+        : chalk.dim('unassigned');
+      console.log(`  ${pri} ${status} ${story.title} ${assignee}`);
       console.log(`    ${chalk.dim(file)}\n`);
     }
   });

--- a/packages/ui/e2e/tree-browser.spec.ts
+++ b/packages/ui/e2e/tree-browser.spec.ts
@@ -122,6 +122,61 @@ test.describe('Tree Browser', () => {
     await expect(tableLink(page, 'Epic Alpha')).toHaveCount(0);
   });
 
+  test('assignee filter dropdown lists fixture assignees plus Unassigned', async ({
+    page,
+  }) => {
+    // The assignee filter is the third <select multiple>, after status and
+    // type. It derives options from the union of `assignee`/`owner` fields
+    // across all entities in the tree.
+    const assigneeSelect = page.locator('select[multiple]').nth(2);
+
+    // Fixture assignees: alice (stories 1/3/6 + epic-alpha owner),
+    // bob (stories 2/5 + epic-beta owner), carol (story 4). Milestone and
+    // roadmap have no assignee/owner, so "Unassigned" must be present too.
+    const optionValues = await assigneeSelect
+      .locator('option')
+      .evaluateAll((opts) => opts.map((o) => (o as HTMLOptionElement).value));
+
+    expect(optionValues).toContain('__unassigned__');
+    expect(optionValues).toContain('alice');
+    expect(optionValues).toContain('bob');
+    expect(optionValues).toContain('carol');
+  });
+
+  test('assignee filter narrows rows to stories/epics owned by that person', async ({
+    page,
+  }) => {
+    const assigneeSelect = page.locator('select[multiple]').nth(2);
+    await assigneeSelect.selectOption(['carol']);
+
+    // Only carol's story should be visible.
+    await expect(tableLink(page, /Story 4 — Backlog Carol/)).toBeVisible();
+
+    // Other assignees' entities must be filtered out.
+    await expect(tableLink(page, /Story 2 — In Progress Bob/)).toHaveCount(0);
+    await expect(tableLink(page, /Story 6 — Orphan Alice/)).toHaveCount(0);
+    await expect(tableLink(page, 'Epic Alpha')).toHaveCount(0);
+    await expect(tableLink(page, 'Epic Beta')).toHaveCount(0);
+    await expect(tableLink(page, 'v1.0 Fixture Milestone')).toHaveCount(0);
+  });
+
+  test('assignee filter Unassigned option shows only entities without owner', async ({
+    page,
+  }) => {
+    const assigneeSelect = page.locator('select[multiple]').nth(2);
+    await assigneeSelect.selectOption(['__unassigned__']);
+
+    // Milestone and roadmap in the fixture have no assignee/owner.
+    await expect(tableLink(page, 'v1.0 Fixture Milestone')).toBeVisible();
+    await expect(tableLink(page, 'E2E Fixture Roadmap')).toBeVisible();
+
+    // Stories and epics all have assignees/owners and must be filtered out.
+    await expect(tableLink(page, /Story 6 — Orphan Alice/)).toHaveCount(0);
+    await expect(tableLink(page, /Story 4 — Backlog Carol/)).toHaveCount(0);
+    await expect(tableLink(page, 'Epic Alpha')).toHaveCount(0);
+    await expect(tableLink(page, 'Epic Beta')).toHaveCount(0);
+  });
+
   test('sorting by title toggles ascending and descending', async ({
     page,
   }) => {

--- a/packages/ui/src/routes/tree-browser.tsx
+++ b/packages/ui/src/routes/tree-browser.tsx
@@ -72,7 +72,15 @@ export function TreeBrowser() {
       return sortDir === 'asc' ? cmp : -cmp;
     });
     return items;
-  }, [allEntities, search, statusFilter, typeFilter, assigneeFilter, sortKey, sortDir]);
+  }, [
+    allEntities,
+    search,
+    statusFilter,
+    typeFilter,
+    assigneeFilter,
+    sortKey,
+    sortDir,
+  ]);
 
   // Build hierarchy: milestones -> epics -> stories
   const hierarchical = useMemo(() => {
@@ -134,7 +142,11 @@ export function TreeBrowser() {
     }
   };
 
-  const useHierarchy = !search && !statusFilter.length && !typeFilter.length && !assigneeFilter.length;
+  const useHierarchy =
+    !search &&
+    !statusFilter.length &&
+    !typeFilter.length &&
+    !assigneeFilter.length;
   const displayRows = useHierarchy
     ? hierarchical
     : filtered.map((e) => ({ entity: e, depth: 0 }));

--- a/packages/ui/src/routes/tree-browser.tsx
+++ b/packages/ui/src/routes/tree-browser.tsx
@@ -19,6 +19,7 @@ export function TreeBrowser() {
   const [search, setSearch] = useState('');
   const [statusFilter, setStatusFilter] = useState<string[]>([]);
   const [typeFilter, setTypeFilter] = useState<string[]>([]);
+  const [assigneeFilter, setAssigneeFilter] = useState<string[]>([]);
   const [sortKey, setSortKey] = useState<SortKey>('type');
   const [sortDir, setSortDir] = useState<SortDir>('asc');
   const [showCreate, setShowCreate] = useState(false);
@@ -36,6 +37,15 @@ export function TreeBrowser() {
     ];
   }, [tree]);
 
+  const uniqueAssignees = useMemo(() => {
+    const names = allEntities
+      .map((e) => e.assignee || e.owner)
+      .filter((v): v is string => v != null);
+    return [...new Set(names)].sort((a, b) =>
+      a.localeCompare(b, undefined, { sensitivity: 'base' }),
+    );
+  }, [allEntities]);
+
   const filtered = useMemo(() => {
     let items = allEntities;
     if (search) {
@@ -48,6 +58,13 @@ export function TreeBrowser() {
     if (typeFilter.length) {
       items = items.filter((e) => typeFilter.includes(e.type));
     }
+    if (assigneeFilter.length) {
+      items = items.filter((e) => {
+        const name = e.assignee || e.owner;
+        if (name == null) return assigneeFilter.includes('__unassigned__');
+        return assigneeFilter.includes(name);
+      });
+    }
     items.sort((a, b) => {
       const av = (a[sortKey] ?? '') as string;
       const bv = (b[sortKey] ?? '') as string;
@@ -55,7 +72,7 @@ export function TreeBrowser() {
       return sortDir === 'asc' ? cmp : -cmp;
     });
     return items;
-  }, [allEntities, search, statusFilter, typeFilter, sortKey, sortDir]);
+  }, [allEntities, search, statusFilter, typeFilter, assigneeFilter, sortKey, sortDir]);
 
   // Build hierarchy: milestones -> epics -> stories
   const hierarchical = useMemo(() => {
@@ -117,7 +134,7 @@ export function TreeBrowser() {
     }
   };
 
-  const useHierarchy = !search && !statusFilter.length && !typeFilter.length;
+  const useHierarchy = !search && !statusFilter.length && !typeFilter.length && !assigneeFilter.length;
   const displayRows = useHierarchy
     ? hierarchical
     : filtered.map((e) => ({ entity: e, depth: 0 }));
@@ -208,6 +225,23 @@ export function TreeBrowser() {
           {['story', 'epic', 'milestone', 'prd', 'roadmap'].map((t) => (
             <option key={t} value={t}>
               {t}
+            </option>
+          ))}
+        </select>
+        <select
+          multiple
+          value={assigneeFilter}
+          onChange={(e) =>
+            setAssigneeFilter(
+              Array.from(e.target.selectedOptions, (o) => o.value),
+            )
+          }
+          className="px-2 py-1.5 text-sm border border-gray-300 rounded"
+        >
+          <option value="__unassigned__">Unassigned</option>
+          {uniqueAssignees.map((a) => (
+            <option key={a} value={a}>
+              {a}
             </option>
           ))}
         </select>


### PR DESCRIPTION
Add multi-select assignee filter dropdown to the Tree Browser UI,
including an "Unassigned" option. Also add `next` CLI command with
`--assignee` flag for filtering pickable stories by assignee.

Closes #39

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>