### PR TITLE
fix(core): resolve adapter packages from workspace node_modules in Node.js

### DIFF
--- a/packages/core/src/plugin-loader.test.ts
+++ b/packages/core/src/plugin-loader.test.ts
@@ -1,6 +1,6 @@
 import { mkdir, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
-import { join } from 'node:path';
+import { join, resolve } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import type { SyncAdapter } from './adapter.js';
 import type { GitpmConfig } from './config.js';
@@ -8,7 +8,11 @@ import { createDefaultGitpmConfig, gitpmConfigSchema } from './config.js';
 import {
   detectAdapter,
   findAdapterByName,
+  findPackageEntry,
+  getPackageEntry,
+  loadAdapters,
   loadGitpmConfig,
+  resolveExportsEntry,
   runHooks,
 } from './plugin-loader.js';
 
@@ -279,5 +283,248 @@ describe('runHooks', () => {
       tmpDir,
     );
     expect(result.ok).toBe(true);
+  });
+});
+
+describe('resolveExportsEntry', () => {
+  it('returns undefined for null/undefined exports', () => {
+    expect(resolveExportsEntry(null)).toBeUndefined();
+    expect(resolveExportsEntry(undefined)).toBeUndefined();
+  });
+
+  it('returns undefined for non-object exports', () => {
+    expect(resolveExportsEntry('./dist/index.js')).toBeUndefined();
+    expect(resolveExportsEntry(42)).toBeUndefined();
+  });
+
+  it('handles object-form exports with import condition', () => {
+    const exports = {
+      '.': { import: './dist/index.js', require: './dist/index.cjs' },
+    };
+    expect(resolveExportsEntry(exports)).toBe('./dist/index.js');
+  });
+
+  it('handles string-form exports', () => {
+    const exports = { '.': './dist/index.js' };
+    expect(resolveExportsEntry(exports)).toBe('./dist/index.js');
+  });
+
+  it('handles default condition when import is missing', () => {
+    const exports = { '.': { default: './dist/index.js' } };
+    expect(resolveExportsEntry(exports)).toBe('./dist/index.js');
+  });
+
+  it('prefers import over default', () => {
+    const exports = { '.': { import: './esm.js', default: './cjs.js' } };
+    expect(resolveExportsEntry(exports)).toBe('./esm.js');
+  });
+
+  it('returns undefined when dot entry has no recognised conditions', () => {
+    const exports = { '.': { require: './dist/index.cjs' } };
+    expect(resolveExportsEntry(exports)).toBeUndefined();
+  });
+});
+
+describe('getPackageEntry', () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = join(tmpdir(), `gitpm-test-pkgentry-${Date.now()}`);
+    await mkdir(tmpDir, { recursive: true });
+  });
+
+  afterEach(async () => {
+    await rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it('returns null for non-existent directory', async () => {
+    const result = await getPackageEntry(join(tmpDir, 'nonexistent'));
+    expect(result).toBeNull();
+  });
+
+  it('resolves import condition from exports field', async () => {
+    const pkgDir = join(tmpDir, 'my-pkg');
+    await mkdir(pkgDir, { recursive: true });
+    await writeFile(
+      join(pkgDir, 'package.json'),
+      JSON.stringify({ exports: { '.': { import: './dist/index.js' } } }),
+    );
+    const result = await getPackageEntry(pkgDir);
+    expect(result).toBe(resolve(pkgDir, 'dist/index.js'));
+  });
+
+  it('resolves string-form exports', async () => {
+    const pkgDir = join(tmpDir, 'str-pkg');
+    await mkdir(pkgDir, { recursive: true });
+    await writeFile(
+      join(pkgDir, 'package.json'),
+      JSON.stringify({ exports: { '.': './lib/main.js' } }),
+    );
+    const result = await getPackageEntry(pkgDir);
+    expect(result).toBe(resolve(pkgDir, 'lib/main.js'));
+  });
+
+  it('falls back to main field when exports has no dot entry', async () => {
+    const pkgDir = join(tmpDir, 'main-pkg');
+    await mkdir(pkgDir, { recursive: true });
+    await writeFile(
+      join(pkgDir, 'package.json'),
+      JSON.stringify({ main: './lib/index.js' }),
+    );
+    const result = await getPackageEntry(pkgDir);
+    expect(result).toBe(resolve(pkgDir, 'lib/index.js'));
+  });
+
+  it('falls back to module field', async () => {
+    const pkgDir = join(tmpDir, 'module-pkg');
+    await mkdir(pkgDir, { recursive: true });
+    await writeFile(
+      join(pkgDir, 'package.json'),
+      JSON.stringify({ module: './esm/index.js' }),
+    );
+    const result = await getPackageEntry(pkgDir);
+    expect(result).toBe(resolve(pkgDir, 'esm/index.js'));
+  });
+
+  it('falls back to index.js when no entry fields exist', async () => {
+    const pkgDir = join(tmpDir, 'bare-pkg');
+    await mkdir(pkgDir, { recursive: true });
+    await writeFile(
+      join(pkgDir, 'package.json'),
+      JSON.stringify({ name: 'bare' }),
+    );
+    const result = await getPackageEntry(pkgDir);
+    expect(result).toBe(resolve(pkgDir, 'index.js'));
+  });
+});
+
+describe('findPackageEntry', () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = join(tmpdir(), `gitpm-test-findpkg-${Date.now()}`);
+    await mkdir(tmpDir, { recursive: true });
+  });
+
+  afterEach(async () => {
+    await rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it('returns null when package is not found anywhere', async () => {
+    const result = await findPackageEntry('@test/nonexistent', tmpDir);
+    expect(result).toBeNull();
+  });
+
+  it('finds package in root node_modules', async () => {
+    const pkgDir = join(tmpDir, 'node_modules', '@test', 'adapter');
+    await mkdir(pkgDir, { recursive: true });
+    await writeFile(
+      join(pkgDir, 'package.json'),
+      JSON.stringify({ main: './dist/index.js' }),
+    );
+    const result = await findPackageEntry('@test/adapter', tmpDir);
+    expect(result).toBe(resolve(pkgDir, 'dist/index.js'));
+  });
+
+  it('finds package in workspace packages/*/node_modules', async () => {
+    const pkgDir = join(
+      tmpDir,
+      'packages',
+      'cli',
+      'node_modules',
+      '@test',
+      'adapter',
+    );
+    await mkdir(pkgDir, { recursive: true });
+    await writeFile(
+      join(pkgDir, 'package.json'),
+      JSON.stringify({ exports: { '.': { import: './dist/index.js' } } }),
+    );
+    const result = await findPackageEntry('@test/adapter', tmpDir);
+    expect(result).toBe(resolve(pkgDir, 'dist/index.js'));
+  });
+
+  it('prefers root node_modules over workspace node_modules', async () => {
+    // Root
+    const rootPkg = join(tmpDir, 'node_modules', 'my-adapter');
+    await mkdir(rootPkg, { recursive: true });
+    await writeFile(
+      join(rootPkg, 'package.json'),
+      JSON.stringify({ main: './root.js' }),
+    );
+    // Workspace
+    const wsPkg = join(tmpDir, 'packages', 'cli', 'node_modules', 'my-adapter');
+    await mkdir(wsPkg, { recursive: true });
+    await writeFile(
+      join(wsPkg, 'package.json'),
+      JSON.stringify({ main: './workspace.js' }),
+    );
+    const result = await findPackageEntry('my-adapter', tmpDir);
+    expect(result).toBe(resolve(rootPkg, 'root.js'));
+  });
+});
+
+describe('loadAdapters workspace fallback', () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = join(tmpdir(), `gitpm-test-loadadapt-${Date.now()}`);
+    await mkdir(tmpDir, { recursive: true });
+  });
+
+  afterEach(async () => {
+    await rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it('loads adapter from workspace node_modules when bare import fails', async () => {
+    // Create a fake adapter module in a workspace-style path
+    const adapterDir = join(
+      tmpDir,
+      'packages',
+      'cli',
+      'node_modules',
+      '@test',
+      'fake-adapter',
+    );
+    await mkdir(adapterDir, { recursive: true });
+    await writeFile(
+      join(adapterDir, 'package.json'),
+      JSON.stringify({ exports: { '.': { import: './index.mjs' } } }),
+    );
+    await writeFile(
+      join(adapterDir, 'index.mjs'),
+      `export const testAdapter = {
+        name: 'test',
+        displayName: 'Test',
+        detect: async () => false,
+        import: async () => ({ ok: true, value: { milestones: 0, epics: 0, stories: 0, totalFiles: 0 } }),
+        export: async () => ({ ok: true, value: { created: { milestones: 0, issues: 0 }, updated: { milestones: 0, issues: 0 }, totalChanges: 0 } }),
+        sync: async () => ({ ok: true, value: { pushed: { milestones: 0, issues: 0 }, pulled: { milestones: 0, issues: 0 }, conflicts: [], resolved: 0, skipped: 0 } }),
+      };`,
+    );
+
+    const config: GitpmConfig = {
+      adapters: ['@test/fake-adapter'],
+      hooks: {},
+    };
+    const result = await loadAdapters(config, tmpDir);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value).toHaveLength(1);
+      expect(result.value[0].name).toBe('test');
+    }
+  });
+
+  it('silently skips adapters not found in any node_modules', async () => {
+    const config: GitpmConfig = {
+      adapters: ['@nonexistent/adapter'],
+      hooks: {},
+    };
+    const result = await loadAdapters(config, tmpDir);
+    // With no adapters loaded and no errors (silently skipped), returns empty list
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value).toHaveLength(0);
+    }
   });
 });

--- a/packages/core/src/plugin-loader.ts
+++ b/packages/core/src/plugin-loader.ts
@@ -1,5 +1,4 @@
-import { existsSync, readdirSync, readFileSync } from 'node:fs';
-import { readFile } from 'node:fs/promises';
+import { access, readdir, readFile } from 'node:fs/promises';
 import { dirname, isAbsolute, join, resolve } from 'node:path';
 import { pathToFileURL } from 'node:url';
 import type { SyncAdapter } from './adapter.js';
@@ -176,11 +175,11 @@ async function loadSingleAdapter(
       // (e.g. packages/cli/node_modules/@gitpm/sync-github) rather than
       // the root node_modules, so Node can't find them from core's location.
       const base = resolve(rootDir ?? process.cwd());
-      const entryPath = findPackageEntry(adapterPath, base);
+      const entryPath = await findPackageEntry(adapterPath, base);
       if (entryPath) {
         mod = await import(pathToFileURL(entryPath).href);
       } else {
-        // Re-throw the original import error for proper error reporting
+        // Throw a module-not-found error for proper error reporting
         throw new Error(`Cannot find package '${adapterPath}'`);
       }
     }
@@ -206,7 +205,10 @@ async function loadSingleAdapter(
  * Handles workspace monorepos where packages may be symlinked into nested
  * node_modules (e.g. packages/cli/node_modules/@scope/pkg).
  */
-function findPackageEntry(packageName: string, rootDir: string): string | null {
+export async function findPackageEntry(
+  packageName: string,
+  rootDir: string,
+): Promise<string | null> {
   const checked = new Set<string>();
 
   // 1. Walk up from rootDir checking node_modules at each level
@@ -215,7 +217,7 @@ function findPackageEntry(packageName: string, rootDir: string): string | null {
     const candidate = join(dir, 'node_modules', packageName);
     if (!checked.has(candidate)) {
       checked.add(candidate);
-      const entry = getPackageEntry(candidate);
+      const entry = await getPackageEntry(candidate);
       if (entry) return entry;
     }
     const parent = dirname(dir);
@@ -225,19 +227,18 @@ function findPackageEntry(packageName: string, rootDir: string): string | null {
 
   // 2. Scan workspace packages (packages/*/node_modules/<pkg>)
   const packagesDir = join(rootDir, 'packages');
-  if (existsSync(packagesDir)) {
-    try {
-      for (const child of readdirSync(packagesDir)) {
-        const candidate = join(packagesDir, child, 'node_modules', packageName);
-        if (!checked.has(candidate)) {
-          checked.add(candidate);
-          const entry = getPackageEntry(candidate);
-          if (entry) return entry;
-        }
+  try {
+    const children = await readdir(packagesDir);
+    for (const child of children) {
+      const candidate = join(packagesDir, child, 'node_modules', packageName);
+      if (!checked.has(candidate)) {
+        checked.add(candidate);
+        const entry = await getPackageEntry(candidate);
+        if (entry) return entry;
       }
-    } catch {
-      // packages dir not readable — skip
     }
+  } catch {
+    // packages dir missing or not readable — skip
   }
 
   return null;
@@ -245,18 +246,43 @@ function findPackageEntry(packageName: string, rootDir: string): string | null {
 
 /**
  * Read a package directory's package.json and return the resolved ESM entry path.
+ * Handles both object-form and string-form exports, plus the 'default' condition.
  */
-function getPackageEntry(packageDir: string): string | null {
+export async function getPackageEntry(
+  packageDir: string,
+): Promise<string | null> {
   const pkgJsonPath = join(packageDir, 'package.json');
-  if (!existsSync(pkgJsonPath)) return null;
   try {
-    const pkg = JSON.parse(readFileSync(pkgJsonPath, 'utf-8'));
+    await access(pkgJsonPath);
+  } catch {
+    return null;
+  }
+  try {
+    const raw = await readFile(pkgJsonPath, 'utf-8');
+    const pkg = JSON.parse(raw);
     const entry =
-      pkg.exports?.['.']?.import || pkg.module || pkg.main || 'index.js';
+      resolveExportsEntry(pkg.exports) || pkg.module || pkg.main || 'index.js';
     return resolve(packageDir, entry);
   } catch {
     return null;
   }
+}
+
+/**
+ * Resolve the ESM entry point from a package.json exports field.
+ * Handles object-form ({".": {"import": "..."}}) and string-form ({".": "..."})
+ * as well as the 'default' condition key.
+ */
+export function resolveExportsEntry(exports: unknown): string | undefined {
+  if (!exports || typeof exports !== 'object') return undefined;
+  const dot = (exports as Record<string, unknown>)['.'];
+  if (typeof dot === 'string') return dot;
+  if (dot && typeof dot === 'object') {
+    const conditions = dot as Record<string, unknown>;
+    if (typeof conditions.import === 'string') return conditions.import;
+    if (typeof conditions.default === 'string') return conditions.default;
+  }
+  return undefined;
 }
 
 /**

--- a/packages/core/src/plugin-loader.ts
+++ b/packages/core/src/plugin-loader.ts
@@ -1,5 +1,6 @@
+import { existsSync, readdirSync, readFileSync } from 'node:fs';
 import { readFile } from 'node:fs/promises';
-import { isAbsolute, join, resolve } from 'node:path';
+import { dirname, isAbsolute, join, resolve } from 'node:path';
 import { pathToFileURL } from 'node:url';
 import type { SyncAdapter } from './adapter.js';
 import { isSyncAdapter } from './adapter.js';
@@ -164,7 +165,25 @@ async function loadSingleAdapter(
     const fileUrl = pathToFileURL(resolvedPath).href;
     mod = await import(fileUrl);
   } else {
-    mod = await import(adapterPath);
+    // Try the standard bare import first (works when packages are in a
+    // standard node_modules tree reachable from this module's location).
+    try {
+      mod = await import(adapterPath);
+    } catch {
+      // Bare import failed — search for the package in node_modules trees
+      // under the project root. In workspace monorepos (especially Bun),
+      // packages are symlinked into consuming packages' node_modules
+      // (e.g. packages/cli/node_modules/@gitpm/sync-github) rather than
+      // the root node_modules, so Node can't find them from core's location.
+      const base = resolve(rootDir ?? process.cwd());
+      const entryPath = findPackageEntry(adapterPath, base);
+      if (entryPath) {
+        mod = await import(pathToFileURL(entryPath).href);
+      } else {
+        // Re-throw the original import error for proper error reporting
+        throw new Error(`Cannot find package '${adapterPath}'`);
+      }
+    }
   }
 
   // Check default export first (canonical)
@@ -180,6 +199,64 @@ async function loadSingleAdapter(
   }
 
   return null;
+}
+
+/**
+ * Search for an npm package's ESM entry point in node_modules directories.
+ * Handles workspace monorepos where packages may be symlinked into nested
+ * node_modules (e.g. packages/cli/node_modules/@scope/pkg).
+ */
+function findPackageEntry(packageName: string, rootDir: string): string | null {
+  const checked = new Set<string>();
+
+  // 1. Walk up from rootDir checking node_modules at each level
+  let dir = rootDir;
+  while (true) {
+    const candidate = join(dir, 'node_modules', packageName);
+    if (!checked.has(candidate)) {
+      checked.add(candidate);
+      const entry = getPackageEntry(candidate);
+      if (entry) return entry;
+    }
+    const parent = dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+
+  // 2. Scan workspace packages (packages/*/node_modules/<pkg>)
+  const packagesDir = join(rootDir, 'packages');
+  if (existsSync(packagesDir)) {
+    try {
+      for (const child of readdirSync(packagesDir)) {
+        const candidate = join(packagesDir, child, 'node_modules', packageName);
+        if (!checked.has(candidate)) {
+          checked.add(candidate);
+          const entry = getPackageEntry(candidate);
+          if (entry) return entry;
+        }
+      }
+    } catch {
+      // packages dir not readable — skip
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Read a package directory's package.json and return the resolved ESM entry path.
+ */
+function getPackageEntry(packageDir: string): string | null {
+  const pkgJsonPath = join(packageDir, 'package.json');
+  if (!existsSync(pkgJsonPath)) return null;
+  try {
+    const pkg = JSON.parse(readFileSync(pkgJsonPath, 'utf-8'));
+    const entry =
+      pkg.exports?.['.']?.import || pkg.module || pkg.main || 'index.js';
+    return resolve(packageDir, entry);
+  } catch {
+    return null;
+  }
 }
 
 /**


### PR DESCRIPTION
The plugin-loader's dynamic import() resolved npm package names relative
to its own location (packages/core/dist/), but Bun workspaces only
symlink workspace packages into consuming packages' node_modules (e.g.
packages/cli/node_modules/@gitpm/sync-github). This caused the
post-merge-sync CI job to fail with "No sync adapters installed" when
running via Node.js.

Add a filesystem-based fallback that searches node_modules trees from the
project root and workspace packages/ directories when the standard bare
import fails.

https://claude.ai/code/session_01CLMEuPLW6e4nBqWFt6y2kx