### PR TITLE
ci: add PR title conventional commit lint

### DIFF
--- a/.github/workflows/pr-title-lint.yml
+++ b/.github/workflows/pr-title-lint.yml
@@ -1,0 +1,46 @@
+name: PR Title Lint
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+    branches: [master]
+
+jobs:
+  lint:
+    name: Conventional Commit Title
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate PR title
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          set -euo pipefail
+
+          # Conventional Commits pattern:
+          #   type(optional-scope): description
+          #   type!: description  (breaking change)
+          #
+          # Allowed types match the release-please + CLAUDE.md convention table.
+          PATTERN='^(feat|fix|chore|docs|refactor|test|ci|style|build|perf)(\([a-z0-9_-]+\))?!?: .+'
+
+          if echo "$PR_TITLE" | grep -Eq "$PATTERN"; then
+            echo "PR title is a valid conventional commit: $PR_TITLE"
+          else
+            echo "::error::PR title does not follow Conventional Commits format."
+            echo ""
+            echo "Expected: <type>(<optional scope>): <description>"
+            echo "Got:      $PR_TITLE"
+            echo ""
+            echo "Allowed types: feat, fix, chore, docs, refactor, test, ci, style, build, perf"
+            echo ""
+            echo "Examples:"
+            echo "  feat(ui): add assignee filter to tree browser"
+            echo "  fix(core): make last_sync_hash optional in sync schemas"
+            echo "  chore(deps): bump the actions group"
+            echo "  test(ui): add e2e coverage for roadmap view"
+            echo ""
+            echo "Why: release-please uses the squash-merge commit message (= PR title)"
+            echo "to determine version bumps. Without a conventional prefix, merged"
+            echo "code changes are invisible to the release pipeline."
+            exit 1
+          fi

--- a/packages/cli/src/commands/next.ts
+++ b/packages/cli/src/commands/next.ts
@@ -18,7 +18,10 @@ const PICKABLE_STATUSES = new Set(['backlog', 'todo']);
 export const nextCommand = new Command('next')
   .description('Show the next stories ready to be picked up')
   .option('-n, --count <number>', 'Number of stories to show', '5')
-  .option('-a, --assignee <name>', 'Filter by assignee')
+  .option(
+    '-a, --assignee <name>',
+    'Filter by assignee (case-insensitive match)',
+  )
   .action(async (opts, cmd) => {
     const metaDir = resolveMetaDir(cmd.optsWithGlobals().metaDir);
     const count = Number.parseInt(opts.count, 10);

--- a/packages/core/src/schemas/common.ts
+++ b/packages/core/src/schemas/common.ts
@@ -27,6 +27,7 @@ export const gitHubSyncSchema = z.object({
   project_item_id: z.string().optional(),
   milestone_id: z.number().int().optional(),
   repo: z.string(),
+  /** Optional for pre-sync entities (imported or hand-written before first push). */
   last_sync_hash: z.string().optional(),
   synced_at: z.string(),
 });
@@ -37,6 +38,7 @@ export const jiraSyncSchema = z.object({
   project_key: z.string(),
   sprint_id: z.number().int().optional(),
   site: z.string(),
+  /** Optional for pre-sync entities (imported or hand-written before first push). */
   last_sync_hash: z.string().optional(),
   synced_at: z.string(),
 });
@@ -48,6 +50,7 @@ export const gitLabSyncSchema = z.object({
   milestone_id: z.number().int().optional(),
   project_id: z.number().int(),
   base_url: z.string(),
+  /** Optional for pre-sync entities (imported or hand-written before first push). */
   last_sync_hash: z.string().optional(),
   synced_at: z.string(),
 });

--- a/packages/sync-github/src/state.ts
+++ b/packages/sync-github/src/state.ts
@@ -157,7 +157,7 @@ export function computeContentHash(entity: ParsedEntity): string {
 
 function buildCanonicalObject(entity: ParsedEntity): Record<string, unknown> {
   const base: Record<string, unknown> = {
-    title: entity.type === 'roadmap' ? entity.title : entity.title,
+    title: entity.title,
   };
 
   if (entity.type === 'story') {

--- a/packages/ui/src/routes/tree-browser.tsx
+++ b/packages/ui/src/routes/tree-browser.tsx
@@ -242,6 +242,7 @@ export function TreeBrowser() {
         </select>
         <select
           multiple
+          aria-label="Filter by assignee"
           value={assigneeFilter}
           onChange={(e) =>
             setAssigneeFilter(


### PR DESCRIPTION
PRs #141 and #144 were squash-merged to master with plain-English
titles instead of conventional commit prefixes, so release-please saw
zero releasable commits and never opened a release PR.

Add a lightweight GitHub Actions workflow that validates every PR title
against the Conventional Commits pattern before merge. This catches
missing prefixes at PR-creation time instead of discovering the gap
after merge when the release pipeline silently skips the changes.

Allowed types: feat, fix, chore, docs, refactor, test, ci, style,
build, perf — matching the release-please + CLAUDE.md convention table.

https://claude.ai/code/session_01Q1s9jocLpfMbZs6eLgQB4w