### PR TITLE
test(core): raise coverage of core source files to 90%+

### DIFF
--- a/.meta/epics/test-coverage-to-100-on-source-code/stories/add-test-coverage-for-packagescore-to-100.md
+++ b/.meta/epics/test-coverage-to-100-on-source-code/stories/add-test-coverage-for-packagescore-to-100.md
@@ -2,7 +2,7 @@
 type: story
 id: FPiV0EvcXREt
 title: Add test coverage for packages/core to 100%
-status: todo
+status: in_review
 priority: high
 assignee: null
 labels:
@@ -12,7 +12,7 @@ estimate: null
 epic_ref:
   id: xGG0RMogvzyo
 created_at: 2026-04-12T19:34:55.144Z
-updated_at: 2026-04-12T19:34:55.144Z
+updated_at: 2026-04-19T12:43:41.674Z
 ---
 
 ## Objective

--- a/packages/core/src/analytics/graph-data.test.ts
+++ b/packages/core/src/analytics/graph-data.test.ts
@@ -179,4 +179,152 @@ describe('buildGraphData', () => {
     expect(result.nodes).toHaveLength(1);
     expect(result.edges).toHaveLength(0);
   });
+
+  it('creates roadmap node with milestone edges', () => {
+    const ms = {
+      type: 'milestone' as const,
+      id: 'm1',
+      title: 'MS',
+      status: 'todo' as const,
+      body: '',
+      filePath: '/m.md',
+      created_at: '',
+      updated_at: '',
+    };
+    const tree = makeTree({
+      roadmaps: [
+        {
+          type: 'roadmap',
+          id: 'r1',
+          title: 'Roadmap 2026',
+          description: '',
+          milestones: [{ id: 'm1' }],
+          filePath: '/r.yaml',
+          resolvedMilestones: [ms],
+        },
+      ] as ResolvedTree['roadmaps'],
+    });
+
+    const result = buildGraphData(tree);
+    expect(result.nodes).toContainEqual({
+      id: 'r1',
+      title: 'Roadmap 2026',
+      type: 'roadmap',
+      status: '',
+    });
+    expect(result.edges).toContainEqual({
+      source: 'r1',
+      target: 'm1',
+      label: 'milestone',
+    });
+  });
+
+  it('creates prd node with epic edges', () => {
+    const epic = {
+      type: 'epic' as const,
+      id: 'e1',
+      title: 'Epic',
+      status: 'in_progress' as const,
+      priority: 'high' as const,
+      labels: [],
+      owner: null,
+      milestone_ref: null,
+      body: '',
+      filePath: '/e.md',
+      created_at: '',
+      updated_at: '',
+    };
+    const tree = makeTree({
+      prds: [
+        {
+          type: 'prd',
+          id: 'p1',
+          title: 'PRD',
+          status: 'todo',
+          owner: null,
+          epic_refs: [{ id: 'e1' }],
+          body: '',
+          filePath: '/p.md',
+          resolvedEpics: [epic],
+        },
+      ] as ResolvedTree['prds'],
+    });
+
+    const result = buildGraphData(tree);
+    expect(result.nodes).toContainEqual({
+      id: 'p1',
+      title: 'PRD',
+      type: 'prd',
+      status: 'todo',
+    });
+    expect(result.edges).toContainEqual({
+      source: 'p1',
+      target: 'e1',
+      label: 'epic_ref',
+    });
+  });
+
+  it('creates sprint node with story edges', () => {
+    const story = {
+      type: 'story' as const,
+      id: 's1',
+      title: 'Story',
+      status: 'todo' as const,
+      priority: 'medium' as const,
+      labels: [],
+      assignee: null,
+      estimate: null,
+      epic_ref: null,
+      body: '',
+      filePath: '/s.md',
+      created_at: '',
+      updated_at: '',
+    };
+    const tree = makeTree({
+      sprints: [
+        {
+          type: 'sprint',
+          id: 'sp1',
+          title: 'Sprint 1',
+          status: 'in_progress',
+          start_date: '2026-01-01',
+          end_date: '2026-01-14',
+          stories: [{ id: 's1' }],
+          body: '',
+          filePath: '/sp.md',
+          created_at: '',
+          updated_at: '',
+          resolvedStories: [story],
+        },
+      ] as ResolvedTree['sprints'],
+    });
+
+    const result = buildGraphData(tree);
+    expect(result.nodes).toContainEqual({
+      id: 'sp1',
+      title: 'Sprint 1',
+      type: 'sprint',
+      status: 'in_progress',
+    });
+    expect(result.edges).toContainEqual({
+      source: 'sp1',
+      target: 's1',
+      label: 'sprint_story',
+    });
+  });
+
+  it('handles undefined sprints array (nullish coalescing)', () => {
+    const tree = {
+      stories: [],
+      epics: [],
+      milestones: [],
+      roadmaps: [],
+      prds: [],
+      errors: [],
+    } as unknown as ResolvedTree;
+
+    const result = buildGraphData(tree);
+    expect(result.nodes).toHaveLength(0);
+    expect(result.edges).toHaveLength(0);
+  });
 });

--- a/packages/core/src/archiver/archiver.test.ts
+++ b/packages/core/src/archiver/archiver.test.ts
@@ -197,4 +197,76 @@ describe('archiveOldEntities', () => {
     expect(result.value.archivedFiles).toEqual([]);
     expect(result.value.archivedEntityIds).toEqual([]);
   });
+
+  it('skips files that fail to parse', async () => {
+    await writeFile(
+      join(metaDir, 'stories', 'broken.md'),
+      '---\ntype: story\n---\njust broken',
+    );
+    const result = await archiveOldEntities(metaDir, {
+      daysOld: 7,
+      dryRun: false,
+    });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.skippedFiles).toHaveLength(1);
+    expect(result.value.skippedFiles[0]).toContain('broken.md');
+    expect(result.value.archivedFiles).toEqual([]);
+  });
+
+  it('skips roadmap files (no status)', async () => {
+    await mkdir(join(metaDir, 'roadmap'), { recursive: true });
+    await writeFile(
+      join(metaDir, 'roadmap', 'roadmap.md'),
+      '---\ntype: roadmap\nid: rm_1\ntitle: My Roadmap\n---\n',
+    );
+    const result = await archiveOldEntities(metaDir, {
+      daysOld: 7,
+      dryRun: false,
+    });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(
+      result.value.skippedFiles.some((f) => f.endsWith('roadmap.md')),
+    ).toBe(true);
+  });
+
+  it('skips entities with invalid date strings', async () => {
+    await writeFile(
+      join(metaDir, 'stories', 'bad-date.md'),
+      `---
+type: story
+id: s1
+title: Bad date story
+status: done
+priority: medium
+labels: []
+created_at: not-a-date
+updated_at: not-a-date
+---
+
+body
+`,
+    );
+    const result = await archiveOldEntities(metaDir, {
+      daysOld: 7,
+      dryRun: false,
+    });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.archivedFiles).toEqual([]);
+    expect(
+      result.value.skippedFiles.some((f) => f.endsWith('bad-date.md')),
+    ).toBe(true);
+  });
+
+  it('returns an error result when archive logic throws', async () => {
+    const result = await archiveOldEntities(
+      join(metaDir, 'nonexistent-subdir-xyz'),
+      { daysOld: 7, dryRun: false },
+    );
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.message).toContain('Archive failed');
+  });
 });

--- a/packages/core/src/parser/parser.test.ts
+++ b/packages/core/src/parser/parser.test.ts
@@ -1,5 +1,7 @@
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { parseFile, parseFileContent } from './parse-file.js';
 import { parseTree } from './parse-tree.js';
 
@@ -57,6 +59,72 @@ type: story
     const result = parseFileContent(content, '/test/bad.md');
     expect(result.ok).toBe(false);
   });
+
+  it('returns error for YAML file that parses to a non-object', () => {
+    const result = parseFileContent('42', '/test/scalar.yaml');
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.message).toContain('Invalid YAML');
+  });
+
+  it('returns error for YAML file that parses to null', () => {
+    const result = parseFileContent('', '/test/empty.yaml');
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.message).toContain('Invalid YAML');
+  });
+
+  it('returns error when YAML content is malformed', () => {
+    const result = parseFileContent('::: not yaml :::', '/test/bad.yaml');
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.message).toContain('Failed to parse');
+  });
+
+  it('returns error for missing type field', () => {
+    const content = `---
+id: "abc"
+title: "no type"
+---`;
+    const result = parseFileContent(content, '/test/typeless.md');
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.message).toContain('Missing or invalid "type"');
+  });
+
+  it('coerces Date instances to ISO strings', () => {
+    const content = `---
+type: milestone
+id: "ms_1"
+title: "Milestone"
+status: todo
+target_date: 2026-06-01
+created_at: 2026-01-01
+updated_at: 2026-01-01
+---`;
+    const result = parseFileContent(content, '/test/m.md');
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(typeof (result.value as Record<string, unknown>).target_date).toBe(
+      'string',
+    );
+  });
+
+  it('coerces nested Date arrays', () => {
+    // roadmap.milestones expects array of entity refs, but we can still
+    // exercise the date-coercion logic by passing a frontmatter with a
+    // Date value inside a nested object.
+    const content = `---
+type: roadmap
+id: "rm_1"
+title: "Roadmap"
+milestones:
+  - id: ms_1
+    target_date: 2026-06-01
+---`;
+    const result = parseFileContent(content, '/test/r.md');
+    expect(result.ok).toBe(true);
+  });
 });
 
 describe('parseFile', () => {
@@ -92,6 +160,23 @@ describe('parseFile', () => {
     const result = await parseFile('/nonexistent/file.md');
     expect(result.ok).toBe(false);
   });
+
+  it('parses a YAML file and coerces top-level dates', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'gitpm-parse-yaml-'));
+    try {
+      const yamlPath = join(dir, 'roadmap.yaml');
+      await writeFile(
+        yamlPath,
+        'type: roadmap\nid: rm_yaml\ntitle: Yaml roadmap\nupdated_at: 2026-01-01\n',
+      );
+      const result = await parseFile(yamlPath);
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.value.type).toBe('roadmap');
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
 });
 
 describe('parseTree', () => {
@@ -119,5 +204,77 @@ describe('parseTree', () => {
       // orphan epic and duplicate-id story should parse OK
       expect(tree.epics.length + tree.stories.length).toBeGreaterThan(0);
     }
+  });
+
+  it('records an error when schema-extensions.yaml is invalid', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'gitpm-parse-ext-'));
+    try {
+      const metaDir = join(dir, '.meta');
+      await mkdir(join(metaDir, '.gitpm'), { recursive: true });
+      await writeFile(
+        join(metaDir, '.gitpm', 'schema-extensions.yaml'),
+        'story:\n  fields:\n    foo:\n      type: invalid_type\n',
+      );
+
+      const result = await parseTree(metaDir);
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      const extErrors = result.value.errors.filter((e) =>
+        e.filePath.endsWith('schema-extensions.yaml'),
+      );
+      expect(extErrors.length).toBeGreaterThan(0);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('collects per-file parse errors without aborting the tree walk', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'gitpm-parse-errs-'));
+    try {
+      const metaDir = join(dir, '.meta', 'stories');
+      await mkdir(metaDir, { recursive: true });
+      await writeFile(
+        join(metaDir, 'bad.md'),
+        '---\ntype: unknown\nid: "x"\ntitle: "X"\n---',
+      );
+      await writeFile(
+        join(metaDir, 'ok.md'),
+        '---\ntype: story\nid: st_ok\ntitle: Ok\nstatus: todo\npriority: medium\nlabels: []\ncreated_at: 2026-01-01T00:00:00Z\nupdated_at: 2026-01-01T00:00:00Z\n---\n',
+      );
+      const result = await parseTree(join(dir, '.meta'));
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.value.errors.length).toBeGreaterThan(0);
+      expect(result.value.stories).toHaveLength(1);
+      expect(result.value.stories[0].id).toBe('st_ok');
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('accepts sprint files into tree.sprints', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'gitpm-parse-sprint-'));
+    try {
+      const metaDir = join(dir, '.meta', 'sprints');
+      await mkdir(metaDir, { recursive: true });
+      await writeFile(
+        join(metaDir, 'sp.md'),
+        '---\ntype: sprint\nid: sp_1\ntitle: Sprint One\nstatus: in_progress\nstart_date: 2026-01-01\nend_date: 2026-01-14\nstories: []\ncreated_at: 2026-01-01T00:00:00Z\nupdated_at: 2026-01-01T00:00:00Z\n---\n',
+      );
+      const result = await parseTree(join(dir, '.meta'));
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.value.sprints).toHaveLength(1);
+      expect(result.value.sprints[0].id).toBe('sp_1');
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('returns an error result when the meta directory does not exist', async () => {
+    const result = await parseTree('/does/not/exist/anywhere-ever');
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.message).toContain('Failed to parse tree');
   });
 });

--- a/packages/core/src/plugin-loader.test.ts
+++ b/packages/core/src/plugin-loader.test.ts
@@ -266,6 +266,23 @@ describe('runHooks', () => {
     }
   });
 
+  it('rejects hook path that resolves outside the project root', async () => {
+    const config: GitpmConfig = {
+      adapters: [],
+      hooks: { 'pre-sync': '../escape.mjs' },
+    };
+    const result = await runHooks(
+      config,
+      'pre-sync',
+      { metaDir: '/tmp', event: 'pre-sync' },
+      tmpDir,
+    );
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.message).toContain('outside the project root');
+    }
+  });
+
   it('runs multiple hooks in array order', async () => {
     const hook1 = join(tmpDir, 'hook1.mjs');
     const hook2 = join(tmpDir, 'hook2.mjs');
@@ -395,6 +412,14 @@ describe('getPackageEntry', () => {
     );
     const result = await getPackageEntry(pkgDir);
     expect(result).toBe(resolve(pkgDir, 'index.js'));
+  });
+
+  it('returns null when package.json is malformed JSON', async () => {
+    const pkgDir = join(tmpDir, 'broken-pkg');
+    await mkdir(pkgDir, { recursive: true });
+    await writeFile(join(pkgDir, 'package.json'), '{ not-valid-json');
+    const result = await getPackageEntry(pkgDir);
+    expect(result).toBeNull();
   });
 });
 
@@ -526,5 +551,62 @@ describe('loadAdapters workspace fallback', () => {
     if (result.ok) {
       expect(result.value).toHaveLength(0);
     }
+  });
+
+  it('reports an error when a relative adapter file does not exist', async () => {
+    const config: GitpmConfig = {
+      adapters: ['./nope.mjs'],
+      hooks: {},
+    };
+    const result = await loadAdapters(config, tmpDir);
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.message).toContain('No adapters could be loaded');
+  });
+
+  it('rejects relative adapter paths that escape the project root', async () => {
+    const config: GitpmConfig = {
+      adapters: ['../outside.mjs'],
+      hooks: {},
+    };
+    const result = await loadAdapters(config, tmpDir);
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.message).toContain('outside the project root');
+  });
+
+  it('reports error when the module does not export a SyncAdapter', async () => {
+    const modPath = join(tmpDir, 'not-adapter.mjs');
+    await writeFile(modPath, 'export default { hello: "world" };');
+    const config: GitpmConfig = {
+      adapters: [modPath],
+      hooks: {},
+    };
+    const result = await loadAdapters(config, tmpDir);
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.message).toContain(
+      'does not export a valid SyncAdapter',
+    );
+  });
+
+  it('loads adapter from default export when present', async () => {
+    const modPath = join(tmpDir, 'adapter-default.mjs');
+    await writeFile(
+      modPath,
+      `export default {
+        name: 'default-export',
+        displayName: 'Default',
+        detect: async () => false,
+        import: async () => ({ ok: true, value: { milestones: 0, epics: 0, stories: 0, totalFiles: 0 } }),
+        export: async () => ({ ok: true, value: { created: { milestones: 0, issues: 0 }, updated: { milestones: 0, issues: 0 }, totalChanges: 0 } }),
+        sync: async () => ({ ok: true, value: { pushed: { milestones: 0, issues: 0 }, pulled: { milestones: 0, issues: 0 }, conflicts: [], resolved: 0, skipped: 0 } }),
+      };`,
+    );
+    const config: GitpmConfig = { adapters: [modPath], hooks: {} };
+    const result = await loadAdapters(config, tmpDir);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value[0].name).toBe('default-export');
   });
 });

--- a/packages/core/src/resolver/resolver.test.ts
+++ b/packages/core/src/resolver/resolver.test.ts
@@ -104,6 +104,169 @@ describe('resolveRefs', () => {
   });
 });
 
+describe('resolveRefs — unresolved reference paths', () => {
+  it('reports unresolved story → epic reference', () => {
+    const tree: MetaTree = {
+      stories: [
+        {
+          type: 'story',
+          id: 's1',
+          title: 'Orphan story',
+          status: 'todo',
+          priority: 'medium',
+          labels: [],
+          assignee: null,
+          estimate: null,
+          epic_ref: { id: 'missing_epic' },
+          body: '',
+          filePath: '/s.md',
+          created_at: '',
+          updated_at: '',
+        },
+      ],
+      epics: [],
+      milestones: [],
+      roadmaps: [],
+      prds: [],
+      sprints: [],
+      errors: [],
+    };
+    const resolved = resolveRefs(tree);
+    expect(resolved.ok).toBe(true);
+    if (!resolved.ok) return;
+    expect(resolved.value.errors).toHaveLength(1);
+    expect(resolved.value.errors[0].message).toContain(
+      'non-existent epic "missing_epic"',
+    );
+    expect(resolved.value.stories[0].resolvedEpic).toBeUndefined();
+  });
+
+  it('reports unresolved roadmap → milestone reference', () => {
+    const tree: MetaTree = {
+      stories: [],
+      epics: [],
+      milestones: [],
+      roadmaps: [
+        {
+          type: 'roadmap',
+          id: 'rm1',
+          title: 'My roadmap',
+          description: '',
+          milestones: [{ id: 'missing_ms' }],
+          filePath: '/r.yaml',
+        },
+      ],
+      prds: [],
+      sprints: [],
+      errors: [],
+    };
+    const resolved = resolveRefs(tree);
+    expect(resolved.ok).toBe(true);
+    if (!resolved.ok) return;
+    const refErrors = resolved.value.errors.filter((e) =>
+      e.message.includes('non-existent milestone'),
+    );
+    expect(refErrors).toHaveLength(1);
+    expect(resolved.value.roadmaps[0].resolvedMilestones).toHaveLength(0);
+  });
+
+  it('reports unresolved prd → epic reference', () => {
+    const tree: MetaTree = {
+      stories: [],
+      epics: [],
+      milestones: [],
+      roadmaps: [],
+      prds: [
+        {
+          type: 'prd',
+          id: 'prd1',
+          title: 'Big PRD',
+          status: 'todo',
+          epic_refs: [{ id: 'missing_epic' }],
+          body: '',
+          filePath: '/p.md',
+        },
+      ],
+      sprints: [],
+      errors: [],
+    };
+    const resolved = resolveRefs(tree);
+    expect(resolved.ok).toBe(true);
+    if (!resolved.ok) return;
+    const refErrors = resolved.value.errors.filter((e) =>
+      e.message.includes('non-existent epic'),
+    );
+    expect(refErrors).toHaveLength(1);
+    expect(resolved.value.prds[0].resolvedEpics).toHaveLength(0);
+  });
+
+  it('resolves sprint → story references', () => {
+    const tree: MetaTree = {
+      stories: [
+        {
+          type: 'story',
+          id: 'st_real',
+          title: 'Existing story',
+          status: 'todo',
+          priority: 'medium',
+          labels: [],
+          assignee: null,
+          estimate: null,
+          epic_ref: null,
+          body: '',
+          filePath: '/s.md',
+          created_at: '',
+          updated_at: '',
+        },
+      ],
+      epics: [],
+      milestones: [],
+      roadmaps: [],
+      prds: [],
+      sprints: [
+        {
+          type: 'sprint',
+          id: 'sp1',
+          title: 'Sprint',
+          status: 'in_progress',
+          start_date: '2026-01-01',
+          end_date: '2026-01-14',
+          stories: [{ id: 'st_real' }, { id: 'missing_story' }],
+          body: '',
+          filePath: '/sp.md',
+          created_at: '',
+          updated_at: '',
+        },
+      ],
+      errors: [],
+    };
+    const resolved = resolveRefs(tree);
+    expect(resolved.ok).toBe(true);
+    if (!resolved.ok) return;
+    expect(resolved.value.sprints[0].resolvedStories).toHaveLength(1);
+    expect(resolved.value.sprints[0].resolvedStories[0].id).toBe('st_real');
+    const storyErrors = resolved.value.errors.filter((e) =>
+      e.message.includes('non-existent story'),
+    );
+    expect(storyErrors).toHaveLength(1);
+  });
+
+  it('handles undefined sprints via nullish fallback', () => {
+    const tree = {
+      stories: [],
+      epics: [],
+      milestones: [],
+      roadmaps: [],
+      prds: [],
+      errors: [],
+    } as unknown as MetaTree;
+    const resolved = resolveRefs(tree);
+    expect(resolved.ok).toBe(true);
+    if (!resolved.ok) return;
+    expect(resolved.value.sprints).toEqual([]);
+  });
+});
+
 describe('buildDependencyGraph', () => {
   it('builds graph from valid tree', async () => {
     const parsed = await parseTree(validTree);

--- a/packages/core/src/writer/create-entity.test.ts
+++ b/packages/core/src/writer/create-entity.test.ts
@@ -1,9 +1,14 @@
-import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { parseFile } from '../parser/parse-file.js';
-import { createEpic, createMilestone, createStory } from './create-entity.js';
+import {
+  createEpic,
+  createMilestone,
+  createSprint,
+  createStory,
+} from './create-entity.js';
 
 describe('createStory', () => {
   let tmpDir: string;
@@ -176,6 +181,31 @@ describe('createEpic', () => {
       id: 'ms_test',
     });
   });
+
+  it('appends numeric suffix when epic slug directory already has epic.md', async () => {
+    const r1 = await createEpic(metaDir, { title: 'Shared Name' });
+    const r2 = await createEpic(metaDir, { title: 'Shared Name' });
+    const r3 = await createEpic(metaDir, { title: 'Shared Name' });
+
+    expect(r1.ok).toBe(true);
+    expect(r2.ok).toBe(true);
+    expect(r3.ok).toBe(true);
+    if (!r1.ok || !r2.ok || !r3.ok) return;
+
+    expect(r1.value.filePath).toContain('/epics/shared-name/epic.md');
+    expect(r2.value.filePath).toContain('/epics/shared-name-2/epic.md');
+    expect(r3.value.filePath).toContain('/epics/shared-name-3/epic.md');
+  });
+
+  it('returns an error Result when write fails due to invalid path', async () => {
+    // Using a file as parent dir forces mkdir to fail.
+    await writeFile(metaDir, 'not-a-directory');
+
+    const result = await createEpic(metaDir, { title: 'Blocked Epic' });
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.message).toContain('Failed to write');
+  });
 });
 
 describe('createMilestone', () => {
@@ -211,5 +241,114 @@ describe('createMilestone', () => {
     expect((parsed.value as Record<string, unknown>).target_date).toContain(
       '2026-06-01',
     );
+  });
+
+  it('creates a milestone with default status when not provided', async () => {
+    const result = await createMilestone(metaDir, {
+      title: 'Future milestone',
+    });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    const parsed = await parseFile(result.value.filePath);
+    expect(parsed.ok).toBe(true);
+    if (!parsed.ok) return;
+    expect((parsed.value as Record<string, unknown>).status).toBe('backlog');
+    expect((parsed.value as Record<string, unknown>).target_date).toBe('');
+  });
+
+  it('returns an error when milestone write fails', async () => {
+    await writeFile(metaDir, 'not-a-directory');
+    const result = await createMilestone(metaDir, { title: 'Blocked' });
+    expect(result.ok).toBe(false);
+  });
+});
+
+describe('createSprint', () => {
+  let tmpDir: string;
+  let metaDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await mkdtemp(join(tmpdir(), 'gitpm-create-'));
+    metaDir = join(tmpDir, '.meta');
+  });
+
+  afterEach(async () => {
+    await rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it('creates a sprint at .meta/sprints/<slug>.md', async () => {
+    const result = await createSprint(metaDir, {
+      title: 'Sprint 42',
+      startDate: '2026-04-01',
+      endDate: '2026-04-14',
+      status: 'in_progress',
+      storyIds: ['st_a', 'st_b'],
+      capacity: 20,
+      body: '## Goals\n\nShip everything.',
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+
+    expect(result.value.filePath).toContain('/sprints/sprint-42.md');
+    expect(result.value.id).toHaveLength(12);
+
+    const parsed = await parseFile(result.value.filePath);
+    expect(parsed.ok).toBe(true);
+    if (!parsed.ok) return;
+    expect(parsed.value.type).toBe('sprint');
+    const sprint = parsed.value as Record<string, unknown>;
+    expect(sprint.start_date).toContain('2026-04-01');
+    expect(sprint.end_date).toContain('2026-04-14');
+    expect(sprint.status).toBe('in_progress');
+    expect(sprint.capacity).toBe(20);
+    expect(sprint.stories).toEqual([{ id: 'st_a' }, { id: 'st_b' }]);
+    expect(sprint.body).toContain('Ship everything.');
+  });
+
+  it('applies defaults for status and storyIds', async () => {
+    const result = await createSprint(metaDir, {
+      title: 'Sprint minimal',
+      startDate: '2026-05-01',
+      endDate: '2026-05-14',
+    });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    const parsed = await parseFile(result.value.filePath);
+    expect(parsed.ok).toBe(true);
+    if (!parsed.ok) return;
+    const sprint = parsed.value as Record<string, unknown>;
+    expect(sprint.status).toBe('todo');
+    expect(sprint.stories).toEqual([]);
+    expect(sprint.body).toBe('');
+  });
+
+  it('appends numeric suffix for duplicate sprint titles', async () => {
+    const r1 = await createSprint(metaDir, {
+      title: 'Dup Sprint',
+      startDate: '2026-06-01',
+      endDate: '2026-06-14',
+    });
+    const r2 = await createSprint(metaDir, {
+      title: 'Dup Sprint',
+      startDate: '2026-06-15',
+      endDate: '2026-06-28',
+    });
+
+    expect(r1.ok).toBe(true);
+    expect(r2.ok).toBe(true);
+    if (!r1.ok || !r2.ok) return;
+    expect(r1.value.filePath).toContain('dup-sprint.md');
+    expect(r2.value.filePath).toContain('dup-sprint-2.md');
+  });
+
+  it('returns an error when sprint write fails', async () => {
+    await writeFile(metaDir, 'not-a-directory');
+    const result = await createSprint(metaDir, {
+      title: 'Blocked sprint',
+      startDate: '2026-07-01',
+      endDate: '2026-07-14',
+    });
+    expect(result.ok).toBe(false);
   });
 });

--- a/packages/core/src/writer/set-fields.test.ts
+++ b/packages/core/src/writer/set-fields.test.ts
@@ -282,4 +282,160 @@ describe('applyAssignments', () => {
     expect(({} as Record<string, unknown>).id).toBeUndefined();
     expect(({} as Record<string, unknown>).safe_value).toBeUndefined();
   });
+
+  it('fails -= on a non-array field', () => {
+    const result = applyAssignments(baseStory, [
+      { field: 'priority', operator: '-=', value: 'medium' },
+    ]);
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.message).toContain('non-array');
+  });
+
+  it('returns error when nested set receives a dangerous path', () => {
+    const result = applyAssignments(baseStory, [
+      { field: 'epic_ref.constructor', operator: '=', value: 'oops' },
+    ]);
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.message).toContain('Dangerous field name');
+  });
+});
+
+describe('applyAssignments schema dispatch', () => {
+  const baseEpic: ParsedEntity = {
+    type: 'epic',
+    id: 'ep_id',
+    title: 'Epic',
+    status: 'backlog',
+    priority: 'medium',
+    labels: [],
+    owner: null,
+    milestone_ref: null,
+    body: '',
+    filePath: '/tmp/e.md',
+    created_at: '2026-01-01T00:00:00Z',
+    updated_at: '2026-01-01T00:00:00Z',
+  };
+
+  const baseMilestone: ParsedEntity = {
+    type: 'milestone',
+    id: 'ms_id',
+    title: 'MS',
+    status: 'backlog',
+    target_date: '',
+    body: '',
+    filePath: '/tmp/ms.md',
+    created_at: '2026-01-01T00:00:00Z',
+    updated_at: '2026-01-01T00:00:00Z',
+  };
+
+  const basePrd: ParsedEntity = {
+    type: 'prd',
+    id: 'pr_id',
+    title: 'PRD',
+    status: 'backlog',
+    epic_refs: [],
+    body: '',
+    filePath: '/tmp/prd.md',
+  };
+
+  const baseRoadmap: ParsedEntity = {
+    type: 'roadmap',
+    id: 'rm_id',
+    title: 'Roadmap',
+    description: '',
+    milestones: [],
+    filePath: '/tmp/r.yaml',
+  };
+
+  it('validates epic fields and returns success', () => {
+    const result = applyAssignments(baseEpic, [
+      { field: 'priority', operator: '=', value: 'high' },
+    ]);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect((result.value as Record<string, unknown>).priority).toBe('high');
+  });
+
+  it('rejects invalid epic values via zod', () => {
+    const result = applyAssignments(baseEpic, [
+      { field: 'status', operator: '=', value: 'not-a-status' },
+    ]);
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.message).toContain('Validation failed');
+  });
+
+  it('validates milestone fields and returns success', () => {
+    const result = applyAssignments(baseMilestone, [
+      { field: 'status', operator: '=', value: 'done' },
+    ]);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect((result.value as Record<string, unknown>).status).toBe('done');
+  });
+
+  it('rejects invalid milestone values via zod', () => {
+    const result = applyAssignments(baseMilestone, [
+      { field: 'title', operator: '=', value: '' },
+    ]);
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.message).toContain('Validation failed');
+  });
+
+  it('validates prd fields and returns success', () => {
+    const result = applyAssignments(basePrd, [
+      { field: 'title', operator: '=', value: 'New PRD title' },
+    ]);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect((result.value as Record<string, unknown>).title).toBe(
+      'New PRD title',
+    );
+  });
+
+  it('rejects invalid prd values via zod', () => {
+    const result = applyAssignments(basePrd, [
+      { field: 'status', operator: '=', value: 'garbage' },
+    ]);
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.message).toContain('Validation failed');
+  });
+
+  it('validates roadmap fields and returns success', () => {
+    const result = applyAssignments(baseRoadmap, [
+      { field: 'description', operator: '=', value: 'Updated description' },
+    ]);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect((result.value as Record<string, unknown>).description).toBe(
+      'Updated description',
+    );
+  });
+
+  it('rejects invalid roadmap values via zod', () => {
+    const result = applyAssignments(baseRoadmap, [
+      { field: 'title', operator: '=', value: '' },
+    ]);
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.message).toContain('Validation failed');
+  });
+
+  it('rejects unknown entity types', () => {
+    const mystery = {
+      ...baseEpic,
+      type: 'sprint',
+    } as unknown as ParsedEntity;
+    const result = applyAssignments(mystery, [
+      { field: 'title', operator: '=', value: 'New' },
+    ]);
+    // sprint type isn't listed in applyAssignments switch, so it hits default
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.message).toContain('Unknown entity type');
+  });
 });

--- a/packages/core/src/writer/write-file.test.ts
+++ b/packages/core/src/writer/write-file.test.ts
@@ -1,0 +1,110 @@
+import {
+  writeFile as fsWriteFile,
+  mkdtemp,
+  readFile,
+  rm,
+} from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import type { ParsedEntity } from '../schemas/index.js';
+import { writeFile } from './write-file.js';
+
+describe('writeFile', () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await mkdtemp(join(tmpdir(), 'gitpm-writefile-'));
+  });
+
+  afterEach(async () => {
+    await rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it('writes a roadmap file as pure YAML (no frontmatter)', async () => {
+    const roadmap: ParsedEntity = {
+      type: 'roadmap',
+      id: 'rm_1',
+      title: 'My Roadmap',
+      description: '',
+      milestones: [{ id: 'ms_1' }],
+      filePath: join(tmpDir, 'roadmap.yaml'),
+    };
+    const result = await writeFile(roadmap, roadmap.filePath);
+    expect(result.ok).toBe(true);
+
+    const raw = await readFile(roadmap.filePath, 'utf-8');
+    expect(raw).not.toContain('---');
+    expect(raw).toContain('type: roadmap');
+    expect(raw).toContain('id: rm_1');
+  });
+
+  it('omits filePath from serialized output', async () => {
+    const story: ParsedEntity = {
+      type: 'story',
+      id: 'st_1',
+      title: 'Test',
+      status: 'todo',
+      priority: 'medium',
+      labels: [],
+      assignee: null,
+      estimate: null,
+      epic_ref: null,
+      body: 'Body text',
+      filePath: join(tmpDir, 'st.md'),
+      created_at: '2026-01-01T00:00:00Z',
+      updated_at: '2026-01-01T00:00:00Z',
+    };
+    const result = await writeFile(story, story.filePath);
+    expect(result.ok).toBe(true);
+
+    const raw = await readFile(story.filePath, 'utf-8');
+    expect(raw).not.toContain('filePath');
+    expect(raw).toContain('Body text');
+  });
+
+  it('handles entities without body cleanly (no trailing blank section)', async () => {
+    const milestone: ParsedEntity = {
+      type: 'milestone',
+      id: 'ms_1',
+      title: 'Milestone',
+      status: 'backlog',
+      target_date: '',
+      body: '',
+      filePath: join(tmpDir, 'ms.md'),
+      created_at: '2026-01-01T00:00:00Z',
+      updated_at: '2026-01-01T00:00:00Z',
+    };
+    const result = await writeFile(milestone, milestone.filePath);
+    expect(result.ok).toBe(true);
+
+    const raw = await readFile(milestone.filePath, 'utf-8');
+    // Ends with `---\n` (no body section appended)
+    expect(raw.endsWith('---\n')).toBe(true);
+  });
+
+  it('returns a Result error when the destination cannot be created', async () => {
+    // Block writeFile by making the parent path a regular file.
+    const blocker = join(tmpDir, 'blocker');
+    await fsWriteFile(blocker, 'blocker');
+    const story: ParsedEntity = {
+      type: 'story',
+      id: 'st_1',
+      title: 'Blocked',
+      status: 'todo',
+      priority: 'medium',
+      labels: [],
+      assignee: null,
+      estimate: null,
+      epic_ref: null,
+      body: '',
+      filePath: join(blocker, 'nested', 'st.md'),
+      created_at: '2026-01-01T00:00:00Z',
+      updated_at: '2026-01-01T00:00:00Z',
+    };
+    const result = await writeFile(story, story.filePath);
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.message).toContain('Failed to write');
+  });
+});

--- a/packages/core/src/writer/writer.test.ts
+++ b/packages/core/src/writer/writer.test.ts
@@ -102,6 +102,88 @@ describe('round-trip: parse → write → parse', () => {
   });
 });
 
+describe('writeTree error paths', () => {
+  it('returns an error result when an entity cannot be written', async () => {
+    const tmpDir = await mkdtemp(join(tmpdir(), 'gitpm-writetree-err-'));
+    try {
+      // Blocking: metaDir is a file, not a dir.
+      const metaDir = join(tmpDir, 'meta-file');
+      const { writeFile: fsWrite } = await import('node:fs/promises');
+      await fsWrite(metaDir, 'blocker');
+
+      const tree = {
+        stories: [],
+        epics: [],
+        milestones: [],
+        roadmaps: [],
+        prds: [],
+        sprints: [
+          {
+            type: 'sprint' as const,
+            id: 'sp1',
+            title: 'S',
+            status: 'todo' as const,
+            start_date: '2026-01-01',
+            end_date: '2026-01-14',
+            stories: [],
+            body: '',
+            filePath: join(metaDir, 'sprints', 'sp1.md'),
+            created_at: '2026-01-01T00:00:00Z',
+            updated_at: '2026-01-01T00:00:00Z',
+          },
+        ],
+        errors: [],
+      };
+
+      const result = await writeTree(tree, metaDir);
+      expect(result.ok).toBe(false);
+    } finally {
+      await rm(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it('handles tree with undefined sprints field', async () => {
+    const tmpDir = await mkdtemp(join(tmpdir(), 'gitpm-writetree-nosprints-'));
+    try {
+      const metaDir = join(tmpDir, '.meta');
+      const tree = {
+        stories: [],
+        epics: [],
+        milestones: [],
+        roadmaps: [],
+        prds: [],
+        errors: [],
+      } as unknown as Parameters<typeof writeTree>[0];
+      const result = await writeTree(tree, metaDir);
+      expect(result.ok).toBe(true);
+    } finally {
+      await rm(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it('returns an error when iterating fails unexpectedly', async () => {
+    // Force the try/catch by passing a tree-like object whose accessors throw.
+    const bad = {
+      get stories(): never[] {
+        throw new Error('boom');
+      },
+      epics: [],
+      milestones: [],
+      roadmaps: [],
+      prds: [],
+      sprints: [],
+      errors: [],
+    };
+    const result = await writeTree(
+      bad as unknown as Parameters<typeof writeTree>[0],
+      '/tmp/nowhere',
+    );
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.message).toContain('/tmp/nowhere');
+  });
+});
+
 describe('scaffoldMeta', () => {
   it('creates a valid .meta tree', async () => {
     const tmpDir = await mkdtemp(join(tmpdir(), 'gitpm-scaffold-'));


### PR DESCRIPTION
Adds tests for previously-uncovered paths across parser, resolver,
writer, archiver, plugin-loader, and analytics modules:

- analytics/graph-data: roadmap/prd/sprint node + edge construction
  and nullish sprint fallback.
- writer/create-entity: createSprint happy path + defaults, epic slug
  suffix bump, milestone/sprint write-failure paths, milestone defaults.
- writer/set-fields: dispatch + zod validation for epic/milestone/prd/
  roadmap, dangerous-key nested rejection, -= on non-array, unknown type.
- writer/write-tree: iteration error catch and undefined sprints branch.
- writer/write-file: roadmap YAML output, filePath omission, dirless
  body, write-failure error result.
- resolver/resolve: unresolved story->epic, roadmap->milestone, and
  prd->epic references; sprint->story resolution with missing ref.
- parser/parse-file: non-object YAML, malformed YAML, missing type,
  Date coercion (top-level and nested).
- parser/parse-tree: invalid schema-extensions, per-file parse error
  collection, sprint ingestion, outer catch for missing dir.
- plugin-loader: missing relative adapter, escape-outside-root guard,
  invalid SyncAdapter export, default-export adapter, malformed
  package.json in getPackageEntry, hook escape-outside-root guard.
- archiver: parse failure skip, roadmap skip, invalid-date skip,
  outer catch for missing dir.

Flips story to in_review.