### PR TITLE
feat: implement Analytics & Project Intelligence epic

### DIFF
--- a/.meta/epics/epic-analytics-project-intelligence/epic.md
+++ b/.meta/epics/epic-analytics-project-intelligence/epic.md
@@ -2,7 +2,7 @@
 type: epic
 id: Jm9BOEIh35z1
 title: "[Epic] Analytics & Project Intelligence"
-status: todo
+status: in_progress
 priority: medium
 owner: null
 labels:
@@ -14,8 +14,8 @@ github:
   issue_number: 67
   repo: yevheniidehtiar/gitpm
   synced_at: 2026-04-06T12:53:26.000Z
-created_at: 2026-04-06T00:00:00Z
-updated_at: 2026-04-06T00:00:00Z
+created_at: 2026-04-06T00:00:00.000Z
+updated_at: 2026-04-12T16:06:39.180Z
 ---
 
 ## Overview

--- a/.meta/epics/epic-analytics-project-intelligence/stories/feat-add-issue-quality-scoring-for-ai-agent-context.md
+++ b/.meta/epics/epic-analytics-project-intelligence/stories/feat-add-issue-quality-scoring-for-ai-agent-context.md
@@ -2,7 +2,7 @@
 type: story
 id: YTEAoETh3A7C
 title: "feat: add issue quality scoring for AI agent context"
-status: todo
+status: done
 priority: medium
 assignee: null
 labels:
@@ -17,8 +17,8 @@ github:
   repo: yevheniidehtiar/gitpm
   last_sync_hash: sha256:c82c2510bf6e5991f3732c93525f0d4ed9e42b4925bd1ef4456bd9e496c4b73d
   synced_at: 2026-04-05T17:24:12.493Z
-created_at: 2026-04-05T09:49:45Z
-updated_at: 2026-04-05T09:49:45Z
+created_at: 2026-04-05T09:49:45.000Z
+updated_at: 2026-04-12T16:06:36.793Z
 ---
 
 ## Motivation

--- a/bun.lock
+++ b/bun.lock
@@ -88,6 +88,8 @@
         "@tanstack/react-query": "^5.60.0",
         "@tanstack/react-router": "^1.82.0",
         "@tanstack/react-virtual": "^3.13.23",
+        "d3-force": "^3.0.0",
+        "d3-selection": "^3.0.0",
         "hono": "^4.12.11",
         "react": "^18.3.0",
         "react-dom": "^18.3.0",
@@ -97,6 +99,8 @@
       "devDependencies": {
         "@playwright/test": "1.59.1",
         "@tailwindcss/vite": "^4.0.0",
+        "@types/d3-force": "^3.0.10",
+        "@types/d3-selection": "^3.0.11",
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
         "@vitejs/plugin-react": "^6.0.1",
@@ -407,6 +411,10 @@
 
     "@types/chai": ["@types/chai@5.2.3", "", { "dependencies": { "@types/deep-eql": "*", "assertion-error": "^2.0.1" } }, "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA=="],
 
+    "@types/d3-force": ["@types/d3-force@3.0.10", "", {}, "sha512-ZYeSaCF3p73RdOKcjj+swRlZfnYpK1EbaDiYICEEp5Q6sUiqFaFQ9qgoshp5CzIyyb/yD09kD9o2zEltCexlgw=="],
+
+    "@types/d3-selection": ["@types/d3-selection@3.0.11", "", {}, "sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w=="],
+
     "@types/debug": ["@types/debug@4.1.13", "", { "dependencies": { "@types/ms": "*" } }, "sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw=="],
 
     "@types/deep-eql": ["@types/deep-eql@4.0.2", "", {}, "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw=="],
@@ -506,6 +514,16 @@
     "cookie-es": ["cookie-es@2.0.1", "", {}, "sha512-aVf4A4hI2w70LnF7GG+7xDQUkliwiXWXFvTjkip4+b64ygDQ2sJPRSKFDHbxn8o0xu9QzPkMuuiWIXyFSE2slA=="],
 
     "csstype": ["csstype@3.2.3", "", {}, "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ=="],
+
+    "d3-dispatch": ["d3-dispatch@3.0.1", "", {}, "sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg=="],
+
+    "d3-force": ["d3-force@3.0.0", "", { "dependencies": { "d3-dispatch": "1 - 3", "d3-quadtree": "1 - 3", "d3-timer": "1 - 3" } }, "sha512-zxV/SsA+U4yte8051P4ECydjD/S+qeYtnaIyAs9tgHCqfguma/aAQDjo85A9Z6EKhBirHRJHXIgJUlffT4wdLg=="],
+
+    "d3-quadtree": ["d3-quadtree@3.0.1", "", {}, "sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw=="],
+
+    "d3-selection": ["d3-selection@3.0.0", "", {}, "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ=="],
+
+    "d3-timer": ["d3-timer@3.0.1", "", {}, "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA=="],
 
     "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
 

--- a/packages/cli/src/__tests__/create.test.ts
+++ b/packages/cli/src/__tests__/create.test.ts
@@ -110,6 +110,7 @@ describe('gitpm create story', () => {
         milestones: [],
         roadmaps: [],
         prds: [],
+        sprints: [],
         errors: [],
       },
     });

--- a/packages/cli/src/__tests__/query.test.ts
+++ b/packages/cli/src/__tests__/query.test.ts
@@ -32,6 +32,7 @@ function makeTree() {
     milestones: [],
     roadmaps: [],
     prds: [],
+    sprints: [],
     errors: [],
   };
 }

--- a/packages/cli/src/__tests__/show.test.ts
+++ b/packages/cli/src/__tests__/show.test.ts
@@ -52,6 +52,7 @@ function makeTree() {
     milestones: [],
     roadmaps: [],
     prds: [],
+    sprints: [],
     errors: [],
   };
 }
@@ -104,6 +105,7 @@ function makeResolvedTree() {
     ],
     roadmaps: [],
     prds: [],
+    sprints: [],
     errors: [],
   };
 }

--- a/packages/cli/src/__tests__/validate.test.ts
+++ b/packages/cli/src/__tests__/validate.test.ts
@@ -44,6 +44,7 @@ function makeTree(
     milestones: [],
     roadmaps: [],
     prds: [],
+    sprints: [],
     errors: [],
     ...overrides,
   };

--- a/packages/cli/src/commands/audit.ts
+++ b/packages/cli/src/commands/audit.ts
@@ -1,0 +1,97 @@
+import { relative } from 'node:path';
+import {
+  type AuditItem,
+  type AuditReport,
+  auditTree,
+  type DuplicatePair,
+  parseTree,
+  resolveRefs,
+} from '@gitpm/core';
+import chalk from 'chalk';
+import { Command } from 'commander';
+import { resolveMetaDir } from '../utils/config.js';
+import { printError, printSuccess } from '../utils/output.js';
+
+function printSection(title: string, items: AuditItem[]): void {
+  if (items.length === 0) return;
+  console.log(chalk.bold.yellow(`  ${title} (${items.length})`));
+  for (const item of items) {
+    const rel = relative(process.cwd(), item.filePath);
+    console.log(
+      `    ${chalk.dim('•')} ${item.title} ${chalk.dim('—')} ${item.reason}`,
+    );
+    console.log(`      ${chalk.dim(rel)}`);
+  }
+  console.log();
+}
+
+function printDuplicates(pairs: DuplicatePair[]): void {
+  if (pairs.length === 0) return;
+  console.log(chalk.bold.yellow(`  Duplicate Candidates (${pairs.length})`));
+  for (const { a, b, similarity } of pairs) {
+    const pct = Math.round(similarity * 100);
+    console.log(
+      `    ${chalk.dim('•')} ${a.title} ${chalk.dim('↔')} ${b.title} ${chalk.cyan(`${pct}%`)}`,
+    );
+  }
+  console.log();
+}
+
+function printReport(report: AuditReport): void {
+  console.log();
+  console.log(chalk.bold('  Project Audit'));
+  console.log(chalk.dim(`  ${'─'.repeat(13)}`));
+  console.log(
+    `  ${report.summary.total} entities scanned, ${report.summary.issues} issue(s) found`,
+  );
+  console.log();
+
+  printSection('Stale Stories', report.stale);
+  printSection('Orphan Stories (no epic)', report.orphans);
+  printSection('Empty Bodies', report.emptyBodies);
+  printSection('Zombie Epics (all stories done)', report.zombieEpics);
+  printDuplicates(report.duplicates);
+}
+
+export const auditCommand = new Command('audit')
+  .description(
+    'Detect stale issues, orphans, duplicates, and project hygiene issues',
+  )
+  .option(
+    '--stale-days <days>',
+    'Days before a todo is considered stale',
+    Number.parseInt,
+    90,
+  )
+  .option('--json', 'Output as JSON')
+  .action(async (opts, cmd) => {
+    const metaDir = resolveMetaDir(cmd.optsWithGlobals().metaDir);
+
+    const parseResult = await parseTree(metaDir);
+    if (!parseResult.ok) {
+      printError(parseResult.error.message);
+      process.exit(1);
+    }
+
+    const resolveResult = resolveRefs(parseResult.value);
+    if (!resolveResult.ok) {
+      printError(resolveResult.error.message);
+      process.exit(1);
+    }
+
+    const report = auditTree(resolveResult.value, {
+      staleDays: opts.staleDays,
+    });
+
+    if (opts.json) {
+      console.log(JSON.stringify(report, null, 2));
+    } else if (report.summary.issues === 0) {
+      printSuccess('No issues found — project is clean!');
+    } else {
+      printReport(report);
+    }
+
+    if (report.summary.issues > 0) {
+      process.exit(1);
+    }
+  });

--- a/packages/cli/src/commands/sprint.ts
+++ b/packages/cli/src/commands/sprint.ts
@@ -1,0 +1,187 @@
+import { relative } from 'node:path';
+import {
+  createSprint,
+  parseTree,
+  type ResolvedSprint,
+  resolveRefs,
+} from '@gitpm/core';
+import chalk from 'chalk';
+import { Command } from 'commander';
+import { resolveMetaDir } from '../utils/config.js';
+import { printError, printSuccess } from '../utils/output.js';
+
+function progressBar(ratio: number, width = 16): string {
+  const filled = Math.round(ratio * width);
+  const empty = width - filled;
+  const bar = '█'.repeat(filled) + '░'.repeat(empty);
+  if (ratio >= 0.75) return chalk.green(bar);
+  if (ratio >= 0.25) return chalk.yellow(bar);
+  return chalk.red(bar);
+}
+
+function sprintProgress(sprint: ResolvedSprint): {
+  done: number;
+  total: number;
+  ratio: number;
+} {
+  const total = sprint.resolvedStories.length;
+  const done = sprint.resolvedStories.filter(
+    (s) => s.status === 'done' || s.status === 'cancelled',
+  ).length;
+  return { done, total, ratio: total > 0 ? done / total : 0 };
+}
+
+const sprintCreateCommand = new Command('create')
+  .description('Create a new sprint')
+  .requiredOption('--title <title>', 'Sprint title')
+  .requiredOption('--start <date>', 'Start date (YYYY-MM-DD)')
+  .requiredOption('--end <date>', 'End date (YYYY-MM-DD)')
+  .option('--capacity <points>', 'Story point capacity', Number.parseInt)
+  .action(async (opts, cmd) => {
+    const metaDir = resolveMetaDir(cmd.optsWithGlobals().metaDir);
+    const result = await createSprint(metaDir, {
+      title: opts.title,
+      startDate: opts.start,
+      endDate: opts.end,
+      capacity: opts.capacity,
+    });
+
+    if (!result.ok) {
+      printError(result.error.message);
+      process.exit(1);
+    }
+
+    const rel = relative(process.cwd(), result.value.filePath);
+    printSuccess(`Created sprint: ${rel} (${result.value.id})`);
+  });
+
+const sprintListCommand = new Command('list')
+  .description('List all sprints with progress')
+  .option('--json', 'Output as JSON')
+  .action(async (opts, cmd) => {
+    const metaDir = resolveMetaDir(cmd.optsWithGlobals().metaDir);
+
+    const parseResult = await parseTree(metaDir);
+    if (!parseResult.ok) {
+      printError(parseResult.error.message);
+      process.exit(1);
+    }
+
+    const resolveResult = resolveRefs(parseResult.value);
+    if (!resolveResult.ok) {
+      printError(resolveResult.error.message);
+      process.exit(1);
+    }
+
+    const sprints = resolveResult.value.sprints;
+
+    if (opts.json) {
+      const data = sprints.map((sp) => {
+        const { done, total, ratio } = sprintProgress(sp);
+        return {
+          id: sp.id,
+          title: sp.title,
+          status: sp.status,
+          start_date: sp.start_date,
+          end_date: sp.end_date,
+          capacity: sp.capacity,
+          stories: total,
+          done,
+          progress: ratio,
+        };
+      });
+      console.log(JSON.stringify(data, null, 2));
+      return;
+    }
+
+    if (sprints.length === 0) {
+      console.log(
+        chalk.dim('  No sprints found. Create one with: gitpm sprint create'),
+      );
+      return;
+    }
+
+    console.log();
+    console.log(chalk.bold('  Sprints'));
+    console.log(chalk.dim(`  ${'─'.repeat(7)}`));
+
+    for (const sp of sprints) {
+      const { done, total, ratio } = sprintProgress(sp);
+      const pct = Math.round(ratio * 100);
+      const dateRange = chalk.dim(
+        `${sp.start_date.slice(0, 10)} → ${sp.end_date.slice(0, 10)}`,
+      );
+      const cap = sp.capacity ? chalk.dim(` (cap: ${sp.capacity}pts)`) : '';
+
+      console.log(
+        `  ${progressBar(ratio)} ${pct}% ${sp.title} ${dateRange}${cap}`,
+      );
+      console.log(
+        `  ${' '.repeat(16)}  ${chalk.dim(`${done}/${total} stories`)} ${chalk.cyan(sp.status)}`,
+      );
+    }
+    console.log();
+  });
+
+const sprintShowCommand = new Command('show')
+  .description('Show sprint details')
+  .argument('<sprint-id>', 'Sprint ID')
+  .action(async (sprintId, _opts, cmd) => {
+    const metaDir = resolveMetaDir(cmd.optsWithGlobals().metaDir);
+
+    const parseResult = await parseTree(metaDir);
+    if (!parseResult.ok) {
+      printError(parseResult.error.message);
+      process.exit(1);
+    }
+
+    const resolveResult = resolveRefs(parseResult.value);
+    if (!resolveResult.ok) {
+      printError(resolveResult.error.message);
+      process.exit(1);
+    }
+
+    const sprint = resolveResult.value.sprints.find((s) => s.id === sprintId);
+    if (!sprint) {
+      printError(`Sprint not found: ${sprintId}`);
+      process.exit(1);
+    }
+
+    const { done, total, ratio } = sprintProgress(sprint);
+    const pct = Math.round(ratio * 100);
+
+    console.log();
+    console.log(chalk.bold(`  ${sprint.title}`));
+    console.log(chalk.dim(`  ${'─'.repeat(sprint.title.length)}`));
+    console.log(`  Status: ${chalk.cyan(sprint.status)}`);
+    console.log(
+      `  Period: ${sprint.start_date.slice(0, 10)} → ${sprint.end_date.slice(0, 10)}`,
+    );
+    if (sprint.capacity) console.log(`  Capacity: ${sprint.capacity} pts`);
+    console.log(`  Progress: ${progressBar(ratio)} ${pct}% (${done}/${total})`);
+    console.log();
+
+    if (sprint.resolvedStories.length > 0) {
+      console.log(chalk.bold('  Stories:'));
+      for (const story of sprint.resolvedStories) {
+        const statusColor =
+          story.status === 'done'
+            ? chalk.green
+            : story.status === 'in_progress'
+              ? chalk.yellow
+              : chalk.dim;
+        console.log(
+          `    ${statusColor('●')} ${story.title} ${chalk.dim(`[${story.status}]`)}`,
+        );
+      }
+    } else {
+      console.log(chalk.dim('  No stories assigned.'));
+    }
+    console.log();
+  });
+
+export const sprintCommand = new Command('sprint')
+  .description('Manage sprints (time-boxed iterations)')
+  .addCommand(sprintCreateCommand)
+  .addCommand(sprintListCommand)
+  .addCommand(sprintShowCommand);

--- a/packages/cli/src/commands/sprint.ts
+++ b/packages/cli/src/commands/sprint.ts
@@ -8,16 +8,7 @@ import {
 import chalk from 'chalk';
 import { Command } from 'commander';
 import { resolveMetaDir } from '../utils/config.js';
-import { printError, printSuccess } from '../utils/output.js';
-
-function progressBar(ratio: number, width = 16): string {
-  const filled = Math.round(ratio * width);
-  const empty = width - filled;
-  const bar = '█'.repeat(filled) + '░'.repeat(empty);
-  if (ratio >= 0.75) return chalk.green(bar);
-  if (ratio >= 0.25) return chalk.yellow(bar);
-  return chalk.red(bar);
-}
+import { printError, printSuccess, progressBar } from '../utils/output.js';
 
 function sprintProgress(sprint: ResolvedSprint): {
   done: number;
@@ -114,7 +105,7 @@ const sprintListCommand = new Command('list')
       const cap = sp.capacity ? chalk.dim(` (cap: ${sp.capacity}pts)`) : '';
 
       console.log(
-        `  ${progressBar(ratio)} ${pct}% ${sp.title} ${dateRange}${cap}`,
+        `  ${progressBar(ratio, 16)} ${pct}% ${sp.title} ${dateRange}${cap}`,
       );
       console.log(
         `  ${' '.repeat(16)}  ${chalk.dim(`${done}/${total} stories`)} ${chalk.cyan(sp.status)}`,
@@ -158,7 +149,9 @@ const sprintShowCommand = new Command('show')
       `  Period: ${sprint.start_date.slice(0, 10)} → ${sprint.end_date.slice(0, 10)}`,
     );
     if (sprint.capacity) console.log(`  Capacity: ${sprint.capacity} pts`);
-    console.log(`  Progress: ${progressBar(ratio)} ${pct}% (${done}/${total})`);
+    console.log(
+      `  Progress: ${progressBar(ratio, 16)} ${pct}% (${done}/${total})`,
+    );
     console.log();
 
     if (sprint.resolvedStories.length > 0) {

--- a/packages/cli/src/commands/status.ts
+++ b/packages/cli/src/commands/status.ts
@@ -7,16 +7,7 @@ import {
 import chalk from 'chalk';
 import { Command } from 'commander';
 import { resolveMetaDir } from '../utils/config.js';
-import { printError } from '../utils/output.js';
-
-function progressBar(ratio: number, width = 20): string {
-  const filled = Math.round(ratio * width);
-  const empty = width - filled;
-  const bar = '█'.repeat(filled) + '░'.repeat(empty);
-  if (ratio >= 0.75) return chalk.green(bar);
-  if (ratio >= 0.25) return chalk.yellow(bar);
-  return chalk.red(bar);
-}
+import { printError, progressBar } from '../utils/output.js';
 
 function pct(ratio: number): string {
   return `${Math.round(ratio * 100)}%`;
@@ -29,7 +20,7 @@ function printProjectProgress(progress: ProjectProgress): void {
 
   const { overall } = progress;
   console.log(
-    `  ${progressBar(overall.progress)} ${pct(overall.progress)} (${overall.done}/${overall.total} stories)`,
+    `  ${progressBar(overall.progress, 20)} ${pct(overall.progress)} (${overall.done}/${overall.total} stories)`,
   );
   console.log();
 

--- a/packages/cli/src/commands/status.ts
+++ b/packages/cli/src/commands/status.ts
@@ -1,0 +1,107 @@
+import {
+  computeProjectProgress,
+  type ProjectProgress,
+  parseTree,
+  resolveRefs,
+} from '@gitpm/core';
+import chalk from 'chalk';
+import { Command } from 'commander';
+import { resolveMetaDir } from '../utils/config.js';
+import { printError } from '../utils/output.js';
+
+function progressBar(ratio: number, width = 20): string {
+  const filled = Math.round(ratio * width);
+  const empty = width - filled;
+  const bar = '█'.repeat(filled) + '░'.repeat(empty);
+  if (ratio >= 0.75) return chalk.green(bar);
+  if (ratio >= 0.25) return chalk.yellow(bar);
+  return chalk.red(bar);
+}
+
+function pct(ratio: number): string {
+  return `${Math.round(ratio * 100)}%`;
+}
+
+function printProjectProgress(progress: ProjectProgress): void {
+  console.log();
+  console.log(chalk.bold('  Project Status'));
+  console.log(chalk.dim(`  ${'─'.repeat(14)}`));
+
+  const { overall } = progress;
+  console.log(
+    `  ${progressBar(overall.progress)} ${pct(overall.progress)} (${overall.done}/${overall.total} stories)`,
+  );
+  console.log();
+
+  for (const ms of progress.milestones) {
+    const dateStr = ms.targetDate
+      ? chalk.dim(` — due ${ms.targetDate.slice(0, 10)}`)
+      : '';
+    console.log(
+      chalk.bold(`  📌 ${ms.title}`) +
+        dateStr +
+        chalk.dim(` (${pct(ms.progress)})`),
+    );
+
+    for (const ep of ms.epics) {
+      const counts = chalk.dim(
+        `${ep.done}/${ep.total} done` +
+          (ep.inProgress > 0 ? `, ${ep.inProgress} active` : '') +
+          (ep.blocked > 0 ? `, ${ep.blocked} blocked` : ''),
+      );
+      console.log(
+        `    ${progressBar(ep.progress, 16)} ${pct(ep.progress)} ${ep.title}`,
+      );
+      console.log(`    ${' '.repeat(16)}  ${counts}`);
+    }
+
+    if (ms.epics.length === 0) {
+      console.log(chalk.dim('    (no epics linked)'));
+    }
+    console.log();
+  }
+
+  if (progress.orphanEpics.length > 0) {
+    console.log(chalk.bold('  Unlinked Epics'));
+    for (const ep of progress.orphanEpics) {
+      const counts = chalk.dim(`${ep.done}/${ep.total} done`);
+      console.log(
+        `    ${progressBar(ep.progress, 16)} ${pct(ep.progress)} ${ep.title}  ${counts}`,
+      );
+    }
+    console.log();
+  }
+}
+
+export const statusCommand = new Command('status')
+  .description('Show project progress across milestones and epics')
+  .option('--json', 'Output as JSON')
+  .action(async (opts, cmd) => {
+    const metaDir = resolveMetaDir(cmd.optsWithGlobals().metaDir);
+
+    const parseResult = await parseTree(metaDir);
+    if (!parseResult.ok) {
+      printError(parseResult.error.message);
+      process.exit(1);
+    }
+
+    const resolveResult = resolveRefs(parseResult.value);
+    if (!resolveResult.ok) {
+      printError(resolveResult.error.message);
+      process.exit(1);
+    }
+
+    const progress = computeProjectProgress(resolveResult.value);
+
+    if (opts.json) {
+      console.log(JSON.stringify(progress, null, 2));
+      return;
+    }
+
+    if (progress.overall.total === 0) {
+      console.log(chalk.dim('  No stories found in .meta/'));
+      return;
+    }
+
+    printProjectProgress(progress);
+  });

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -3,6 +3,7 @@ import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { Command } from 'commander';
 import { archiveCommand } from './commands/archive.js';
+import { auditCommand } from './commands/audit.js';
 import { commitCommand } from './commands/commit.js';
 import { createCommand } from './commands/create.js';
 import { importCommand } from './commands/import.js';
@@ -15,6 +16,8 @@ import { qualityCommand } from './commands/quality.js';
 import { queryCommand } from './commands/query.js';
 import { setCommand } from './commands/set.js';
 import { showCommand } from './commands/show.js';
+import { sprintCommand } from './commands/sprint.js';
+import { statusCommand } from './commands/status.js';
 import { syncCommand } from './commands/sync.js';
 import { validateCommand } from './commands/validate.js';
 
@@ -46,6 +49,9 @@ program.addCommand(importCommand);
 program.addCommand(pushCommand);
 program.addCommand(pullCommand);
 program.addCommand(syncCommand);
+program.addCommand(statusCommand);
+program.addCommand(sprintCommand);
+program.addCommand(auditCommand);
 program.addCommand(archiveCommand);
 
 program.parse();

--- a/packages/cli/src/utils/output.ts
+++ b/packages/cli/src/utils/output.ts
@@ -12,6 +12,15 @@ export function printWarning(msg: string): void {
   console.warn(chalk.yellow(`⚠ ${msg}`));
 }
 
+export function progressBar(ratio: number, width: number): string {
+  const filled = Math.round(ratio * width);
+  const empty = width - filled;
+  const bar = '█'.repeat(filled) + '░'.repeat(empty);
+  if (ratio >= 0.75) return chalk.green(bar);
+  if (ratio >= 0.25) return chalk.yellow(bar);
+  return chalk.red(bar);
+}
+
 export function printTree(files: string[]): void {
   for (const file of files) {
     const parts = file.split('/');

--- a/packages/core/src/analytics/audit.test.ts
+++ b/packages/core/src/analytics/audit.test.ts
@@ -51,6 +51,7 @@ function makeTree(overrides: Partial<ResolvedTree> = {}): ResolvedTree {
     milestones: [],
     roadmaps: [],
     prds: [],
+    sprints: [],
     errors: [],
     ...overrides,
   };

--- a/packages/core/src/analytics/audit.test.ts
+++ b/packages/core/src/analytics/audit.test.ts
@@ -1,0 +1,195 @@
+import { describe, expect, it } from 'vitest';
+import type { ResolvedEpic, ResolvedTree } from '../resolver/types.js';
+import { auditTree } from './audit.js';
+
+function makeStory(overrides: Record<string, unknown> = {}) {
+  return {
+    type: 'story' as const,
+    id: `s-${Math.random().toString(36).slice(2, 8)}`,
+    title: 'Test story',
+    status: 'todo' as const,
+    priority: 'medium' as const,
+    assignee: null,
+    labels: [],
+    estimate: null,
+    epic_ref: null,
+    body: 'Some body text',
+    filePath: '/tmp/test.md',
+    created_at: '2026-01-01T00:00:00Z',
+    updated_at: '2026-01-01T00:00:00Z',
+    ...overrides,
+  };
+}
+
+function makeEpic(
+  stories: ReturnType<typeof makeStory>[],
+  overrides: Record<string, unknown> = {},
+): ResolvedEpic {
+  return {
+    type: 'epic' as const,
+    id: `e-${Math.random().toString(36).slice(2, 8)}`,
+    title: 'Test epic',
+    status: 'in_progress' as const,
+    priority: 'medium' as const,
+    owner: null,
+    labels: [],
+    milestone_ref: null,
+    body: 'Epic body',
+    filePath: '/tmp/epic.md',
+    created_at: '2026-01-01T00:00:00Z',
+    updated_at: '2026-01-01T00:00:00Z',
+    resolvedStories: stories,
+    resolvedMilestone: undefined,
+    ...overrides,
+  } as ResolvedEpic;
+}
+
+function makeTree(overrides: Partial<ResolvedTree> = {}): ResolvedTree {
+  return {
+    stories: [],
+    epics: [],
+    milestones: [],
+    roadmaps: [],
+    prds: [],
+    errors: [],
+    ...overrides,
+  };
+}
+
+describe('auditTree', () => {
+  describe('stale detection', () => {
+    it('detects stale stories (old updated_at, todo status)', () => {
+      const oldDate = new Date();
+      oldDate.setDate(oldDate.getDate() - 120);
+      const tree = makeTree({
+        stories: [
+          makeStory({ updated_at: oldDate.toISOString(), status: 'todo' }),
+          makeStory({ updated_at: new Date().toISOString(), status: 'todo' }),
+        ] as ResolvedTree['stories'],
+      });
+      const report = auditTree(tree);
+      expect(report.stale).toHaveLength(1);
+    });
+
+    it('does not flag done stories as stale', () => {
+      const oldDate = new Date();
+      oldDate.setDate(oldDate.getDate() - 120);
+      const tree = makeTree({
+        stories: [
+          makeStory({ updated_at: oldDate.toISOString(), status: 'done' }),
+        ] as ResolvedTree['stories'],
+      });
+      const report = auditTree(tree);
+      expect(report.stale).toHaveLength(0);
+    });
+
+    it('respects custom staleDays', () => {
+      const date = new Date();
+      date.setDate(date.getDate() - 40);
+      const tree = makeTree({
+        stories: [
+          makeStory({ updated_at: date.toISOString(), status: 'todo' }),
+        ] as ResolvedTree['stories'],
+      });
+      expect(auditTree(tree, { staleDays: 30 }).stale).toHaveLength(1);
+      expect(auditTree(tree, { staleDays: 60 }).stale).toHaveLength(0);
+    });
+  });
+
+  describe('orphan detection', () => {
+    it('detects stories without epic_ref', () => {
+      const tree = makeTree({
+        stories: [
+          makeStory({ epic_ref: null }),
+          makeStory({ epic_ref: { id: 'e-1' } }),
+        ] as ResolvedTree['stories'],
+      });
+      const report = auditTree(tree);
+      expect(report.orphans).toHaveLength(1);
+    });
+
+    it('does not flag done orphans', () => {
+      const tree = makeTree({
+        stories: [
+          makeStory({ epic_ref: null, status: 'done' }),
+        ] as ResolvedTree['stories'],
+      });
+      expect(auditTree(tree).orphans).toHaveLength(0);
+    });
+  });
+
+  describe('empty body detection', () => {
+    it('detects stories and epics with empty bodies', () => {
+      const tree = makeTree({
+        stories: [
+          makeStory({ body: '' }),
+          makeStory({ body: '   ' }),
+          makeStory({ body: 'has content' }),
+        ] as ResolvedTree['stories'],
+        epics: [makeEpic([], { body: '' })],
+      });
+      const report = auditTree(tree);
+      expect(report.emptyBodies).toHaveLength(3);
+    });
+  });
+
+  describe('zombie epic detection', () => {
+    it('detects epics where all stories are done but epic is not', () => {
+      const doneStories = [
+        makeStory({ status: 'done' }),
+        makeStory({ status: 'cancelled' }),
+      ];
+      const tree = makeTree({
+        epics: [
+          makeEpic(doneStories, { status: 'in_progress' }),
+          makeEpic([makeStory({ status: 'done' })], { status: 'done' }),
+        ],
+      });
+      const report = auditTree(tree);
+      expect(report.zombieEpics).toHaveLength(1);
+    });
+
+    it('does not flag epics with no stories', () => {
+      const tree = makeTree({
+        epics: [makeEpic([], { status: 'todo' })],
+      });
+      expect(auditTree(tree).zombieEpics).toHaveLength(0);
+    });
+  });
+
+  describe('duplicate detection', () => {
+    it('detects similar titles', () => {
+      const tree = makeTree({
+        stories: [
+          makeStory({ title: 'Add user authentication module' }),
+          makeStory({ title: 'Add user authentication modules' }),
+        ] as ResolvedTree['stories'],
+      });
+      const report = auditTree(tree);
+      expect(report.duplicates.length).toBeGreaterThanOrEqual(1);
+      expect(report.duplicates[0].similarity).toBeGreaterThanOrEqual(0.85);
+    });
+
+    it('does not flag dissimilar titles', () => {
+      const tree = makeTree({
+        stories: [
+          makeStory({ title: 'Add authentication' }),
+          makeStory({ title: 'Fix database migration' }),
+        ] as ResolvedTree['stories'],
+      });
+      expect(auditTree(tree).duplicates).toHaveLength(0);
+    });
+  });
+
+  it('computes summary correctly', () => {
+    const tree = makeTree({
+      stories: [
+        makeStory({ epic_ref: null, body: '' }),
+      ] as ResolvedTree['stories'],
+      milestones: [],
+    });
+    const report = auditTree(tree);
+    expect(report.summary.total).toBe(1);
+    expect(report.summary.issues).toBeGreaterThanOrEqual(2); // orphan + empty body
+  });
+});

--- a/packages/core/src/analytics/audit.ts
+++ b/packages/core/src/analytics/audit.ts
@@ -1,0 +1,225 @@
+import type {
+  ResolvedEpic,
+  ResolvedStory,
+  ResolvedTree,
+} from '../resolver/types.js';
+
+export interface AuditConfig {
+  staleDays: number;
+}
+
+export interface AuditItem {
+  id: string;
+  title: string;
+  type: string;
+  filePath: string;
+  reason: string;
+}
+
+export interface DuplicatePair {
+  a: { id: string; title: string; filePath: string };
+  b: { id: string; title: string; filePath: string };
+  similarity: number;
+}
+
+export interface AuditReport {
+  stale: AuditItem[];
+  orphans: AuditItem[];
+  emptyBodies: AuditItem[];
+  zombieEpics: AuditItem[];
+  duplicates: DuplicatePair[];
+  summary: { total: number; issues: number };
+}
+
+const DEFAULT_CONFIG: AuditConfig = { staleDays: 90 };
+const DONE_STATUSES = new Set(['done', 'cancelled']);
+
+function daysBetween(a: Date, b: Date): number {
+  return Math.abs(a.getTime() - b.getTime()) / (1000 * 60 * 60 * 24);
+}
+
+function levenshtein(a: string, b: string): number {
+  const m = a.length;
+  const n = b.length;
+  if (m === 0) return n;
+  if (n === 0) return m;
+
+  const dp: number[][] = Array.from({ length: m + 1 }, () =>
+    Array.from({ length: n + 1 }, () => 0),
+  );
+
+  for (let i = 0; i <= m; i++) dp[i][0] = i;
+  for (let j = 0; j <= n; j++) dp[0][j] = j;
+
+  for (let i = 1; i <= m; i++) {
+    for (let j = 1; j <= n; j++) {
+      const cost = a[i - 1] === b[j - 1] ? 0 : 1;
+      dp[i][j] = Math.min(
+        dp[i - 1][j] + 1,
+        dp[i][j - 1] + 1,
+        dp[i - 1][j - 1] + cost,
+      );
+    }
+  }
+
+  return dp[m][n];
+}
+
+function normalizeTitle(title: string): string {
+  return title
+    .toLowerCase()
+    .replace(/[^a-z0-9\s]/g, '')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+function findStale(
+  stories: ResolvedStory[],
+  now: Date,
+  staleDays: number,
+): AuditItem[] {
+  return stories
+    .filter((s) => {
+      if (DONE_STATUSES.has(s.status)) return false;
+      if (s.status !== 'todo' && s.status !== 'backlog') return false;
+      const updated = s.updated_at ? new Date(s.updated_at) : null;
+      if (!updated) return true; // no date = stale
+      return daysBetween(now, updated) > staleDays;
+    })
+    .map((s) => {
+      const days = s.updated_at
+        ? Math.round(daysBetween(now, new Date(s.updated_at)))
+        : -1;
+      return {
+        id: s.id,
+        title: s.title,
+        type: 'story',
+        filePath: s.filePath,
+        reason: days >= 0 ? `${days} days since last update` : 'no update date',
+      };
+    });
+}
+
+function findOrphans(stories: ResolvedStory[]): AuditItem[] {
+  return stories
+    .filter((s) => s.epic_ref == null && !DONE_STATUSES.has(s.status))
+    .map((s) => ({
+      id: s.id,
+      title: s.title,
+      type: 'story',
+      filePath: s.filePath,
+      reason: 'no epic link',
+    }));
+}
+
+function findEmptyBodies(tree: ResolvedTree): AuditItem[] {
+  const items: AuditItem[] = [];
+  for (const s of tree.stories) {
+    if (s.body.trim().length === 0 && !DONE_STATUSES.has(s.status)) {
+      items.push({
+        id: s.id,
+        title: s.title,
+        type: 'story',
+        filePath: s.filePath,
+        reason: 'empty body',
+      });
+    }
+  }
+  for (const e of tree.epics) {
+    if (e.body.trim().length === 0 && !DONE_STATUSES.has(e.status)) {
+      items.push({
+        id: e.id,
+        title: e.title,
+        type: 'epic',
+        filePath: e.filePath,
+        reason: 'empty body',
+      });
+    }
+  }
+  return items;
+}
+
+function findZombieEpics(epics: ResolvedEpic[]): AuditItem[] {
+  return epics
+    .filter((e) => {
+      if (DONE_STATUSES.has(e.status)) return false;
+      if (e.resolvedStories.length === 0) return false;
+      return e.resolvedStories.every((s) => DONE_STATUSES.has(s.status));
+    })
+    .map((e) => ({
+      id: e.id,
+      title: e.title,
+      type: 'epic',
+      filePath: e.filePath,
+      reason: 'all stories done but epic is not',
+    }));
+}
+
+function findDuplicates(tree: ResolvedTree): DuplicatePair[] {
+  const entities = [
+    ...tree.stories.map((s) => ({
+      id: s.id,
+      title: s.title,
+      filePath: s.filePath,
+      norm: normalizeTitle(s.title),
+    })),
+    ...tree.epics.map((e) => ({
+      id: e.id,
+      title: e.title,
+      filePath: e.filePath,
+      norm: normalizeTitle(e.title),
+    })),
+  ];
+
+  const pairs: DuplicatePair[] = [];
+  for (let i = 0; i < entities.length; i++) {
+    for (let j = i + 1; j < entities.length; j++) {
+      const a = entities[i];
+      const b = entities[j];
+      const maxLen = Math.max(a.norm.length, b.norm.length);
+      if (maxLen === 0) continue;
+      const dist = levenshtein(a.norm, b.norm);
+      const similarity = 1 - dist / maxLen;
+      if (similarity >= 0.85) {
+        pairs.push({
+          a: { id: a.id, title: a.title, filePath: a.filePath },
+          b: { id: b.id, title: b.title, filePath: b.filePath },
+          similarity,
+        });
+      }
+    }
+  }
+  return pairs.sort((a, b) => b.similarity - a.similarity);
+}
+
+export function auditTree(
+  tree: ResolvedTree,
+  config?: Partial<AuditConfig>,
+): AuditReport {
+  const cfg = { ...DEFAULT_CONFIG, ...config };
+  const now = new Date();
+
+  const stale = findStale(tree.stories, now, cfg.staleDays);
+  const orphans = findOrphans(tree.stories);
+  const emptyBodies = findEmptyBodies(tree);
+  const zombieEpics = findZombieEpics(tree.epics);
+  const duplicates = findDuplicates(tree);
+
+  const total =
+    tree.stories.length + tree.epics.length + tree.milestones.length;
+  const issues =
+    stale.length +
+    orphans.length +
+    emptyBodies.length +
+    zombieEpics.length +
+    duplicates.length;
+
+  return {
+    stale,
+    orphans,
+    emptyBodies,
+    zombieEpics,
+    duplicates,
+    summary: { total, issues },
+  };
+}

--- a/packages/core/src/analytics/graph-data.test.ts
+++ b/packages/core/src/analytics/graph-data.test.ts
@@ -1,0 +1,182 @@
+import { describe, expect, it } from 'vitest';
+import type {
+  ResolvedEpic,
+  ResolvedMilestone,
+  ResolvedTree,
+} from '../resolver/types.js';
+import { buildGraphData } from './graph-data.js';
+
+function makeTree(overrides: Partial<ResolvedTree> = {}): ResolvedTree {
+  return {
+    stories: [],
+    epics: [],
+    milestones: [],
+    roadmaps: [],
+    prds: [],
+    sprints: [],
+    errors: [],
+    ...overrides,
+  };
+}
+
+describe('buildGraphData', () => {
+  it('returns empty graph for empty tree', () => {
+    const result = buildGraphData(makeTree());
+    expect(result.nodes).toHaveLength(0);
+    expect(result.edges).toHaveLength(0);
+  });
+
+  it('creates nodes for all entity types', () => {
+    const tree = makeTree({
+      stories: [
+        {
+          type: 'story',
+          id: 's1',
+          title: 'Story',
+          status: 'todo',
+          priority: 'medium',
+          labels: [],
+          assignee: null,
+          estimate: null,
+          epic_ref: null,
+          body: '',
+          filePath: '/s.md',
+          created_at: '',
+          updated_at: '',
+        },
+      ] as ResolvedTree['stories'],
+      epics: [
+        {
+          type: 'epic',
+          id: 'e1',
+          title: 'Epic',
+          status: 'in_progress',
+          priority: 'high',
+          labels: [],
+          owner: null,
+          milestone_ref: null,
+          body: '',
+          filePath: '/e.md',
+          created_at: '',
+          updated_at: '',
+          resolvedStories: [],
+          resolvedMilestone: undefined,
+        },
+      ] as ResolvedEpic[],
+      milestones: [
+        {
+          type: 'milestone',
+          id: 'm1',
+          title: 'MS',
+          status: 'todo',
+          body: '',
+          filePath: '/m.md',
+          created_at: '',
+          updated_at: '',
+          resolvedEpics: [],
+        },
+      ] as ResolvedMilestone[],
+    });
+
+    const result = buildGraphData(tree);
+    expect(result.nodes).toHaveLength(3);
+    expect(result.nodes.map((n) => n.type)).toEqual([
+      'story',
+      'epic',
+      'milestone',
+    ]);
+  });
+
+  it('creates edges for story→epic and epic→milestone refs', () => {
+    const ms = {
+      type: 'milestone' as const,
+      id: 'm1',
+      title: 'MS',
+      status: 'todo' as const,
+      body: '',
+      filePath: '/m.md',
+      created_at: '',
+      updated_at: '',
+      resolvedEpics: [],
+    };
+
+    const epic = {
+      type: 'epic' as const,
+      id: 'e1',
+      title: 'Epic',
+      status: 'in_progress' as const,
+      priority: 'high' as const,
+      labels: [],
+      owner: null,
+      milestone_ref: { id: 'm1' },
+      body: '',
+      filePath: '/e.md',
+      created_at: '',
+      updated_at: '',
+      resolvedStories: [],
+      resolvedMilestone: ms,
+    };
+
+    const tree = makeTree({
+      stories: [
+        {
+          type: 'story',
+          id: 's1',
+          title: 'Story',
+          status: 'todo',
+          priority: 'medium',
+          labels: [],
+          assignee: null,
+          estimate: null,
+          epic_ref: { id: 'e1' },
+          body: '',
+          filePath: '/s.md',
+          created_at: '',
+          updated_at: '',
+          resolvedEpic: epic,
+        },
+      ] as ResolvedTree['stories'],
+      epics: [epic] as ResolvedEpic[],
+      milestones: [ms] as ResolvedMilestone[],
+    });
+
+    const result = buildGraphData(tree);
+    expect(result.edges).toHaveLength(2);
+    expect(result.edges).toContainEqual({
+      source: 's1',
+      target: 'e1',
+      label: 'epic_ref',
+    });
+    expect(result.edges).toContainEqual({
+      source: 'e1',
+      target: 'm1',
+      label: 'milestone_ref',
+    });
+  });
+
+  it('does not create edges for unresolved refs', () => {
+    const tree = makeTree({
+      stories: [
+        {
+          type: 'story',
+          id: 's1',
+          title: 'Orphan',
+          status: 'todo',
+          priority: 'medium',
+          labels: [],
+          assignee: null,
+          estimate: null,
+          epic_ref: null,
+          body: '',
+          filePath: '/s.md',
+          created_at: '',
+          updated_at: '',
+        },
+      ] as ResolvedTree['stories'],
+    });
+
+    const result = buildGraphData(tree);
+    expect(result.nodes).toHaveLength(1);
+    expect(result.edges).toHaveLength(0);
+  });
+});

--- a/packages/core/src/analytics/graph-data.ts
+++ b/packages/core/src/analytics/graph-data.ts
@@ -1,0 +1,83 @@
+import type { ResolvedTree } from '../resolver/types.js';
+
+export interface GraphNode {
+  id: string;
+  title: string;
+  type: string;
+  status: string;
+}
+
+export interface GraphEdge {
+  source: string;
+  target: string;
+  label: string;
+}
+
+export interface GraphData {
+  nodes: GraphNode[];
+  edges: GraphEdge[];
+}
+
+export function buildGraphData(tree: ResolvedTree): GraphData {
+  const nodes: GraphNode[] = [];
+  const edges: GraphEdge[] = [];
+
+  for (const s of tree.stories) {
+    nodes.push({ id: s.id, title: s.title, type: 'story', status: s.status });
+    if (s.resolvedEpic) {
+      edges.push({
+        source: s.id,
+        target: s.resolvedEpic.id,
+        label: 'epic_ref',
+      });
+    }
+  }
+
+  for (const e of tree.epics) {
+    nodes.push({ id: e.id, title: e.title, type: 'epic', status: e.status });
+    if (e.resolvedMilestone) {
+      edges.push({
+        source: e.id,
+        target: e.resolvedMilestone.id,
+        label: 'milestone_ref',
+      });
+    }
+  }
+
+  for (const m of tree.milestones) {
+    nodes.push({
+      id: m.id,
+      title: m.title,
+      type: 'milestone',
+      status: m.status,
+    });
+  }
+
+  for (const r of tree.roadmaps) {
+    nodes.push({ id: r.id, title: r.title, type: 'roadmap', status: '' });
+    for (const ms of r.resolvedMilestones) {
+      edges.push({ source: r.id, target: ms.id, label: 'milestone' });
+    }
+  }
+
+  for (const p of tree.prds) {
+    nodes.push({ id: p.id, title: p.title, type: 'prd', status: p.status });
+    for (const ep of p.resolvedEpics) {
+      edges.push({ source: p.id, target: ep.id, label: 'epic_ref' });
+    }
+  }
+
+  for (const sp of tree.sprints ?? []) {
+    nodes.push({
+      id: sp.id,
+      title: sp.title,
+      type: 'sprint',
+      status: sp.status,
+    });
+    for (const story of sp.resolvedStories) {
+      edges.push({ source: sp.id, target: story.id, label: 'sprint_story' });
+    }
+  }
+
+  return { nodes, edges };
+}

--- a/packages/core/src/analytics/progress.test.ts
+++ b/packages/core/src/analytics/progress.test.ts
@@ -160,6 +160,7 @@ describe('computeProjectProgress', () => {
       ],
       roadmaps: [],
       prds: [],
+      sprints: [],
       errors: [],
     };
 
@@ -180,6 +181,7 @@ describe('computeProjectProgress', () => {
       milestones: [],
       roadmaps: [],
       prds: [],
+      sprints: [],
       errors: [],
     };
     const result = computeProjectProgress(tree);

--- a/packages/core/src/analytics/progress.test.ts
+++ b/packages/core/src/analytics/progress.test.ts
@@ -1,0 +1,190 @@
+import { describe, expect, it } from 'vitest';
+import type {
+  ResolvedEpic,
+  ResolvedMilestone,
+  ResolvedTree,
+} from '../resolver/types.js';
+import {
+  computeEpicProgress,
+  computeMilestoneProgress,
+  computeProjectProgress,
+} from './progress.js';
+
+function makeStory(overrides: Record<string, unknown> = {}) {
+  return {
+    type: 'story' as const,
+    id: `s-${Math.random().toString(36).slice(2, 8)}`,
+    title: 'Test story',
+    status: 'todo' as const,
+    priority: 'medium' as const,
+    assignee: null,
+    labels: [],
+    estimate: null,
+    epic_ref: null,
+    body: '',
+    filePath: '/tmp/test.md',
+    created_at: '2026-01-01T00:00:00Z',
+    updated_at: '2026-01-01T00:00:00Z',
+    ...overrides,
+  };
+}
+
+function makeEpic(
+  stories: ReturnType<typeof makeStory>[],
+  overrides: Record<string, unknown> = {},
+): ResolvedEpic {
+  return {
+    type: 'epic' as const,
+    id: `e-${Math.random().toString(36).slice(2, 8)}`,
+    title: 'Test epic',
+    status: 'in_progress' as const,
+    priority: 'medium' as const,
+    owner: null,
+    labels: [],
+    milestone_ref: null,
+    body: '',
+    filePath: '/tmp/epic.md',
+    created_at: '2026-01-01T00:00:00Z',
+    updated_at: '2026-01-01T00:00:00Z',
+    resolvedStories: stories,
+    resolvedMilestone: undefined,
+    ...overrides,
+  } as ResolvedEpic;
+}
+
+describe('computeEpicProgress', () => {
+  it('returns zero progress for epic with no stories', () => {
+    const epic = makeEpic([]);
+    const result = computeEpicProgress(epic);
+    expect(result.total).toBe(0);
+    expect(result.done).toBe(0);
+    expect(result.progress).toBe(0);
+  });
+
+  it('computes progress from mixed statuses', () => {
+    const stories = [
+      makeStory({ status: 'done' }),
+      makeStory({ status: 'done' }),
+      makeStory({ status: 'in_progress' }),
+      makeStory({ status: 'todo' }),
+    ];
+    const epic = makeEpic(stories);
+    const result = computeEpicProgress(epic);
+    expect(result.total).toBe(4);
+    expect(result.done).toBe(2);
+    expect(result.inProgress).toBe(1);
+    expect(result.progress).toBe(0.5);
+  });
+
+  it('counts cancelled as done', () => {
+    const stories = [
+      makeStory({ status: 'cancelled' }),
+      makeStory({ status: 'done' }),
+    ];
+    const result = computeEpicProgress(makeEpic(stories));
+    expect(result.done).toBe(2);
+    expect(result.progress).toBe(1);
+  });
+
+  it('counts blocked stories (todo/backlog with no assignee)', () => {
+    const stories = [
+      makeStory({ status: 'todo', assignee: null }),
+      makeStory({ status: 'todo', assignee: 'alice' }),
+      makeStory({ status: 'backlog', assignee: null }),
+    ];
+    const result = computeEpicProgress(makeEpic(stories));
+    expect(result.blocked).toBe(2);
+  });
+});
+
+describe('computeMilestoneProgress', () => {
+  it('aggregates across linked epics', () => {
+    const ms: ResolvedMilestone = {
+      type: 'milestone',
+      id: 'ms-1',
+      title: 'v1.0',
+      status: 'in_progress',
+      body: '',
+      filePath: '/tmp/ms.md',
+      created_at: '2026-01-01T00:00:00Z',
+      updated_at: '2026-01-01T00:00:00Z',
+      resolvedEpics: [],
+    } as ResolvedMilestone;
+
+    const epics: ResolvedEpic[] = [
+      makeEpic([makeStory({ status: 'done' }), makeStory({ status: 'todo' })], {
+        milestone_ref: { id: 'ms-1' },
+      }),
+      makeEpic([makeStory({ status: 'done' }), makeStory({ status: 'done' })], {
+        milestone_ref: { id: 'ms-1' },
+      }),
+      makeEpic([makeStory({ status: 'todo' })], {
+        milestone_ref: { id: 'other' },
+      }),
+    ];
+
+    const result = computeMilestoneProgress(ms, epics);
+    expect(result.total).toBe(4);
+    expect(result.done).toBe(3);
+    expect(result.progress).toBe(0.75);
+    expect(result.epics).toHaveLength(2);
+  });
+});
+
+describe('computeProjectProgress', () => {
+  it('separates milestone-linked and orphan epics', () => {
+    const tree: ResolvedTree = {
+      stories: [],
+      epics: [
+        makeEpic([makeStory({ status: 'done' })], {
+          id: 'linked',
+          milestone_ref: { id: 'ms-1' },
+        }),
+        makeEpic([makeStory({ status: 'todo' })], {
+          id: 'orphan',
+          milestone_ref: null,
+        }),
+      ],
+      milestones: [
+        {
+          type: 'milestone',
+          id: 'ms-1',
+          title: 'v1.0',
+          status: 'in_progress',
+          body: '',
+          filePath: '/tmp/ms.md',
+          created_at: '2026-01-01T00:00:00Z',
+          updated_at: '2026-01-01T00:00:00Z',
+          resolvedEpics: [],
+        } as ResolvedMilestone,
+      ],
+      roadmaps: [],
+      prds: [],
+      errors: [],
+    };
+
+    const result = computeProjectProgress(tree);
+    expect(result.milestones).toHaveLength(1);
+    expect(result.milestones[0].done).toBe(1);
+    expect(result.orphanEpics).toHaveLength(1);
+    expect(result.orphanEpics[0].epicId).toBe('orphan');
+    expect(result.overall.total).toBe(2);
+    expect(result.overall.done).toBe(1);
+    expect(result.overall.progress).toBe(0.5);
+  });
+
+  it('handles empty tree', () => {
+    const tree: ResolvedTree = {
+      stories: [],
+      epics: [],
+      milestones: [],
+      roadmaps: [],
+      prds: [],
+      errors: [],
+    };
+    const result = computeProjectProgress(tree);
+    expect(result.milestones).toHaveLength(0);
+    expect(result.orphanEpics).toHaveLength(0);
+    expect(result.overall.progress).toBe(0);
+  });
+});

--- a/packages/core/src/analytics/progress.ts
+++ b/packages/core/src/analytics/progress.ts
@@ -1,0 +1,117 @@
+import type {
+  ResolvedEpic,
+  ResolvedMilestone,
+  ResolvedTree,
+} from '../resolver/types.js';
+
+export interface EpicProgress {
+  epicId: string;
+  title: string;
+  status: string;
+  total: number;
+  done: number;
+  inProgress: number;
+  blocked: number;
+  progress: number; // 0–1
+}
+
+export interface MilestoneProgress {
+  milestoneId: string;
+  title: string;
+  targetDate?: string;
+  epics: EpicProgress[];
+  total: number;
+  done: number;
+  progress: number; // 0–1
+}
+
+export interface ProjectProgress {
+  milestones: MilestoneProgress[];
+  orphanEpics: EpicProgress[];
+  overall: { total: number; done: number; progress: number };
+}
+
+const DONE_STATUSES = new Set(['done', 'cancelled']);
+const ACTIVE_STATUSES = new Set(['in_progress', 'in_review']);
+
+export function computeEpicProgress(epic: ResolvedEpic): EpicProgress {
+  const stories = epic.resolvedStories;
+  const total = stories.length;
+  const done = stories.filter((s) => DONE_STATUSES.has(s.status)).length;
+  const inProgress = stories.filter((s) =>
+    ACTIVE_STATUSES.has(s.status),
+  ).length;
+  const blocked = stories.filter(
+    (s) =>
+      !DONE_STATUSES.has(s.status) &&
+      !ACTIVE_STATUSES.has(s.status) &&
+      s.assignee == null,
+  ).length;
+
+  return {
+    epicId: epic.id,
+    title: epic.title,
+    status: epic.status,
+    total,
+    done,
+    inProgress,
+    blocked,
+    progress: total > 0 ? done / total : 0,
+  };
+}
+
+export function computeMilestoneProgress(
+  milestone: ResolvedMilestone,
+  allEpics: ResolvedEpic[],
+): MilestoneProgress {
+  const linkedEpics = allEpics.filter(
+    (e) => e.milestone_ref?.id === milestone.id,
+  );
+  const epics = linkedEpics.map(computeEpicProgress);
+  const total = epics.reduce((sum, e) => sum + e.total, 0);
+  const done = epics.reduce((sum, e) => sum + e.done, 0);
+
+  return {
+    milestoneId: milestone.id,
+    title: milestone.title,
+    targetDate: milestone.target_date,
+    epics,
+    total,
+    done,
+    progress: total > 0 ? done / total : 0,
+  };
+}
+
+export function computeProjectProgress(tree: ResolvedTree): ProjectProgress {
+  const milestoneIds = new Set(tree.milestones.map((m) => m.id));
+  const linkedEpicIds = new Set(
+    tree.epics
+      .filter((e) => e.milestone_ref && milestoneIds.has(e.milestone_ref.id))
+      .map((e) => e.id),
+  );
+
+  const milestones = tree.milestones.map((ms) =>
+    computeMilestoneProgress(ms, tree.epics),
+  );
+
+  const orphanEpics = tree.epics
+    .filter((e) => !linkedEpicIds.has(e.id))
+    .map(computeEpicProgress);
+
+  const allTotal =
+    milestones.reduce((s, m) => s + m.total, 0) +
+    orphanEpics.reduce((s, e) => s + e.total, 0);
+  const allDone =
+    milestones.reduce((s, m) => s + m.done, 0) +
+    orphanEpics.reduce((s, e) => s + e.done, 0);
+
+  return {
+    milestones,
+    orphanEpics,
+    overall: {
+      total: allTotal,
+      done: allDone,
+      progress: allTotal > 0 ? allDone / allTotal : 0,
+    },
+  };
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -15,6 +15,29 @@ export type {
 } from './adapter.js';
 export { isSyncAdapter } from './adapter.js';
 export type {
+  AuditConfig,
+  AuditItem,
+  AuditReport,
+  DuplicatePair,
+} from './analytics/audit.js';
+export { auditTree } from './analytics/audit.js';
+export type {
+  GraphData,
+  GraphEdge,
+  GraphNode,
+} from './analytics/graph-data.js';
+export { buildGraphData } from './analytics/graph-data.js';
+export type {
+  EpicProgress,
+  MilestoneProgress,
+  ProjectProgress,
+} from './analytics/progress.js';
+export {
+  computeEpicProgress,
+  computeMilestoneProgress,
+  computeProjectProgress,
+} from './analytics/progress.js';
+export type {
   ArchiveOptions,
   ArchiveResult,
 } from './archiver/index.js';
@@ -56,6 +79,7 @@ export type {
   ResolvedMilestone,
   ResolvedPrd,
   ResolvedRoadmap,
+  ResolvedSprint,
   ResolvedStory,
   ResolvedTree,
 } from './resolver/index.js';
@@ -71,6 +95,7 @@ export type {
   CreateEpicOptions,
   CreateMilestoneOptions,
   CreateResult,
+  CreateSprintOptions,
   CreateStoryOptions,
   FieldAssignment,
   MoveOptions,
@@ -80,6 +105,7 @@ export {
   applyAssignments,
   createEpic,
   createMilestone,
+  createSprint,
   createStory,
   moveStory,
   parseAssignment,

--- a/packages/core/src/parser/parse-file.ts
+++ b/packages/core/src/parser/parse-file.ts
@@ -10,6 +10,7 @@ import {
   milestoneSchema,
   prdSchema,
   roadmapSchema,
+  sprintSchema,
   storySchema,
 } from '../schemas/index.js';
 
@@ -109,6 +110,10 @@ function getSchema(type: string, extensions?: SchemaExtensions) {
       return extensions
         ? extendEntitySchema(prdSchema, extensions, 'prd')
         : prdSchema;
+    case 'sprint':
+      return extensions
+        ? extendEntitySchema(sprintSchema, extensions, 'sprint')
+        : sprintSchema;
     default:
       return null;
   }

--- a/packages/core/src/parser/parse-tree.ts
+++ b/packages/core/src/parser/parse-tree.ts
@@ -52,6 +52,7 @@ export async function parseTree(metaDir: string): Promise<Result<MetaTree>> {
       milestones: [],
       roadmaps: [],
       prds: [],
+      sprints: [],
       errors: [],
     };
 
@@ -88,6 +89,9 @@ export async function parseTree(metaDir: string): Promise<Result<MetaTree>> {
           break;
         case 'prd':
           tree.prds.push(entity);
+          break;
+        case 'sprint':
+          tree.sprints.push(entity);
           break;
       }
     }

--- a/packages/core/src/parser/types.ts
+++ b/packages/core/src/parser/types.ts
@@ -4,6 +4,7 @@ import type {
   ParsedEntity,
   Prd,
   Roadmap,
+  Sprint,
   Story,
 } from '../schemas/index.js';
 
@@ -13,6 +14,7 @@ export interface MetaTree {
   milestones: Milestone[];
   roadmaps: Roadmap[];
   prds: Prd[];
+  sprints: Sprint[];
   errors: ParseError[];
 }
 

--- a/packages/core/src/quality/score.test.ts
+++ b/packages/core/src/quality/score.test.ts
@@ -46,6 +46,7 @@ function makeTree(
     milestones: [],
     roadmaps: [],
     prds: [],
+    sprints: [],
     errors: [],
   };
 }

--- a/packages/core/src/query/filter.ts
+++ b/packages/core/src/query/filter.ts
@@ -21,6 +21,7 @@ export function filterEntities(
     ...tree.milestones,
     ...tree.roadmaps,
     ...tree.prds,
+    ...(tree.sprints ?? []),
   ];
 
   if (filter.type && filter.type.length > 0) {

--- a/packages/core/src/resolver/graph.ts
+++ b/packages/core/src/resolver/graph.ts
@@ -10,6 +10,7 @@ export function buildDependencyGraph(tree: ResolvedTree): DependencyGraph {
   for (const m of tree.milestones) adjacency.set(m.id, []);
   for (const r of tree.roadmaps) adjacency.set(r.id, []);
   for (const p of tree.prds) adjacency.set(p.id, []);
+  for (const sp of tree.sprints ?? []) adjacency.set(sp.id, []);
 
   // Add edges: child → parent (story → epic, epic → milestone, etc.)
   for (const s of tree.stories) {

--- a/packages/core/src/resolver/index.ts
+++ b/packages/core/src/resolver/index.ts
@@ -6,6 +6,7 @@ export type {
   ResolvedMilestone,
   ResolvedPrd,
   ResolvedRoadmap,
+  ResolvedSprint,
   ResolvedStory,
   ResolvedTree,
 } from './types.js';

--- a/packages/core/src/resolver/resolve.ts
+++ b/packages/core/src/resolver/resolve.ts
@@ -6,6 +6,7 @@ import type {
   ResolvedMilestone,
   ResolvedPrd,
   ResolvedRoadmap,
+  ResolvedSprint,
   ResolvedStory,
   ResolvedTree,
 } from './types.js';
@@ -108,6 +109,26 @@ export function resolveRefs(tree: MetaTree): Result<ResolvedTree> {
     return { ...prd, resolvedEpics: resolvedEpicsList };
   });
 
+  // Resolve sprints
+  const storyMap = new Map(tree.stories.map((s) => [s.id, s]));
+  const resolvedSprints: ResolvedSprint[] = (tree.sprints ?? []).map(
+    (sprint) => {
+      const resolvedStoriesList: typeof tree.stories = [];
+      for (const ref of sprint.stories) {
+        const story = storyMap.get(ref.id);
+        if (story) {
+          resolvedStoriesList.push(story);
+        } else {
+          errors.push({
+            filePath: sprint.filePath,
+            message: `Sprint "${sprint.title}" references non-existent story "${ref.id}"`,
+          });
+        }
+      }
+      return { ...sprint, resolvedStories: resolvedStoriesList };
+    },
+  );
+
   return {
     ok: true,
     value: {
@@ -116,6 +137,7 @@ export function resolveRefs(tree: MetaTree): Result<ResolvedTree> {
       milestones: resolvedMilestones,
       roadmaps: resolvedRoadmaps,
       prds: resolvedPrds,
+      sprints: resolvedSprints,
       errors,
     },
   };

--- a/packages/core/src/resolver/resolver.test.ts
+++ b/packages/core/src/resolver/resolver.test.ts
@@ -153,6 +153,7 @@ describe('buildDependencyGraph', () => {
       milestones: [],
       roadmaps: [],
       prds: [],
+      sprints: [],
       errors: [],
     };
     const resolved = resolveRefs(tree);

--- a/packages/core/src/resolver/types.ts
+++ b/packages/core/src/resolver/types.ts
@@ -1,6 +1,13 @@
 import type { ParseError } from '../parser/types.js';
 import type { EntityId } from '../schemas/common.js';
-import type { Epic, Milestone, Prd, Roadmap, Story } from '../schemas/index.js';
+import type {
+  Epic,
+  Milestone,
+  Prd,
+  Roadmap,
+  Sprint,
+  Story,
+} from '../schemas/index.js';
 
 export interface ResolvedStory extends Story {
   resolvedEpic?: Epic;
@@ -23,12 +30,17 @@ export interface ResolvedPrd extends Prd {
   resolvedEpics: Epic[];
 }
 
+export interface ResolvedSprint extends Sprint {
+  resolvedStories: Story[];
+}
+
 export interface ResolvedTree {
   stories: ResolvedStory[];
   epics: ResolvedEpic[];
   milestones: ResolvedMilestone[];
   roadmaps: ResolvedRoadmap[];
   prds: ResolvedPrd[];
+  sprints: ResolvedSprint[];
   errors: ParseError[];
 }
 

--- a/packages/core/src/schemas/index.ts
+++ b/packages/core/src/schemas/index.ts
@@ -40,6 +40,8 @@ export type { Prd, PrdFrontmatter } from './prd.js';
 export { prdFrontmatterSchema, prdSchema } from './prd.js';
 export type { Roadmap } from './roadmap.js';
 export { roadmapSchema } from './roadmap.js';
+export type { Sprint, SprintFrontmatter } from './sprint.js';
+export { sprintFrontmatterSchema, sprintSchema } from './sprint.js';
 export type { Story, StoryFrontmatter } from './story.js';
 export { storyFrontmatterSchema, storySchema } from './story.js';
 
@@ -47,6 +49,7 @@ import type { Epic } from './epic.js';
 import type { Milestone } from './milestone.js';
 import type { Prd } from './prd.js';
 import type { Roadmap } from './roadmap.js';
+import type { Sprint } from './sprint.js';
 import type { Story } from './story.js';
 
-export type ParsedEntity = Story | Epic | Milestone | Roadmap | Prd;
+export type ParsedEntity = Story | Epic | Milestone | Roadmap | Prd | Sprint;

--- a/packages/core/src/schemas/sprint.ts
+++ b/packages/core/src/schemas/sprint.ts
@@ -1,0 +1,34 @@
+import { z } from 'zod';
+import {
+  entityIdSchema,
+  entityRefSchema,
+  gitHubSyncSchema,
+  gitLabSyncSchema,
+  jiraSyncSchema,
+  statusSchema,
+} from './common.js';
+
+export const sprintFrontmatterSchema = z.object({
+  type: z.literal('sprint'),
+  id: entityIdSchema,
+  title: z.string().min(1),
+  start_date: z.string(),
+  end_date: z.string(),
+  status: statusSchema,
+  stories: z.array(entityRefSchema).default([]),
+  capacity: z.number().optional(),
+  github: gitHubSyncSchema.optional(),
+  jira: jiraSyncSchema.optional(),
+  gitlab: gitLabSyncSchema.optional(),
+  created_at: z.string(),
+  updated_at: z.string(),
+});
+
+export type SprintFrontmatter = z.infer<typeof sprintFrontmatterSchema>;
+
+export const sprintSchema = sprintFrontmatterSchema.extend({
+  body: z.string(),
+  filePath: z.string(),
+});
+
+export type Sprint = z.infer<typeof sprintSchema>;

--- a/packages/core/src/validator/validator.test.ts
+++ b/packages/core/src/validator/validator.test.ts
@@ -85,6 +85,7 @@ describe('validateTree', () => {
       milestones: [],
       roadmaps: [],
       prds: [],
+      sprints: [],
       errors: [],
     };
 
@@ -131,6 +132,7 @@ describe('validateTree', () => {
       milestones: [],
       roadmaps: [],
       prds: [],
+      sprints: [],
       errors: [],
     };
 
@@ -173,6 +175,7 @@ describe('validateTree', () => {
       milestones: [],
       roadmaps: [],
       prds: [],
+      sprints: [],
       errors: [],
     };
 

--- a/packages/core/src/writer/create-entity.ts
+++ b/packages/core/src/writer/create-entity.ts
@@ -5,6 +5,7 @@ import type { ParsedEntity } from '../parser/types.js';
 import type { Priority, Result, Status } from '../schemas/common.js';
 import type { Epic } from '../schemas/epic.js';
 import type { Milestone } from '../schemas/milestone.js';
+import type { Sprint } from '../schemas/sprint.js';
 import type { Story } from '../schemas/story.js';
 import { toSlug } from './slug.js';
 import { writeFile } from './write-file.js';
@@ -59,6 +60,16 @@ export interface CreateMilestoneOptions {
   title: string;
   status?: Status;
   targetDate?: string;
+  body?: string;
+}
+
+export interface CreateSprintOptions {
+  title: string;
+  startDate: string;
+  endDate: string;
+  status?: Status;
+  storyIds?: string[];
+  capacity?: number;
   body?: string;
 }
 
@@ -195,6 +206,45 @@ export async function createMilestone(
     return {
       ok: false,
       error: new Error(`Failed to create milestone: ${err}`),
+    };
+  }
+}
+
+export async function createSprint(
+  metaDir: string,
+  options: CreateSprintOptions,
+): Promise<Result<CreateResult>> {
+  try {
+    const id = nanoid(12);
+    const slug = toSlug(options.title);
+    const now = new Date().toISOString();
+
+    const sprintDir = join(metaDir, 'sprints');
+    const filePath = await uniquePath(sprintDir, slug, '.md');
+
+    const sprint: Sprint = {
+      type: 'sprint',
+      id,
+      title: options.title,
+      start_date: options.startDate,
+      end_date: options.endDate,
+      status: options.status ?? 'todo',
+      stories: (options.storyIds ?? []).map((sid) => ({ id: sid })),
+      capacity: options.capacity,
+      body: options.body ?? '',
+      filePath,
+      created_at: now,
+      updated_at: now,
+    };
+
+    const result = await writeFile(sprint, filePath);
+    if (!result.ok) return result;
+
+    return { ok: true, value: { filePath, id, entity: sprint } };
+  } catch (err) {
+    return {
+      ok: false,
+      error: new Error(`Failed to create sprint: ${err}`),
     };
   }
 }

--- a/packages/core/src/writer/index.ts
+++ b/packages/core/src/writer/index.ts
@@ -2,9 +2,15 @@ export type {
   CreateEpicOptions,
   CreateMilestoneOptions,
   CreateResult,
+  CreateSprintOptions,
   CreateStoryOptions,
 } from './create-entity.js';
-export { createEpic, createMilestone, createStory } from './create-entity.js';
+export {
+  createEpic,
+  createMilestone,
+  createSprint,
+  createStory,
+} from './create-entity.js';
 export type { MoveOptions, MoveResult } from './move-entity.js';
 export { moveStory } from './move-entity.js';
 export { scaffoldMeta } from './scaffold.js';

--- a/packages/core/src/writer/scaffold.ts
+++ b/packages/core/src/writer/scaffold.ts
@@ -82,6 +82,7 @@ export async function scaffoldMeta(
         },
       ],
       prds: [],
+      sprints: [],
       errors: [],
     };
 

--- a/packages/core/src/writer/write-tree.ts
+++ b/packages/core/src/writer/write-tree.ts
@@ -13,6 +13,7 @@ export async function writeTree(
       ...tree.milestones,
       ...tree.roadmaps,
       ...tree.prds,
+      ...(tree.sprints ?? []),
     ];
 
     for (const entity of allEntities) {

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -39,6 +39,8 @@
     "@tanstack/react-query": "^5.60.0",
     "@tanstack/react-router": "^1.82.0",
     "@tanstack/react-virtual": "^3.13.23",
+    "d3-force": "^3.0.0",
+    "d3-selection": "^3.0.0",
     "hono": "^4.12.11",
     "react": "^18.3.0",
     "react-dom": "^18.3.0",
@@ -48,6 +50,8 @@
   "devDependencies": {
     "@playwright/test": "1.59.1",
     "@tailwindcss/vite": "^4.0.0",
+    "@types/d3-force": "^3.0.10",
+    "@types/d3-selection": "^3.0.11",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.1",

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -16,13 +16,16 @@ import { ToastProvider } from './components/Toast.js';
 import { TypeIcon } from './components/TypeIcon.js';
 import {
   type TreeResponse,
+  useProgress,
   useSyncStatus,
   useTree,
   useValidation,
 } from './lib/api.js';
 import { BoardView } from './routes/board.js';
 import { EntityEditor } from './routes/entity-editor.js';
+import { GraphView } from './routes/graph.js';
 import { RoadmapView } from './routes/roadmap.js';
+import { SprintView } from './routes/sprint.js';
 import { SyncDashboard } from './routes/sync-dashboard.js';
 import { TreeBrowser } from './routes/tree-browser.js';
 
@@ -34,8 +37,30 @@ const queryClient = new QueryClient({
 
 // --- Layout ---
 
+function MiniProgress({ ratio }: { ratio: number }) {
+  const pct = Math.round(ratio * 100);
+  const color =
+    ratio >= 0.75
+      ? 'bg-emerald-400'
+      : ratio >= 0.25
+        ? 'bg-yellow-400'
+        : 'bg-red-400';
+  return (
+    <span className="inline-flex items-center gap-1 ml-auto shrink-0">
+      <span className="w-12 h-1 bg-gray-700 rounded-full overflow-hidden">
+        <span
+          className={`block h-full rounded-full ${color}`}
+          style={{ width: `${pct}%` }}
+        />
+      </span>
+      <span className="text-[10px] text-gray-500 w-7 text-right">{pct}%</span>
+    </span>
+  );
+}
+
 function Sidebar() {
   const { data: tree } = useTree();
+  const { data: progress } = useProgress();
   const validation = useValidation();
   const [validating, setValidating] = useState(false);
 
@@ -43,6 +68,8 @@ function Sidebar() {
     { to: '/', label: 'Tree Browser', icon: '🌳' },
     { to: '/board', label: 'Board', icon: '📋' },
     { to: '/roadmap', label: 'Roadmap', icon: '🗺️' },
+    { to: '/sprint', label: 'Sprints', icon: '🏃' },
+    { to: '/graph', label: 'Graph', icon: '🔗' },
     { to: '/sync', label: 'Sync Dashboard', icon: '🔄' },
   ];
 
@@ -92,17 +119,38 @@ function Sidebar() {
                 if (!items?.length) return null;
                 return (
                   <div key={key} className="mb-2">
-                    {items.map((e) => (
-                      <Link
-                        key={e.id}
-                        to="/entity/$id"
-                        params={{ id: e.id }}
-                        className="flex items-center gap-1.5 px-3 py-1 rounded text-xs hover:bg-gray-800 truncate [&.active]:bg-gray-700"
-                      >
-                        <TypeIcon type={e.type} />
-                        <span className="truncate">{e.title}</span>
-                      </Link>
-                    ))}
+                    {items.map((e) => {
+                      const ep =
+                        e.type === 'epic'
+                          ? (progress?.milestones
+                              .flatMap((m) => m.epics)
+                              .find((p) => p.epicId === e.id) ??
+                            progress?.orphanEpics.find(
+                              (p) => p.epicId === e.id,
+                            ))
+                          : undefined;
+                      const ms =
+                        e.type === 'milestone'
+                          ? progress?.milestones.find(
+                              (m) => m.milestoneId === e.id,
+                            )
+                          : undefined;
+                      const ratio = ep?.progress ?? ms?.progress;
+                      return (
+                        <Link
+                          key={e.id}
+                          to="/entity/$id"
+                          params={{ id: e.id }}
+                          className="flex items-center gap-1.5 px-3 py-1 rounded text-xs hover:bg-gray-800 [&.active]:bg-gray-700"
+                        >
+                          <TypeIcon type={e.type} />
+                          <span className="truncate">{e.title}</span>
+                          {ratio != null && ratio > 0 && (
+                            <MiniProgress ratio={ratio} />
+                          )}
+                        </Link>
+                      );
+                    })}
                   </div>
                 );
               },
@@ -149,9 +197,13 @@ function TopBar() {
         ? [{ label: 'Roadmap', to: '/roadmap' }]
         : path === '/board'
           ? [{ label: 'Board', to: '/board' }]
-          : path === '/sync'
-            ? [{ label: 'Sync', to: '/sync' }]
-            : [{ label: 'Tree', to: '/' }]),
+          : path === '/sprint'
+            ? [{ label: 'Sprints', to: '/sprint' }]
+            : path === '/graph'
+              ? [{ label: 'Graph', to: '/graph' }]
+              : path === '/sync'
+                ? [{ label: 'Sync', to: '/sync' }]
+                : [{ label: 'Tree', to: '/' }]),
   ];
 
   const lastSync = syncStatus?.lastSync;
@@ -246,6 +298,18 @@ const boardRoute = createRoute({
   component: BoardView,
 });
 
+const sprintRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: '/sprint',
+  component: SprintView,
+});
+
+const graphRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: '/graph',
+  component: GraphView,
+});
+
 const syncRoute = createRoute({
   getParentRoute: () => rootRoute,
   path: '/sync',
@@ -257,6 +321,8 @@ const routeTree = rootRoute.addChildren([
   entityRoute,
   roadmapRoute,
   boardRoute,
+  sprintRoute,
+  graphRoute,
   syncRoute,
 ]);
 

--- a/packages/ui/src/lib/api.ts
+++ b/packages/ui/src/lib/api.ts
@@ -25,6 +25,7 @@ export interface TreeResponse {
   milestones: Entity[];
   roadmaps: Entity[];
   prds: Entity[];
+  sprints: Entity[];
   errors: { filePath: string; message: string }[];
   counts: Record<string, number>;
 }

--- a/packages/ui/src/lib/api.ts
+++ b/packages/ui/src/lib/api.ts
@@ -119,6 +119,70 @@ export function useDeleteEntity() {
   });
 }
 
+// --- Progress ---
+
+export interface EpicProgress {
+  epicId: string;
+  title: string;
+  status: string;
+  total: number;
+  done: number;
+  inProgress: number;
+  blocked: number;
+  progress: number;
+}
+
+export interface MilestoneProgress {
+  milestoneId: string;
+  title: string;
+  targetDate?: string;
+  epics: EpicProgress[];
+  total: number;
+  done: number;
+  progress: number;
+}
+
+export interface ProjectProgress {
+  milestones: MilestoneProgress[];
+  orphanEpics: EpicProgress[];
+  overall: { total: number; done: number; progress: number };
+}
+
+export function useProgress() {
+  return useQuery<ProjectProgress>({
+    queryKey: ['progress'],
+    queryFn: () => fetchJson('/progress'),
+    refetchOnWindowFocus: true,
+  });
+}
+
+// --- Graph ---
+
+export interface GraphNode {
+  id: string;
+  title: string;
+  type: string;
+  status: string;
+}
+
+export interface GraphEdge {
+  source: string;
+  target: string;
+  label: string;
+}
+
+export interface GraphData {
+  nodes: GraphNode[];
+  edges: GraphEdge[];
+}
+
+export function useGraphData() {
+  return useQuery<GraphData>({
+    queryKey: ['graph'],
+    queryFn: () => fetchJson('/graph'),
+  });
+}
+
 // --- Validation ---
 
 export interface ValidationResponse {

--- a/packages/ui/src/routes/graph.tsx
+++ b/packages/ui/src/routes/graph.tsx
@@ -1,0 +1,257 @@
+import { useNavigate } from '@tanstack/react-router';
+import {
+  forceCenter,
+  forceLink,
+  forceManyBody,
+  forceSimulation,
+  type SimulationLinkDatum,
+  type SimulationNodeDatum,
+} from 'd3-force';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { EmptyState } from '../components/EmptyState.js';
+import { Spinner } from '../components/Spinner.js';
+import { type GraphEdge, type GraphNode, useGraphData } from '../lib/api.js';
+
+const TYPE_COLORS: Record<string, string> = {
+  story: '#60A5FA',
+  epic: '#A78BFA',
+  milestone: '#FBBF24',
+  roadmap: '#34D399',
+  prd: '#F472B6',
+};
+
+const DONE_STATUSES = new Set(['done', 'cancelled']);
+
+interface SimNode extends SimulationNodeDatum {
+  id: string;
+  title: string;
+  type: string;
+  status: string;
+  radius: number;
+}
+
+interface SimLink extends SimulationLinkDatum<SimNode> {
+  label: string;
+}
+
+function buildSimData(
+  nodes: GraphNode[],
+  edges: GraphEdge[],
+): { simNodes: SimNode[]; simLinks: SimLink[] } {
+  const nodeMap = new Map<string, SimNode>();
+
+  const typeRadius: Record<string, number> = {
+    milestone: 18,
+    epic: 14,
+    story: 8,
+    roadmap: 20,
+    prd: 12,
+  };
+
+  for (const n of nodes) {
+    nodeMap.set(n.id, {
+      ...n,
+      radius: typeRadius[n.type] ?? 10,
+    });
+  }
+
+  const simLinks: SimLink[] = edges
+    .filter((e) => nodeMap.has(e.source) && nodeMap.has(e.target))
+    .map((e) => ({
+      source: e.source,
+      target: e.target,
+      label: e.label,
+    }));
+
+  return { simNodes: Array.from(nodeMap.values()), simLinks };
+}
+
+export function GraphView() {
+  const { data, isLoading } = useGraphData();
+  const svgRef = useRef<SVGSVGElement>(null);
+  const navigate = useNavigate();
+  const [tooltip, setTooltip] = useState<{
+    x: number;
+    y: number;
+    node: SimNode;
+  } | null>(null);
+  const [simNodes, setSimNodes] = useState<SimNode[]>([]);
+  const [simLinks, setSimLinks] = useState<SimLink[]>([]);
+
+  const { initialNodes, initialLinks } = useMemo(() => {
+    if (!data) return { initialNodes: [], initialLinks: [] };
+    const { simNodes: n, simLinks: l } = buildSimData(data.nodes, data.edges);
+    return { initialNodes: n, initialLinks: l };
+  }, [data]);
+
+  useEffect(() => {
+    if (initialNodes.length === 0) return;
+
+    const sim = forceSimulation<SimNode>(initialNodes)
+      .force(
+        'link',
+        forceLink<SimNode, SimLink>(initialLinks)
+          .id((d) => d.id)
+          .distance(80),
+      )
+      .force('charge', forceManyBody().strength(-200))
+      .force('center', forceCenter(400, 300));
+
+    sim.on('tick', () => {
+      setSimNodes([...sim.nodes()]);
+      setSimLinks([...initialLinks]);
+    });
+
+    return () => {
+      sim.stop();
+    };
+  }, [initialNodes, initialLinks]);
+
+  const handleNodeClick = useCallback(
+    (nodeId: string) => {
+      navigate({ to: '/entity/$id', params: { id: nodeId } });
+    },
+    [navigate],
+  );
+
+  if (isLoading) {
+    return (
+      <div className="flex justify-center py-12">
+        <Spinner className="h-8 w-8" />
+      </div>
+    );
+  }
+
+  if (!data || data.nodes.length === 0) {
+    return (
+      <EmptyState
+        icon="🔗"
+        message="No entities found. Create some stories and epics to see the dependency graph."
+      />
+    );
+  }
+
+  return (
+    <div>
+      <h2 className="text-lg font-semibold mb-4">Dependency Graph</h2>
+      <div className="bg-white rounded-lg border border-gray-200 relative overflow-hidden">
+        <svg
+          ref={svgRef}
+          width="100%"
+          height={600}
+          viewBox="0 0 800 600"
+          className="w-full"
+          role="img"
+        >
+          <title>Entity Dependency Graph</title>
+          <defs>
+            <marker
+              id="arrowhead"
+              viewBox="0 0 10 7"
+              refX="10"
+              refY="3.5"
+              markerWidth="6"
+              markerHeight="5"
+              orient="auto"
+            >
+              <polygon points="0 0, 10 3.5, 0 7" fill="#9CA3AF" />
+            </marker>
+          </defs>
+
+          {/* Edges */}
+          {simLinks.map((link) => {
+            const s = link.source as SimNode;
+            const t = link.target as SimNode;
+            if (!s.x || !s.y || !t.x || !t.y) return null;
+            return (
+              <line
+                key={`${s.id}-${t.id}-${link.label}`}
+                x1={s.x}
+                y1={s.y}
+                x2={t.x}
+                y2={t.y}
+                stroke="#D1D5DB"
+                strokeWidth={1.5}
+                markerEnd="url(#arrowhead)"
+              />
+            );
+          })}
+
+          {/* Nodes */}
+          {simNodes.map((node) => {
+            const color = TYPE_COLORS[node.type] ?? '#9CA3AF';
+            const opacity = DONE_STATUSES.has(node.status) ? 0.4 : 1;
+            return (
+              // biome-ignore lint/a11y/noStaticElementInteractions: SVG <g> cannot use semantic elements
+              <g
+                key={node.id}
+                transform={`translate(${node.x ?? 0},${node.y ?? 0})`}
+                style={{ cursor: 'pointer' }}
+                onClick={() => handleNodeClick(node.id)}
+                onMouseEnter={(e) => {
+                  const rect = svgRef.current?.getBoundingClientRect();
+                  if (rect) {
+                    setTooltip({
+                      x: e.clientX - rect.left,
+                      y: e.clientY - rect.top - 30,
+                      node,
+                    });
+                  }
+                }}
+                onMouseLeave={() => setTooltip(null)}
+              >
+                <circle
+                  r={node.radius}
+                  fill={color}
+                  opacity={opacity}
+                  stroke={color}
+                  strokeWidth={2}
+                />
+                {node.radius >= 12 && (
+                  <text
+                    textAnchor="middle"
+                    dy={node.radius + 14}
+                    fontSize={10}
+                    fill="#6B7280"
+                    className="select-none pointer-events-none"
+                  >
+                    {node.title.length > 20
+                      ? `${node.title.slice(0, 20)}...`
+                      : node.title}
+                  </text>
+                )}
+              </g>
+            );
+          })}
+        </svg>
+
+        {/* Tooltip */}
+        {tooltip && (
+          <div
+            className="absolute bg-gray-900 text-white text-xs rounded px-2 py-1 pointer-events-none shadow-lg"
+            style={{ left: tooltip.x, top: tooltip.y }}
+          >
+            <span className="font-medium">{tooltip.node.title}</span>
+            <br />
+            <span className="text-gray-400">
+              {tooltip.node.type} &middot; {tooltip.node.status || 'n/a'}
+            </span>
+          </div>
+        )}
+
+        {/* Legend */}
+        <div className="absolute bottom-3 left-3 bg-white/90 rounded border border-gray-200 p-2 text-xs flex flex-wrap gap-3">
+          {Object.entries(TYPE_COLORS).map(([type, color]) => (
+            <div key={type} className="flex items-center gap-1">
+              <span
+                className="w-3 h-3 rounded-full"
+                style={{ backgroundColor: color }}
+              />
+              <span className="text-gray-600">{type}</span>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/packages/ui/src/routes/graph.tsx
+++ b/packages/ui/src/routes/graph.tsx
@@ -162,7 +162,8 @@ export function GraphView() {
           {simLinks.map((link) => {
             const s = link.source as SimNode;
             const t = link.target as SimNode;
-            if (!s.x || !s.y || !t.x || !t.y) return null;
+            if (s.x == null || s.y == null || t.x == null || t.y == null)
+              return null;
             return (
               <line
                 key={`${s.id}-${t.id}-${link.label}`}

--- a/packages/ui/src/routes/roadmap.tsx
+++ b/packages/ui/src/routes/roadmap.tsx
@@ -2,7 +2,7 @@ import { useMemo } from 'react';
 import { EmptyState } from '../components/EmptyState.js';
 import { Spinner } from '../components/Spinner.js';
 import { StatusBadge } from '../components/StatusBadge.js';
-import { type Entity, useTree } from '../lib/api.js';
+import { type Entity, useProgress, useTree } from '../lib/api.js';
 
 const STATUS_COLORS: Record<string, string> = {
   backlog: '#9CA3AF',
@@ -15,6 +15,7 @@ const STATUS_COLORS: Record<string, string> = {
 
 export function RoadmapView() {
   const { data: tree, isLoading } = useTree();
+  const { data: progress } = useProgress();
 
   const milestones = useMemo(() => {
     if (!tree) return [];
@@ -157,6 +158,10 @@ export function RoadmapView() {
                   const epColor =
                     STATUS_COLORS[ep.status ?? 'backlog'] ?? '#9CA3AF';
                   const barWidth = 120;
+                  const epProgress = progress?.milestones
+                    .flatMap((m) => m.epics)
+                    .find((p) => p.epicId === ep.id);
+                  const ratio = epProgress?.progress ?? 0;
 
                   return (
                     <g key={ep.id}>
@@ -167,8 +172,19 @@ export function RoadmapView() {
                         height={24}
                         rx={4}
                         fill={epColor}
-                        opacity={0.3}
+                        opacity={0.15}
                       />
+                      {ratio > 0 && (
+                        <rect
+                          x={x - 20}
+                          y={epY}
+                          width={barWidth * ratio}
+                          height={24}
+                          rx={4}
+                          fill={epColor}
+                          opacity={0.4}
+                        />
+                      )}
                       <rect
                         x={x - 20}
                         y={epY}
@@ -190,6 +206,16 @@ export function RoadmapView() {
                           ? `${ep.title.slice(0, 18)}...`
                           : ep.title}
                       </text>
+                      {ratio > 0 && (
+                        <text
+                          x={x - 20 + barWidth + 6}
+                          y={epY + 16}
+                          fill="#6b7280"
+                          fontSize="10"
+                        >
+                          {Math.round(ratio * 100)}%
+                        </text>
+                      )}
                     </g>
                   );
                 })}

--- a/packages/ui/src/routes/sprint.tsx
+++ b/packages/ui/src/routes/sprint.tsx
@@ -4,12 +4,13 @@ import { EmptyState } from '../components/EmptyState.js';
 import { PriorityBadge } from '../components/PriorityBadge.js';
 import { Spinner } from '../components/Spinner.js';
 import { StatusBadge } from '../components/StatusBadge.js';
-import { type Entity, type TreeResponse, useTree } from '../lib/api.js';
+import { type Entity, useTree } from '../lib/api.js';
 
 interface SprintEntity extends Entity {
   start_date?: string;
   end_date?: string;
   stories?: { id: string }[];
+  resolvedStories?: Entity[];
   capacity?: number;
 }
 
@@ -43,26 +44,17 @@ export function SprintView() {
 
   const sprints = useMemo(() => {
     if (!tree) return [];
-    return ((tree as TreeResponse).sprints as SprintEntity[]).sort((a, b) =>
+    return ((tree.sprints ?? []) as SprintEntity[]).sort((a, b) =>
       (a.start_date ?? '').localeCompare(b.start_date ?? ''),
     );
-  }, [tree]);
-
-  const storyMap = useMemo(() => {
-    if (!tree) return new Map<string, Entity>();
-    const map = new Map<string, Entity>();
-    for (const s of (tree as TreeResponse).stories) {
-      map.set(s.id, s);
-    }
-    return map;
   }, [tree]);
 
   const backlogStories = useMemo(() => {
     if (!tree) return [];
     const assignedIds = new Set(
-      sprints.flatMap((sp) => (sp.stories ?? []).map((s) => s.id)),
+      sprints.flatMap((sp) => (sp.resolvedStories ?? []).map((s) => s.id)),
     );
-    return (tree as TreeResponse).stories.filter(
+    return tree.stories.filter(
       (s) =>
         !assignedIds.has(s.id) &&
         s.status !== 'done' &&
@@ -93,9 +85,7 @@ export function SprintView() {
       <div className="flex gap-4 overflow-x-auto pb-4">
         {/* Sprint columns */}
         {sprints.map((sp) => {
-          const sprintStories = (sp.stories ?? [])
-            .map((ref) => storyMap.get(ref.id))
-            .filter(Boolean) as Entity[];
+          const sprintStories = sp.resolvedStories ?? [];
           const done = sprintStories.filter(
             (s) => s.status === 'done' || s.status === 'cancelled',
           ).length;

--- a/packages/ui/src/routes/sprint.tsx
+++ b/packages/ui/src/routes/sprint.tsx
@@ -43,9 +43,9 @@ export function SprintView() {
 
   const sprints = useMemo(() => {
     if (!tree) return [];
-    return (
-      (tree as TreeResponse & { sprints?: SprintEntity[] }).sprints ?? []
-    ).sort((a, b) => (a.start_date ?? '').localeCompare(b.start_date ?? ''));
+    return ((tree as TreeResponse).sprints as SprintEntity[]).sort((a, b) =>
+      (a.start_date ?? '').localeCompare(b.start_date ?? ''),
+    );
   }, [tree]);
 
   const storyMap = useMemo(() => {

--- a/packages/ui/src/routes/sprint.tsx
+++ b/packages/ui/src/routes/sprint.tsx
@@ -1,0 +1,188 @@
+import { Link } from '@tanstack/react-router';
+import { useMemo } from 'react';
+import { EmptyState } from '../components/EmptyState.js';
+import { PriorityBadge } from '../components/PriorityBadge.js';
+import { Spinner } from '../components/Spinner.js';
+import { StatusBadge } from '../components/StatusBadge.js';
+import { type Entity, type TreeResponse, useTree } from '../lib/api.js';
+
+interface SprintEntity extends Entity {
+  start_date?: string;
+  end_date?: string;
+  stories?: { id: string }[];
+  capacity?: number;
+}
+
+function SprintProgress({ done, total }: { done: number; total: number }) {
+  const ratio = total > 0 ? done / total : 0;
+  const pct = Math.round(ratio * 100);
+  const color =
+    ratio >= 0.75
+      ? 'bg-emerald-500'
+      : ratio >= 0.25
+        ? 'bg-yellow-500'
+        : 'bg-red-500';
+
+  return (
+    <div className="flex items-center gap-2">
+      <div className="w-24 h-2 bg-gray-200 rounded-full overflow-hidden">
+        <div
+          className={`h-full rounded-full ${color}`}
+          style={{ width: `${pct}%` }}
+        />
+      </div>
+      <span className="text-xs text-gray-500">
+        {pct}% ({done}/{total})
+      </span>
+    </div>
+  );
+}
+
+export function SprintView() {
+  const { data: tree, isLoading } = useTree();
+
+  const sprints = useMemo(() => {
+    if (!tree) return [];
+    return (
+      (tree as TreeResponse & { sprints?: SprintEntity[] }).sprints ?? []
+    ).sort((a, b) => (a.start_date ?? '').localeCompare(b.start_date ?? ''));
+  }, [tree]);
+
+  const storyMap = useMemo(() => {
+    if (!tree) return new Map<string, Entity>();
+    const map = new Map<string, Entity>();
+    for (const s of (tree as TreeResponse).stories) {
+      map.set(s.id, s);
+    }
+    return map;
+  }, [tree]);
+
+  const backlogStories = useMemo(() => {
+    if (!tree) return [];
+    const assignedIds = new Set(
+      sprints.flatMap((sp) => (sp.stories ?? []).map((s) => s.id)),
+    );
+    return (tree as TreeResponse).stories.filter(
+      (s) =>
+        !assignedIds.has(s.id) &&
+        s.status !== 'done' &&
+        s.status !== 'cancelled',
+    );
+  }, [tree, sprints]);
+
+  if (isLoading) {
+    return (
+      <div className="flex justify-center py-12">
+        <Spinner className="h-8 w-8" />
+      </div>
+    );
+  }
+
+  if (sprints.length === 0) {
+    return (
+      <EmptyState
+        icon="🏃"
+        message="No sprints defined yet. Create one via CLI: gitpm sprint create --title 'Sprint W15' --start 2026-04-07 --end 2026-04-13"
+      />
+    );
+  }
+
+  return (
+    <div>
+      <h2 className="text-lg font-semibold mb-4">Sprint Planning</h2>
+      <div className="flex gap-4 overflow-x-auto pb-4">
+        {/* Sprint columns */}
+        {sprints.map((sp) => {
+          const sprintStories = (sp.stories ?? [])
+            .map((ref) => storyMap.get(ref.id))
+            .filter(Boolean) as Entity[];
+          const done = sprintStories.filter(
+            (s) => s.status === 'done' || s.status === 'cancelled',
+          ).length;
+
+          return (
+            <div
+              key={sp.id}
+              className="bg-white rounded-lg border border-gray-200 min-w-72 flex-shrink-0 flex flex-col"
+            >
+              {/* Header */}
+              <div className="p-3 border-b border-gray-100">
+                <div className="flex items-center justify-between mb-1">
+                  <h3 className="font-medium text-sm">{sp.title}</h3>
+                  <StatusBadge status={sp.status ?? 'todo'} />
+                </div>
+                <p className="text-xs text-gray-400">
+                  {sp.start_date?.slice(0, 10)} &rarr;{' '}
+                  {sp.end_date?.slice(0, 10)}
+                </p>
+                <div className="mt-2">
+                  <SprintProgress done={done} total={sprintStories.length} />
+                </div>
+                {sp.capacity && (
+                  <p className="text-xs text-gray-400 mt-1">
+                    Capacity: {sp.capacity} pts
+                  </p>
+                )}
+              </div>
+              {/* Stories */}
+              <div className="flex-1 p-2 space-y-1 overflow-y-auto max-h-96">
+                {sprintStories.length === 0 && (
+                  <p className="text-xs text-gray-400 text-center py-4">
+                    No stories assigned
+                  </p>
+                )}
+                {sprintStories.map((story) => (
+                  <Link
+                    key={story.id}
+                    to="/entity/$id"
+                    params={{ id: story.id }}
+                    className="block p-2 rounded border border-gray-100 hover:border-gray-300 text-xs"
+                  >
+                    <div className="font-medium text-gray-800 mb-1 truncate">
+                      {story.title}
+                    </div>
+                    <div className="flex items-center gap-1.5">
+                      <StatusBadge status={story.status ?? 'todo'} />
+                      {story.priority && (
+                        <PriorityBadge priority={story.priority} />
+                      )}
+                    </div>
+                  </Link>
+                ))}
+              </div>
+            </div>
+          );
+        })}
+
+        {/* Backlog column */}
+        <div className="bg-gray-50 rounded-lg border border-gray-200 min-w-72 flex-shrink-0 flex flex-col">
+          <div className="p-3 border-b border-gray-100">
+            <h3 className="font-medium text-sm text-gray-500">
+              Backlog ({backlogStories.length})
+            </h3>
+          </div>
+          <div className="flex-1 p-2 space-y-1 overflow-y-auto max-h-96">
+            {backlogStories.map((story) => (
+              <Link
+                key={story.id}
+                to="/entity/$id"
+                params={{ id: story.id }}
+                className="block p-2 rounded border border-gray-100 hover:border-gray-300 bg-white text-xs"
+              >
+                <div className="font-medium text-gray-800 mb-1 truncate">
+                  {story.title}
+                </div>
+                <div className="flex items-center gap-1.5">
+                  <StatusBadge status={story.status ?? 'todo'} />
+                  {story.priority && (
+                    <PriorityBadge priority={story.priority} />
+                  )}
+                </div>
+              </Link>
+            ))}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/packages/ui/src/server/index.ts
+++ b/packages/ui/src/server/index.ts
@@ -2,6 +2,8 @@ import { unlink } from 'node:fs/promises';
 import { join } from 'node:path';
 import type { ParsedEntity, Priority, ResolvedTree, Status } from '@gitpm/core';
 import {
+  buildGraphData,
+  computeProjectProgress,
   parseTree,
   resolveRefs,
   toSlug,
@@ -41,6 +43,7 @@ export function createApp(metaDir: string) {
       tree.milestones,
       tree.roadmaps,
       tree.prds,
+      tree.sprints,
     ]) {
       const found = (list as ParsedEntity[]).find((e) => e.id === id);
       if (found) return found;
@@ -60,6 +63,7 @@ export function createApp(metaDir: string) {
           milestones: tree.milestones.length,
           roadmaps: tree.roadmaps.length,
           prds: tree.prds.length,
+          sprints: tree.sprints.length,
           errors: tree.errors.length,
         },
       });
@@ -182,6 +186,19 @@ export function createApp(metaDir: string) {
             filePath,
           } as ParsedEntity;
           break;
+        case 'sprint':
+          filePath = join(metaDir, 'sprints', `${slug}.md`);
+          entity = {
+            ...base,
+            type: 'sprint',
+            status: (rest.status as Status) || 'todo',
+            start_date: (rest.start_date as string) || '',
+            end_date: (rest.end_date as string) || '',
+            stories: (rest.stories as Array<{ id: string }>) || [],
+            capacity: (rest.capacity as number) || undefined,
+            filePath,
+          } as ParsedEntity;
+          break;
         default:
           return c.json({ error: `Unknown type: ${type}` }, 400);
       }
@@ -204,6 +221,26 @@ export function createApp(metaDir: string) {
 
       await unlink(entity.filePath);
       return c.body(null, 204);
+    } catch (err) {
+      return c.json({ error: String(err) }, 500);
+    }
+  });
+
+  // GET /api/progress
+  app.get('/api/progress', async (c) => {
+    try {
+      const tree = await getResolvedTree();
+      return c.json(computeProjectProgress(tree));
+    } catch (err) {
+      return c.json({ error: String(err) }, 500);
+    }
+  });
+
+  // GET /api/graph
+  app.get('/api/graph', async (c) => {
+    try {
+      const tree = await getResolvedTree();
+      return c.json(buildGraphData(tree));
     } catch (err) {
       return c.json({ error: String(err) }, 500);
     }


### PR DESCRIPTION
Add four new analytics features to GitPM:

- Progress tracking: `gitpm status` CLI command with progress bars,
  `/api/progress` endpoint, sidebar/roadmap progress indicators in UI
- Stale issue detection: `gitpm audit` CLI command detecting stale
  stories, orphans, empty bodies, zombie epics, and duplicate candidates
- Dependency graph visualization: new UI route `/#/graph` with d3-force
  layout showing entity relationships with click-to-navigate
- Sprint planning: new `sprint` entity type with schema, parser,
  resolver, writer support; `gitpm sprint create/list/show` CLI;
  sprint board UI view at `/#/sprint`

Also marks quality scoring story (#43) as done (was already
implemented) and sets epic to in_progress.

https://claude.ai/code/session_01Ptn1DBccyYE241sDwGsKfF