### PR TITLE
test(sync-github): raise coverage above 80% on all source files

### DIFF
--- a/.meta/epics/test-coverage-to-100-on-source-code/stories/add-test-coverage-for-packagessync-github-to-100.md
+++ b/.meta/epics/test-coverage-to-100-on-source-code/stories/add-test-coverage-for-packagessync-github-to-100.md
@@ -2,7 +2,7 @@
 type: story
 id: gZqoT27kxWyx
 title: Add test coverage for packages/sync-github to 100%
-status: todo
+status: in_review
 priority: high
 assignee: null
 labels:
@@ -12,7 +12,7 @@ estimate: null
 epic_ref:
   id: xGG0RMogvzyo
 created_at: 2026-04-12T19:34:57.917Z
-updated_at: 2026-04-12T19:34:57.917Z
+updated_at: 2026-04-19T12:50:08.430Z
 ---
 
 ## Objective

--- a/packages/sync-github/src/__tests__/adapter.test.ts
+++ b/packages/sync-github/src/__tests__/adapter.test.ts
@@ -1,0 +1,224 @@
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockImport = vi.fn();
+const mockExport = vi.fn();
+const mockSync = vi.fn();
+
+vi.mock('../import.js', () => ({
+  importFromGitHub: (opts: unknown) => mockImport(opts),
+}));
+vi.mock('../export.js', () => ({
+  exportToGitHub: (opts: unknown) => mockExport(opts),
+}));
+vi.mock('../sync.js', () => ({
+  syncWithGitHub: (opts: unknown) => mockSync(opts),
+}));
+
+import { githubAdapter } from '../adapter.js';
+
+describe('githubAdapter', () => {
+  let tmpDir: string;
+  let metaDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await mkdtemp(join(tmpdir(), 'gitpm-adapter-test-'));
+    metaDir = join(tmpDir, '.meta');
+    mockImport.mockReset();
+    mockExport.mockReset();
+    mockSync.mockReset();
+    mockImport.mockResolvedValue({ ok: true, value: {} });
+    mockExport.mockResolvedValue({ ok: true, value: {} });
+    mockSync.mockResolvedValue({ ok: true, value: {} });
+  });
+
+  afterEach(async () => {
+    await rm(tmpDir, { recursive: true, force: true });
+    vi.restoreAllMocks();
+  });
+
+  describe('metadata', () => {
+    it('exposes name and displayName', () => {
+      expect(githubAdapter.name).toBe('github');
+      expect(githubAdapter.displayName).toBe('GitHub');
+    });
+  });
+
+  describe('detect', () => {
+    it('returns false when no config exists', async () => {
+      const result = await githubAdapter.detect(metaDir);
+      expect(result).toBe(false);
+    });
+
+    it('returns true when github-config.yaml exists', async () => {
+      await mkdir(join(metaDir, 'sync'), { recursive: true });
+      await writeFile(
+        join(metaDir, 'sync', 'github-config.yaml'),
+        'repo: owner/repo\nauto_sync: false\n',
+        'utf-8',
+      );
+      const result = await githubAdapter.detect(metaDir);
+      expect(result).toBe(true);
+    });
+  });
+
+  describe('import', () => {
+    it('returns error when no token is provided', async () => {
+      const result = await githubAdapter.import({ metaDir });
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error.message).toContain('GitHub token is required');
+      }
+    });
+
+    it('returns error when no repo is provided', async () => {
+      const result = await githubAdapter.import({
+        metaDir,
+        token: 'tok',
+      });
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error.message).toContain('GitHub repo is required');
+      }
+    });
+
+    it('forwards to importFromGitHub when token and repo given as top-level', async () => {
+      await githubAdapter.import({
+        metaDir,
+        token: 'tok',
+        repo: 'owner/repo',
+        projectNumber: 7,
+        linkStrategy: 'body-refs',
+      });
+      expect(mockImport).toHaveBeenCalledWith({
+        token: 'tok',
+        repo: 'owner/repo',
+        projectNumber: 7,
+        metaDir,
+        linkStrategy: 'body-refs',
+      });
+    });
+
+    it('resolves token and repo from credentials map', async () => {
+      await githubAdapter.import({
+        metaDir,
+        credentials: { token: 'tok2', repo: 'a/b' },
+      });
+      expect(mockImport).toHaveBeenCalledWith(
+        expect.objectContaining({ token: 'tok2', repo: 'a/b', metaDir }),
+      );
+    });
+  });
+
+  describe('export', () => {
+    it('returns error when no token is provided', async () => {
+      const result = await githubAdapter.export({ metaDir });
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error.message).toContain('GitHub token is required');
+      }
+    });
+
+    it('returns error when no repo can be resolved', async () => {
+      const result = await githubAdapter.export({
+        metaDir,
+        token: 'tok',
+      });
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error.message).toContain('GitHub repo is required');
+      }
+    });
+
+    it('forwards to exportToGitHub with top-level repo', async () => {
+      await githubAdapter.export({
+        metaDir,
+        token: 'tok',
+        repo: 'owner/repo',
+        dryRun: true,
+      });
+      expect(mockExport).toHaveBeenCalledWith({
+        token: 'tok',
+        repo: 'owner/repo',
+        metaDir,
+        dryRun: true,
+      });
+    });
+
+    it('falls back to repo from github-config.yaml', async () => {
+      await mkdir(join(metaDir, 'sync'), { recursive: true });
+      await writeFile(
+        join(metaDir, 'sync', 'github-config.yaml'),
+        'repo: config/repo\nauto_sync: false\n',
+        'utf-8',
+      );
+      await githubAdapter.export({ metaDir, token: 'tok' });
+      expect(mockExport).toHaveBeenCalledWith(
+        expect.objectContaining({ repo: 'config/repo' }),
+      );
+    });
+
+    it('falls back to repo from credentials map', async () => {
+      await githubAdapter.export({
+        metaDir,
+        credentials: { token: 'tok', repo: 'cred/repo' },
+      });
+      expect(mockExport).toHaveBeenCalledWith(
+        expect.objectContaining({ repo: 'cred/repo' }),
+      );
+    });
+  });
+
+  describe('sync', () => {
+    it('returns error when no token is provided', async () => {
+      const result = await githubAdapter.sync({ metaDir });
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error.message).toContain('GitHub token is required');
+      }
+    });
+
+    it('returns error when no repo can be resolved', async () => {
+      const result = await githubAdapter.sync({
+        metaDir,
+        token: 'tok',
+      });
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error.message).toContain('GitHub repo is required');
+      }
+    });
+
+    it('forwards to syncWithGitHub with top-level repo', async () => {
+      await githubAdapter.sync({
+        metaDir,
+        token: 'tok',
+        repo: 'owner/repo',
+        strategy: 'local-wins',
+        dryRun: false,
+      });
+      expect(mockSync).toHaveBeenCalledWith({
+        token: 'tok',
+        repo: 'owner/repo',
+        metaDir,
+        strategy: 'local-wins',
+        dryRun: false,
+      });
+    });
+
+    it('falls back to repo from github-config.yaml', async () => {
+      await mkdir(join(metaDir, 'sync'), { recursive: true });
+      await writeFile(
+        join(metaDir, 'sync', 'github-config.yaml'),
+        'repo: config/sync\nauto_sync: false\n',
+        'utf-8',
+      );
+      await githubAdapter.sync({ metaDir, token: 'tok' });
+      expect(mockSync).toHaveBeenCalledWith(
+        expect.objectContaining({ repo: 'config/sync' }),
+      );
+    });
+  });
+});

--- a/packages/sync-github/src/__tests__/checkpoint.test.ts
+++ b/packages/sync-github/src/__tests__/checkpoint.test.ts
@@ -95,6 +95,23 @@ describe('checkpoint', () => {
       expect(result.ok).toBe(false);
     });
 
+    it('returns error when the checkpoint file has invalid format', async () => {
+      const { writeFile } = await import('node:fs/promises');
+      const { mkdir } = await import('node:fs/promises');
+      await mkdir(join(tmpDir, '.gitpm'), { recursive: true });
+      // Invalid: missing required fields
+      await writeFile(
+        join(tmpDir, '.gitpm', 'sync-checkpoint.json'),
+        '{"foo":"bar"}',
+        'utf-8',
+      );
+      const result = await loadCheckpoint(tmpDir);
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error.message).toContain('Invalid checkpoint format');
+      }
+    });
+
     it('overwrites existing checkpoint on save', async () => {
       await saveCheckpoint(tmpDir, sampleCheckpoint);
 
@@ -115,6 +132,39 @@ describe('checkpoint', () => {
       if (loadResult.ok) {
         expect(loadResult.value.processedEntityIds).toHaveLength(4);
         expect(loadResult.value.lastError).toBeUndefined();
+      }
+    });
+  });
+
+  describe('error branches', () => {
+    it('hasCheckpoint returns error for non-ENOENT failures', async () => {
+      // A path containing a NUL byte makes stat reject with a non-ENOENT error
+      const result = await hasCheckpoint(`${tmpDir}\u0000/bad`);
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error.message).toContain(
+          'Failed to check for checkpoint',
+        );
+      }
+    });
+
+    it('saveCheckpoint returns error for invalid target path', async () => {
+      const result = await saveCheckpoint(`${tmpDir}\u0000/bad`, {
+        startedAt: '2026-01-01T00:00:00Z',
+        repo: 'o/r',
+        processedEntityIds: [],
+      });
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error.message).toContain('Failed to save checkpoint');
+      }
+    });
+
+    it('clearCheckpoint returns error for invalid path', async () => {
+      const result = await clearCheckpoint(`${tmpDir}\u0000/bad`);
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error.message).toContain('Failed to clear checkpoint');
       }
     });
   });

--- a/packages/sync-github/src/__tests__/client.test.ts
+++ b/packages/sync-github/src/__tests__/client.test.ts
@@ -1,0 +1,300 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+type OctokitInstance = {
+  issues: {
+    listMilestones: ReturnType<typeof vi.fn>;
+    listForRepo: ReturnType<typeof vi.fn>;
+    get: ReturnType<typeof vi.fn>;
+    getMilestone: ReturnType<typeof vi.fn>;
+    create: ReturnType<typeof vi.fn>;
+    update: ReturnType<typeof vi.fn>;
+    createMilestone: ReturnType<typeof vi.fn>;
+    updateMilestone: ReturnType<typeof vi.fn>;
+  };
+  request: ReturnType<typeof vi.fn>;
+};
+
+const octokitInstance: OctokitInstance = {
+  issues: {
+    listMilestones: vi.fn(),
+    listForRepo: vi.fn(),
+    get: vi.fn(),
+    getMilestone: vi.fn(),
+    create: vi.fn(),
+    update: vi.fn(),
+    createMilestone: vi.fn(),
+    updateMilestone: vi.fn(),
+  },
+  request: vi.fn(),
+};
+
+vi.mock('@octokit/rest', () => ({
+  Octokit: class {
+    issues = octokitInstance.issues;
+    request = octokitInstance.request;
+  },
+}));
+
+import { GitHubClient } from '../client.js';
+
+function okResponse<T>(data: T, headers: Record<string, string> = {}) {
+  return {
+    data,
+    headers: {
+      'x-ratelimit-remaining': '4999',
+      'x-ratelimit-reset': '0',
+      ...headers,
+    },
+    status: 200,
+    url: '',
+  };
+}
+
+describe('GitHubClient', () => {
+  let client: GitHubClient;
+
+  beforeEach(() => {
+    // Reset every mock method on the instance but keep identity
+    for (const fn of Object.values(octokitInstance.issues)) {
+      fn.mockReset();
+    }
+    octokitInstance.request.mockReset();
+    client = new GitHubClient('test-token');
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('listMilestones', () => {
+    it('fetches open and closed milestones and combines them', async () => {
+      octokitInstance.issues.listMilestones
+        .mockResolvedValueOnce(okResponse([{ number: 1, title: 'Open MS' }]))
+        .mockResolvedValueOnce(okResponse([{ number: 2, title: 'Closed MS' }]));
+
+      const result = await client.listMilestones('owner', 'repo');
+      expect(result).toEqual([
+        { number: 1, title: 'Open MS' },
+        { number: 2, title: 'Closed MS' },
+      ]);
+      expect(octokitInstance.issues.listMilestones).toHaveBeenCalledTimes(2);
+    });
+
+    it('paginates until fewer than perPage results are returned', async () => {
+      const firstPage = Array.from({ length: 100 }, (_, i) => ({
+        number: i + 1,
+        title: `MS ${i + 1}`,
+      }));
+      const secondPage = [{ number: 101, title: 'MS 101' }];
+
+      octokitInstance.issues.listMilestones
+        .mockResolvedValueOnce(okResponse(firstPage))
+        .mockResolvedValueOnce(okResponse(secondPage))
+        .mockResolvedValueOnce(okResponse([])); // closed
+
+      const result = await client.listMilestones('owner', 'repo');
+      expect(result).toHaveLength(101);
+      expect(octokitInstance.issues.listMilestones).toHaveBeenCalledTimes(3);
+    });
+  });
+
+  describe('listIssues', () => {
+    it('filters out pull requests', async () => {
+      octokitInstance.issues.listForRepo.mockResolvedValueOnce(
+        okResponse([
+          { number: 1, title: 'issue' },
+          { number: 2, title: 'pr', pull_request: { url: 'http://x' } },
+        ]),
+      );
+
+      const result = await client.listIssues('owner', 'repo');
+      expect(result).toEqual([{ number: 1, title: 'issue' }]);
+    });
+
+    it('passes state option through', async () => {
+      octokitInstance.issues.listForRepo.mockResolvedValueOnce(okResponse([]));
+      await client.listIssues('owner', 'repo', { state: 'open' });
+      expect(octokitInstance.issues.listForRepo).toHaveBeenCalledWith(
+        expect.objectContaining({ state: 'open' }),
+      );
+    });
+
+    it('defaults state to "all" when no option given', async () => {
+      octokitInstance.issues.listForRepo.mockResolvedValueOnce(okResponse([]));
+      await client.listIssues('owner', 'repo');
+      expect(octokitInstance.issues.listForRepo).toHaveBeenCalledWith(
+        expect.objectContaining({ state: 'all' }),
+      );
+    });
+  });
+
+  describe('getProject / getProjectItems (GraphQL stubs)', () => {
+    it('returns null for getProject', async () => {
+      const r = await client.getProject('o', 'r', 1);
+      expect(r).toBeNull();
+    });
+    it('returns [] for getProjectItems', async () => {
+      const r = await client.getProjectItems('PVT_1');
+      expect(r).toEqual([]);
+    });
+  });
+
+  describe('listSubIssues', () => {
+    it('returns sub-issue list when API succeeds', async () => {
+      octokitInstance.request.mockResolvedValueOnce(
+        okResponse([{ id: 10, number: 10, title: 'Sub A' }]),
+      );
+      const result = await client.listSubIssues('o', 'r', 1);
+      expect(result).toEqual([{ id: 10, number: 10, title: 'Sub A' }]);
+    });
+
+    it('returns [] when the API call throws (endpoint unavailable)', async () => {
+      octokitInstance.request.mockRejectedValueOnce(new Error('not found'));
+      const result = await client.listSubIssues('o', 'r', 1);
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe('getIssue', () => {
+    it('returns issue when found', async () => {
+      octokitInstance.issues.get.mockResolvedValueOnce(
+        okResponse({ number: 1, title: 'Found' }),
+      );
+      const result = await client.getIssue('o', 'r', 1);
+      expect(result).toEqual({ number: 1, title: 'Found' });
+    });
+
+    it('returns null when the API throws', async () => {
+      octokitInstance.issues.get.mockRejectedValueOnce(new Error('not found'));
+      const result = await client.getIssue('o', 'r', 999);
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('getMilestone', () => {
+    it('returns milestone when found', async () => {
+      octokitInstance.issues.getMilestone.mockResolvedValueOnce(
+        okResponse({ number: 1, title: 'Found' }),
+      );
+      const result = await client.getMilestone('o', 'r', 1);
+      expect(result).toEqual({ number: 1, title: 'Found' });
+    });
+
+    it('returns null when the API throws', async () => {
+      octokitInstance.issues.getMilestone.mockRejectedValueOnce(
+        new Error('not found'),
+      );
+      const result = await client.getMilestone('o', 'r', 999);
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('createIssue / updateIssue', () => {
+    it('creates an issue and returns data', async () => {
+      octokitInstance.issues.create.mockResolvedValueOnce(
+        okResponse({ number: 42, title: 'Hello' }),
+      );
+      const result = await client.createIssue('o', 'r', { title: 'Hello' });
+      expect(result).toEqual({ number: 42, title: 'Hello' });
+      expect(octokitInstance.issues.create).toHaveBeenCalledWith(
+        expect.objectContaining({ owner: 'o', repo: 'r', title: 'Hello' }),
+      );
+    });
+
+    it('updates an issue and returns data', async () => {
+      octokitInstance.issues.update.mockResolvedValueOnce(
+        okResponse({ number: 42, title: 'Updated' }),
+      );
+      const result = await client.updateIssue('o', 'r', 42, {
+        state: 'closed',
+      });
+      expect(result).toEqual({ number: 42, title: 'Updated' });
+      expect(octokitInstance.issues.update).toHaveBeenCalledWith(
+        expect.objectContaining({ issue_number: 42, state: 'closed' }),
+      );
+    });
+  });
+
+  describe('createMilestone / updateMilestone', () => {
+    it('creates a milestone', async () => {
+      octokitInstance.issues.createMilestone.mockResolvedValueOnce(
+        okResponse({ number: 3, title: 'New MS' }),
+      );
+      const result = await client.createMilestone('o', 'r', {
+        title: 'New MS',
+      });
+      expect(result).toEqual({ number: 3, title: 'New MS' });
+    });
+
+    it('updates a milestone', async () => {
+      octokitInstance.issues.updateMilestone.mockResolvedValueOnce(
+        okResponse({ number: 3, title: 'Updated MS' }),
+      );
+      const result = await client.updateMilestone('o', 'r', 3, {
+        title: 'Updated MS',
+      });
+      expect(result).toEqual({ number: 3, title: 'Updated MS' });
+      expect(octokitInstance.issues.updateMilestone).toHaveBeenCalledWith(
+        expect.objectContaining({ milestone_number: 3 }),
+      );
+    });
+  });
+
+  describe('rate limit handling', () => {
+    it('warns when remaining is low', async () => {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      octokitInstance.issues.get.mockResolvedValueOnce(
+        okResponse({ number: 1, title: 'x' }, { 'x-ratelimit-remaining': '5' }),
+      );
+      await client.getIssue('o', 'r', 1);
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('rate limit low'),
+      );
+    });
+
+    it('sleeps and warns when remaining is 0 and reset is in the future', async () => {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      const setTimeoutSpy = vi.spyOn(global, 'setTimeout').mockImplementation(((
+        cb: () => void,
+      ) => {
+        cb();
+        return 0 as unknown as NodeJS.Timeout;
+      }) as typeof setTimeout);
+
+      const futureReset = Math.floor(Date.now() / 1000) + 60;
+      octokitInstance.issues.get.mockResolvedValueOnce(
+        okResponse(
+          { number: 1, title: 'x' },
+          {
+            'x-ratelimit-remaining': '0',
+            'x-ratelimit-reset': String(futureReset),
+          },
+        ),
+      );
+      await client.getIssue('o', 'r', 1);
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Rate limit exhausted'),
+      );
+      setTimeoutSpy.mockRestore();
+    });
+
+    it('does not sleep when reset is in the past', async () => {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      const setTimeoutSpy = vi.spyOn(global, 'setTimeout');
+
+      const pastReset = Math.floor(Date.now() / 1000) - 60;
+      octokitInstance.issues.get.mockResolvedValueOnce(
+        okResponse(
+          { number: 1, title: 'x' },
+          {
+            'x-ratelimit-remaining': '0',
+            'x-ratelimit-reset': String(pastReset),
+          },
+        ),
+      );
+      await client.getIssue('o', 'r', 1);
+      expect(warnSpy).not.toHaveBeenCalled();
+      expect(setTimeoutSpy).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/sync-github/src/__tests__/config.test.ts
+++ b/packages/sync-github/src/__tests__/config.test.ts
@@ -1,0 +1,87 @@
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { createDefaultConfig, loadConfig, saveConfig } from '../config.js';
+
+describe('config', () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await mkdtemp(join(tmpdir(), 'gitpm-config-test-'));
+  });
+
+  afterEach(async () => {
+    await rm(tmpDir, { recursive: true, force: true });
+  });
+
+  describe('loadConfig', () => {
+    it('loads a valid config file', async () => {
+      await mkdir(join(tmpDir, 'sync'), { recursive: true });
+      await writeFile(
+        join(tmpDir, 'sync', 'github-config.yaml'),
+        'repo: owner/name\nauto_sync: true\n',
+        'utf-8',
+      );
+      const result = await loadConfig(tmpDir);
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.value.repo).toBe('owner/name');
+        expect(result.value.auto_sync).toBe(true);
+      }
+    });
+
+    it('returns error when file does not exist', async () => {
+      const result = await loadConfig(tmpDir);
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error.message).toContain('Failed to load GitHub config');
+      }
+    });
+  });
+
+  describe('saveConfig', () => {
+    it('round-trips a config through save and load', async () => {
+      const cfg = createDefaultConfig('owner/name', 3);
+      const saveResult = await saveConfig(tmpDir, cfg);
+      expect(saveResult.ok).toBe(true);
+
+      const loadResult = await loadConfig(tmpDir);
+      expect(loadResult.ok).toBe(true);
+      if (loadResult.ok) {
+        expect(loadResult.value.repo).toBe('owner/name');
+        expect(loadResult.value.project_number).toBe(3);
+        expect(loadResult.value.auto_sync).toBe(false);
+      }
+    });
+
+    it('returns error when target path is invalid', async () => {
+      const result = await saveConfig(
+        `${tmpDir}\u0000/bad`,
+        createDefaultConfig('a/b'),
+      );
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error.message).toContain('Failed to save GitHub config');
+      }
+    });
+  });
+
+  describe('createDefaultConfig', () => {
+    it('returns sensible defaults', () => {
+      const cfg = createDefaultConfig('owner/name');
+      expect(cfg.repo).toBe('owner/name');
+      expect(cfg.auto_sync).toBe(false);
+      expect(cfg.label_mapping.epic_labels).toContain('epic');
+      expect(cfg.status_mapping).toMatchObject({ Todo: 'todo', Done: 'done' });
+    });
+
+    it('merges custom status mappings on top of defaults', () => {
+      const cfg = createDefaultConfig('o/n', undefined, {
+        Planned: 'todo',
+      });
+      expect(cfg.status_mapping.Planned).toBe('todo');
+      expect(cfg.status_mapping.Done).toBe('done');
+    });
+  });
+});

--- a/packages/sync-github/src/__tests__/diff.test.ts
+++ b/packages/sync-github/src/__tests__/diff.test.ts
@@ -1,4 +1,4 @@
-import type { Milestone, Story } from '@gitpm/core';
+import type { Epic, Milestone, Story } from '@gitpm/core';
 import { describe, expect, it } from 'vitest';
 import type { GhIssue, GhMilestone } from '../client.js';
 import {
@@ -181,6 +181,94 @@ describe('diffEntity', () => {
     expect(result.conflicts[0].field).toBe('status');
     expect(result.conflicts[0].localValue).toBe('in_progress');
     expect(result.conflicts[0].remoteValue).toBe('done');
+  });
+
+  it('diffs epic entities (covers epic branch in localEntityFields)', () => {
+    const baseEpic: Epic = {
+      type: 'epic',
+      id: 'epic-001',
+      title: 'Epic',
+      status: 'todo',
+      priority: 'medium',
+      owner: 'alice',
+      labels: ['backend'],
+      milestone_ref: null,
+      github: null,
+      body: 'Epic body',
+      created_at: '2026-01-01T00:00:00Z',
+      updated_at: '2026-01-01T00:00:00Z',
+      filePath: '.meta/epics/e/epic.md',
+    };
+    const baseline = {
+      title: 'Epic',
+      status: 'todo',
+      priority: 'medium',
+      owner: 'alice',
+      labels: ['backend'],
+      body: 'Epic body',
+    };
+    const modified: Epic = { ...baseEpic, owner: 'bob' };
+    const result = diffEntity(modified, baseline, baseline, baseline);
+    expect(result.status).toBe('local_changed');
+    expect(result.localChanges[0].field).toBe('owner');
+  });
+
+  it('diffs non-story/epic/milestone entities (covers default branch)', () => {
+    const roadmap = {
+      type: 'roadmap' as const,
+      id: 'rm',
+      title: 'Roadmap',
+      description: '',
+      milestones: [],
+      updated_at: '2026-01-01T00:00:00Z',
+      filePath: '.meta/roadmap/roadmap.yaml',
+    };
+    const baseline = { title: 'Roadmap' };
+    const result = diffEntity(roadmap, baseline, baseline, baseline);
+    expect(result.status).toBe('in_sync');
+  });
+
+  it('diffs milestone entities (covers milestone branch in localEntityFields)', () => {
+    const baseMilestone: Milestone = {
+      type: 'milestone',
+      id: 'ms-001',
+      title: 'Q2',
+      status: 'in_progress',
+      target_date: '2026-06-30T00:00:00Z',
+      github: null,
+      body: 'body',
+      created_at: '2026-01-01T00:00:00Z',
+      updated_at: '2026-01-01T00:00:00Z',
+      filePath: '.meta/roadmap/milestones/q2.md',
+    };
+    const baseline = {
+      title: 'Q2',
+      status: 'in_progress',
+      target_date: '2026-06-30T00:00:00Z',
+      body: 'body',
+    };
+    const modified: Milestone = { ...baseMilestone, status: 'done' };
+    const result = diffEntity(modified, baseline, baseline, baseline);
+    expect(result.status).toBe('local_changed');
+  });
+
+  it('ignores string changes that differ only in surrounding whitespace', () => {
+    // This specifically exercises the string-trim branch of fieldEquals (line 113 in diff.ts).
+    const baseline = {
+      title: 'Story',
+      status: 'todo',
+      priority: 'medium',
+      labels: ['frontend'],
+      assignee: 'alice',
+      body: '   hello world   ',
+    };
+    const remote = {
+      ...baseline,
+      body: 'hello world',
+    };
+    const result = diffEntity(baseStory, remote, baseline, baseline);
+    // "body" trimmed → equal on both sides → no remote_changed
+    expect(result.status).toBe('local_changed');
   });
 
   it('does not conflict when both changed to same value', () => {

--- a/packages/sync-github/src/__tests__/export.test.ts
+++ b/packages/sync-github/src/__tests__/export.test.ts
@@ -1,13 +1,14 @@
-import { mkdtemp, rm } from 'node:fs/promises';
+import { mkdtemp, rm, unlink } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import { writeFile as coreWriteFile, parseTree } from '@gitpm/core';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import fixtureIssues from '../__fixtures__/github-issues.json';
 import fixtureMilestones from '../__fixtures__/github-milestones.json';
 import type { GhIssue, GhMilestone } from '../client.js';
 import { exportToGitHub } from '../export.js';
 import { importFromGitHub } from '../import.js';
-import { loadState } from '../state.js';
+import { loadState, saveState } from '../state.js';
 
 // Track mock calls
 const mockCreateIssue = vi.fn().mockImplementation(async () => ({
@@ -159,6 +160,195 @@ describe('exportToGitHub', () => {
     if (stateBefore.ok && stateAfter.ok) {
       expect(stateAfter.value.last_sync).toBe(stateBefore.value.last_sync);
     }
+  });
+
+  it('closes GitHub issues/milestones for locally-deleted entities', async () => {
+    await importFromGitHub({
+      token: 'test-token',
+      repo: 'test-org/test-repo',
+      metaDir,
+    });
+
+    const tree = await parseTree(metaDir);
+    if (!tree.ok) throw new Error('parseTree failed');
+    const story = tree.value.stories[0];
+    const milestone = tree.value.milestones[0];
+
+    await unlink(story.filePath);
+    await unlink(milestone.filePath);
+
+    const result = await exportToGitHub({
+      token: 'test-token',
+      repo: 'test-org/test-repo',
+      metaDir,
+    });
+
+    expect(result.ok).toBe(true);
+    expect(mockUpdateIssue).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.any(String),
+      expect.any(Number),
+      expect.objectContaining({ state: 'closed' }),
+    );
+    expect(mockUpdateMilestone).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.any(String),
+      expect.any(Number),
+      expect.objectContaining({ state: 'closed' }),
+    );
+  });
+
+  it('creates brand new milestone + issue (status=done) when they are absent from state', async () => {
+    await importFromGitHub({
+      token: 'test-token',
+      repo: 'test-org/test-repo',
+      metaDir,
+    });
+
+    const tree = await parseTree(metaDir);
+    if (!tree.ok) throw new Error('parseTree failed');
+    const milestone = tree.value.milestones[0];
+    const story = tree.value.stories[0];
+    milestone.github = null;
+    story.github = null;
+    story.status = 'done';
+    await coreWriteFile(milestone, milestone.filePath);
+    await coreWriteFile(story, story.filePath);
+
+    const state = await loadState(metaDir);
+    if (!state.ok) throw new Error('loadState failed');
+    delete state.value.entities[milestone.id];
+    delete state.value.entities[story.id];
+    await saveState(metaDir, state.value);
+
+    const result = await exportToGitHub({
+      token: 'test-token',
+      repo: 'test-org/test-repo',
+      metaDir,
+    });
+    expect(result.ok).toBe(true);
+    expect(mockCreateMilestone).toHaveBeenCalled();
+    expect(mockCreateIssue).toHaveBeenCalled();
+    // status=done → close after create
+    expect(mockUpdateIssue).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.any(String),
+      expect.any(Number),
+      expect.objectContaining({ state: 'closed' }),
+    );
+  });
+
+  it('pushes local hash-changed updates to GitHub', async () => {
+    await importFromGitHub({
+      token: 'test-token',
+      repo: 'test-org/test-repo',
+      metaDir,
+    });
+
+    const tree = await parseTree(metaDir);
+    if (!tree.ok) throw new Error('parseTree failed');
+    const story = tree.value.stories[0];
+    const milestone = tree.value.milestones[0];
+
+    // Force stale hash in sync state so exportToGitHub detects change.
+    const state = await loadState(metaDir);
+    if (!state.ok) throw new Error('loadState failed');
+    state.value.entities[story.id] = {
+      ...state.value.entities[story.id],
+      local_hash: 'sha256:stale',
+    };
+    state.value.entities[milestone.id] = {
+      ...state.value.entities[milestone.id],
+      local_hash: 'sha256:stale',
+    };
+    await saveState(metaDir, state.value);
+
+    const result = await exportToGitHub({
+      token: 'test-token',
+      repo: 'test-org/test-repo',
+      metaDir,
+    });
+    expect(result.ok).toBe(true);
+    expect(mockUpdateIssue).toHaveBeenCalled();
+    expect(mockUpdateMilestone).toHaveBeenCalled();
+  });
+
+  it('returns an error when parseTree fails for a missing directory', async () => {
+    const result = await exportToGitHub({
+      token: 'test-token',
+      repo: 'test-org/test-repo',
+      metaDir: join(tmpDir, 'does-not-exist'),
+    });
+    expect(result.ok).toBe(false);
+  });
+
+  it('returns an error when createIssue rejects with a non-Error', async () => {
+    await importFromGitHub({
+      token: 'test-token',
+      repo: 'test-org/test-repo',
+      metaDir,
+    });
+
+    const tree = await parseTree(metaDir);
+    if (!tree.ok) throw new Error('parseTree failed');
+    const story = tree.value.stories[0];
+    story.github = null;
+    await coreWriteFile(story, story.filePath);
+
+    const state = await loadState(metaDir);
+    if (!state.ok) throw new Error('loadState failed');
+    delete state.value.entities[story.id];
+    await saveState(metaDir, state.value);
+
+    // biome-ignore lint/suspicious/noExplicitAny: testing non-Error rejection
+    mockCreateIssue.mockRejectedValueOnce('quota' as any);
+
+    const result = await exportToGitHub({
+      token: 'test-token',
+      repo: 'test-org/test-repo',
+      metaDir,
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.message).toContain('Export failed');
+    }
+  });
+
+  it('resolves milestone number for new epic with milestone_ref', async () => {
+    await importFromGitHub({
+      token: 'test-token',
+      repo: 'test-org/test-repo',
+      metaDir,
+    });
+
+    const tree = await parseTree(metaDir);
+    if (!tree.ok) throw new Error('parseTree failed');
+    const milestone = tree.value.milestones[0];
+    const epic = tree.value.epics[0];
+    epic.milestone_ref = { id: milestone.id };
+    // Remove the github metadata so it is treated as new
+    epic.github = null;
+    await coreWriteFile(epic, epic.filePath);
+
+    const state = await loadState(metaDir);
+    if (!state.ok) throw new Error('loadState failed');
+    delete state.value.entities[epic.id];
+    await saveState(metaDir, state.value);
+
+    const result = await exportToGitHub({
+      token: 'test-token',
+      repo: 'test-org/test-repo',
+      metaDir,
+    });
+
+    expect(result.ok).toBe(true);
+    expect(mockCreateIssue).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.any(String),
+      expect.objectContaining({
+        milestone: state.value.entities[milestone.id].github_milestone_number,
+      }),
+    );
   });
 
   it('updates sync state after export', async () => {

--- a/packages/sync-github/src/__tests__/import.test.ts
+++ b/packages/sync-github/src/__tests__/import.test.ts
@@ -157,6 +157,77 @@ describe('importFromGitHub', () => {
     expect(storiesWithEpicRef.length).toBeGreaterThanOrEqual(2);
   });
 
+  it('fetches sub-issues when linkStrategy is "sub-issues"', async () => {
+    const { GitHubClient } = await import('../client.js');
+    const listSubIssuesMock = vi
+      .fn()
+      .mockResolvedValueOnce([
+        { id: 300, number: 3, title: 'Price Feed' },
+        { id: 400, number: 4, title: 'Solver' },
+      ])
+      .mockResolvedValue([]);
+    vi.mocked(GitHubClient).mockImplementation(function () {
+      return {
+        listMilestones: vi.fn().mockResolvedValue(fixtureMilestones),
+        listIssues: vi
+          .fn()
+          .mockResolvedValue(
+            (fixtureIssues as GhIssue[]).filter((i) => !i.pull_request),
+          ),
+        listSubIssues: listSubIssuesMock,
+        getProject: vi.fn().mockResolvedValue(null),
+        getProjectItems: vi.fn().mockResolvedValue([]),
+      } as never;
+    });
+
+    const result = await importFromGitHub({
+      ...defaultOptions,
+      metaDir,
+      linkStrategy: 'sub-issues',
+    });
+    expect(result.ok).toBe(true);
+    expect(listSubIssuesMock).toHaveBeenCalled();
+  });
+
+  it('returns error from outer catch when listMilestones throws an Error', async () => {
+    const { GitHubClient } = await import('../client.js');
+    vi.mocked(GitHubClient).mockImplementationOnce(function () {
+      return {
+        listMilestones: vi.fn().mockRejectedValue(new Error('auth failed')),
+        listIssues: vi.fn().mockResolvedValue([]),
+        listSubIssues: vi.fn().mockResolvedValue([]),
+        getProject: vi.fn().mockResolvedValue(null),
+        getProjectItems: vi.fn().mockResolvedValue([]),
+      } as never;
+    });
+
+    const result = await importFromGitHub({ ...defaultOptions, metaDir });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.message).toContain('auth failed');
+    }
+  });
+
+  it('wraps non-Error thrown values in outer catch', async () => {
+    const { GitHubClient } = await import('../client.js');
+    vi.mocked(GitHubClient).mockImplementationOnce(function () {
+      return {
+        // biome-ignore lint/suspicious/noExplicitAny: testing non-Error rejection
+        listMilestones: vi.fn().mockRejectedValue('string error' as any),
+        listIssues: vi.fn().mockResolvedValue([]),
+        listSubIssues: vi.fn().mockResolvedValue([]),
+        getProject: vi.fn().mockResolvedValue(null),
+        getProjectItems: vi.fn().mockResolvedValue([]),
+      } as never;
+    });
+
+    const result = await importFromGitHub({ ...defaultOptions, metaDir });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.message).toContain('Import failed');
+    }
+  });
+
   it('works with no milestones', async () => {
     // Re-mock to return empty milestones
     const { GitHubClient } = await import('../client.js');

--- a/packages/sync-github/src/__tests__/linker.test.ts
+++ b/packages/sync-github/src/__tests__/linker.test.ts
@@ -534,6 +534,33 @@ describe('resolveEpicLink', () => {
     });
   });
 
+  describe('unknown strategy', () => {
+    it('returns null for an unrecognized strategy name', () => {
+      const epic = makeEpic('epic1', 'My Epic');
+      const story = makeStory('story1', 'My Story');
+      const ghStory = makeGhIssue({ number: 2 });
+
+      const ctx: LinkContext = {
+        ghIssues: [makeGhIssue({ number: 1 }), ghStory],
+        issueNumberToEntity: new Map([
+          [1, epic],
+          [2, story],
+        ]),
+        epicIssueNumberToEpic: new Map([[1, epic]]),
+        epicSubIssues: new Map(),
+      };
+
+      // Cast through unknown to bypass TS exhaustiveness check
+      const result = resolveEpicLink(
+        ghStory,
+        story,
+        ctx,
+        'nonexistent' as unknown as 'all',
+      );
+      expect(result).toBeNull();
+    });
+  });
+
   describe('score strategy (composite)', () => {
     it('links via sub-issues match (10 pts, above threshold)', () => {
       const epic = makeEpic('epic1', 'My Epic');

--- a/packages/sync-github/src/__tests__/state.test.ts
+++ b/packages/sync-github/src/__tests__/state.test.ts
@@ -129,6 +129,21 @@ describe('computeContentHash', () => {
     const hash = computeContentHash(ms);
     expect(hash).toMatch(/^sha256:[a-f0-9]{64}$/);
   });
+
+  it('works for PRD entities (covers prd branch)', () => {
+    const prd = {
+      type: 'prd' as const,
+      id: 'prd-0001',
+      title: 'Example PRD',
+      status: 'todo' as const,
+      owner: null,
+      epic_refs: [],
+      body: 'PRD body',
+      filePath: '.meta/prd/example.md',
+    };
+    const hash = computeContentHash(prd);
+    expect(hash).toMatch(/^sha256:[a-f0-9]{64}$/);
+  });
 });
 
 describe('createInitialState', () => {
@@ -178,6 +193,37 @@ describe('createInitialState', () => {
     expect(entry.local_hash).toBe(entry.remote_hash);
     expect(entry.local_hash).toMatch(/^sha256:/);
   });
+
+  it('persists github_project_item_id from entity metadata', () => {
+    const story = makeStory({
+      github: {
+        issue_number: 5,
+        project_item_id: 'PVTI_abc',
+        repo: 'org/repo',
+        last_sync_hash: '',
+        synced_at: '',
+      },
+    });
+    const state = createInitialState('org/repo', [story]);
+    expect(state.entities['test-story-01'].github_project_item_id).toBe(
+      'PVTI_abc',
+    );
+  });
+
+  it('skips roadmap entities', () => {
+    const story = makeStory();
+    const roadmap = {
+      type: 'roadmap' as const,
+      id: 'rm',
+      title: 'Rm',
+      description: '',
+      milestones: [],
+      updated_at: '2026-01-01T00:00:00Z',
+      filePath: '.meta/roadmap/roadmap.yaml',
+    };
+    const state = createInitialState('org/repo', [story, roadmap]);
+    expect(Object.keys(state.entities)).toEqual(['test-story-01']);
+  });
 });
 
 describe('saveState / loadState', () => {
@@ -203,6 +249,33 @@ describe('saveState / loadState', () => {
       expect(loadResult.value.repo).toBe('org/repo');
       expect(loadResult.value.project_number).toBe(5);
       expect(Object.keys(loadResult.value.entities)).toHaveLength(2);
+    }
+  });
+
+  it('returns error when saveState target path is invalid', async () => {
+    // Use a path that includes a NUL byte to force mkdir/writeFile to throw
+    const result = await saveState(
+      `${tmpDir}\u0000/invalid`,
+      createInitialState('org/repo', [makeStory()]),
+    );
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.message).toContain('Failed to save sync state');
+    }
+  });
+
+  it('returns error when github-state.json is unparseable JSON', async () => {
+    const { mkdir, writeFile } = await import('node:fs/promises');
+    await mkdir(join(tmpDir, 'sync'), { recursive: true });
+    await writeFile(
+      join(tmpDir, 'sync', 'github-state.json'),
+      '{not json',
+      'utf-8',
+    );
+    const result = await loadState(tmpDir);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.message).toContain('Failed to load sync state');
     }
   });
 

--- a/packages/sync-github/src/__tests__/sync.test.ts
+++ b/packages/sync-github/src/__tests__/sync.test.ts
@@ -1,4 +1,5 @@
-import { mkdtemp, rm } from 'node:fs/promises';
+import { createHash } from 'node:crypto';
+import { mkdtemp, rm, unlink } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { writeFile as coreWriteFile, parseTree } from '@gitpm/core';
@@ -7,9 +8,17 @@ import fixtureIssues from '../__fixtures__/github-issues.json';
 import fixtureMilestones from '../__fixtures__/github-milestones.json';
 import { hasCheckpoint, saveCheckpoint } from '../checkpoint.js';
 import type { GhIssue, GhMilestone } from '../client.js';
+import { remoteIssueFields, remoteMilestoneFields } from '../diff.js';
 import { importFromGitHub } from '../import.js';
+import { loadState, saveState } from '../state.js';
 import { syncWithGitHub } from '../sync.js';
 import type { SyncCheckpoint } from '../types.js';
+
+function hashOf(fields: Record<string, unknown>): string {
+  return `sha256:${createHash('sha256').update(JSON.stringify(fields)).digest('hex')}`;
+}
+const remoteHashOfIssue = (gh: GhIssue) => hashOf(remoteIssueFields(gh));
+const remoteHashOfMs = (gh: GhMilestone) => hashOf(remoteMilestoneFields(gh));
 
 const mockUpdateIssue = vi.fn().mockImplementation(async () => ({
   number: 1,
@@ -306,6 +315,498 @@ describe('syncWithGitHub', () => {
     expect(result.ok).toBe(true);
     if (result.ok) {
       expect(result.value.resumedFromCheckpoint).toBe(true);
+    }
+  });
+
+  it('returns error when checkpoint check fails', async () => {
+    // Prime sync state so loadState succeeds
+    await importFromGitHub({
+      token: 'test-token',
+      repo: 'test-org/test-repo',
+      metaDir,
+    });
+    // Sync against a broken checkpoint path (NUL byte in metaDir)
+    const result = await syncWithGitHub({
+      token: 'test-token',
+      repo: 'test-org/test-repo',
+      metaDir: `${metaDir}\u0000/bad`,
+      strategy: 'local-wins',
+    });
+    expect(result.ok).toBe(false);
+  });
+
+  it('pushes local_changed milestone and issue to remote (local-wins path)', async () => {
+    await importFromGitHub({
+      token: 'test-token',
+      repo: 'test-org/test-repo',
+      metaDir,
+    });
+
+    const tree = await parseTree(metaDir);
+    if (!tree.ok) throw new Error('parseTree failed');
+    const milestone = tree.value.milestones[0];
+    const story = tree.value.stories[0];
+
+    const state = await loadState(metaDir);
+    if (!state.ok) throw new Error('loadState failed');
+
+    // Build fake remote resources whose hashes will match state.remote_hash
+    const fakeIssue: GhIssue = {
+      number: state.value.entities[story.id].github_issue_number ?? 1,
+      title: 'Remote Title',
+      body: 'Remote body',
+      state: 'open',
+      assignee: null,
+      labels: [],
+      milestone: null,
+      created_at: '2026-01-01T00:00:00Z',
+      updated_at: '2026-01-01T00:00:00Z',
+    };
+    const fakeMilestone: GhMilestone = {
+      number: state.value.entities[milestone.id].github_milestone_number ?? 1,
+      title: 'Remote MS',
+      description: 'remote ms body',
+      state: 'open',
+      due_on: null,
+      created_at: '2026-01-01T00:00:00Z',
+      updated_at: '2026-01-01T00:00:00Z',
+    };
+    mockGetIssue.mockImplementation(async (_o, _r, n) =>
+      n === fakeIssue.number ? fakeIssue : null,
+    );
+    mockGetMilestone.mockImplementation(async (_o, _r, n) =>
+      n === fakeMilestone.number ? fakeMilestone : null,
+    );
+
+    // Force state so current remote hash matches stored remote_hash (no remote
+    // change) but stored local_hash is stale → triggers local_changed.
+    state.value.entities[story.id] = {
+      ...state.value.entities[story.id],
+      local_hash: 'sha256:stale',
+      remote_hash: remoteHashOfIssue(fakeIssue),
+    };
+    state.value.entities[milestone.id] = {
+      ...state.value.entities[milestone.id],
+      local_hash: 'sha256:stale',
+      remote_hash: remoteHashOfMs(fakeMilestone),
+    };
+    await saveState(metaDir, state.value);
+
+    const result = await syncWithGitHub({
+      token: 'test-token',
+      repo: 'test-org/test-repo',
+      metaDir,
+      strategy: 'local-wins',
+    });
+    expect(result.ok).toBe(true);
+    expect(mockUpdateIssue).toHaveBeenCalled();
+    expect(mockUpdateMilestone).toHaveBeenCalled();
+  });
+
+  it('pulls remote_changed entities into local when remote changed', async () => {
+    await importFromGitHub({
+      token: 'test-token',
+      repo: 'test-org/test-repo',
+      metaDir,
+    });
+
+    const tree = await parseTree(metaDir);
+    if (!tree.ok) throw new Error('parseTree failed');
+    const milestone = tree.value.milestones[0];
+    const story = tree.value.stories[0];
+
+    const state = await loadState(metaDir);
+    if (!state.ok) throw new Error('loadState failed');
+
+    const fakeIssue: GhIssue = {
+      number: state.value.entities[story.id].github_issue_number ?? 1,
+      title: 'Remote-Renamed Title',
+      body: 'Remote body change',
+      state: 'closed',
+      assignee: { login: 'remote-user' },
+      labels: [{ name: 'remote-label' }],
+      milestone: null,
+      created_at: '2026-01-01T00:00:00Z',
+      updated_at: '2026-01-01T00:00:00Z',
+    };
+    const fakeMilestone: GhMilestone = {
+      number: state.value.entities[milestone.id].github_milestone_number ?? 1,
+      title: 'Remote Milestone Renamed',
+      description: 'remote desc',
+      state: 'closed',
+      due_on: '2026-09-30T00:00:00Z',
+      created_at: '2026-01-01T00:00:00Z',
+      updated_at: '2026-01-01T00:00:00Z',
+    };
+    mockGetIssue.mockImplementation(async (_o, _r, n) =>
+      n === fakeIssue.number ? fakeIssue : null,
+    );
+    mockGetMilestone.mockImplementation(async (_o, _r, n) =>
+      n === fakeMilestone.number ? fakeMilestone : null,
+    );
+
+    // Local not modified → currentLocalHash matches state.local_hash.
+    // Make state.remote_hash stale → remote_changed.
+    state.value.entities[story.id] = {
+      ...state.value.entities[story.id],
+      remote_hash: 'sha256:stale-remote',
+    };
+    state.value.entities[milestone.id] = {
+      ...state.value.entities[milestone.id],
+      remote_hash: 'sha256:stale-remote',
+    };
+    await saveState(metaDir, state.value);
+
+    const result = await syncWithGitHub({
+      token: 'test-token',
+      repo: 'test-org/test-repo',
+      metaDir,
+      strategy: 'remote-wins',
+    });
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.pulled.issues).toBeGreaterThan(0);
+      expect(result.value.pulled.milestones).toBeGreaterThan(0);
+    }
+  });
+
+  it('pulls remote_changed data into an epic (covers applyRemoteIssue owner branch)', async () => {
+    await importFromGitHub({
+      token: 'test-token',
+      repo: 'test-org/test-repo',
+      metaDir,
+    });
+
+    const tree = await parseTree(metaDir);
+    if (!tree.ok) throw new Error('parseTree failed');
+    const epic = tree.value.epics[0];
+
+    const state = await loadState(metaDir);
+    if (!state.ok) throw new Error('loadState failed');
+
+    const fakeIssue: GhIssue = {
+      number: state.value.entities[epic.id].github_issue_number ?? 1,
+      title: 'Renamed Epic',
+      body: 'Epic body update',
+      state: 'closed',
+      assignee: { login: 'new-owner' },
+      labels: [{ name: 'epic' }],
+      milestone: null,
+      created_at: '2026-01-01T00:00:00Z',
+      updated_at: '2026-01-01T00:00:00Z',
+    };
+    mockGetIssue.mockImplementation(async (_o, _r, n) =>
+      n === fakeIssue.number ? fakeIssue : null,
+    );
+
+    state.value.entities[epic.id] = {
+      ...state.value.entities[epic.id],
+      remote_hash: 'sha256:stale-remote',
+    };
+    await saveState(metaDir, state.value);
+
+    const result = await syncWithGitHub({
+      token: 'test-token',
+      repo: 'test-org/test-repo',
+      metaDir,
+      strategy: 'remote-wins',
+    });
+    expect(result.ok).toBe(true);
+  });
+
+  it('both_changed → local-wins resolves to local update', async () => {
+    await importFromGitHub({
+      token: 'test-token',
+      repo: 'test-org/test-repo',
+      metaDir,
+    });
+
+    const tree = await parseTree(metaDir);
+    if (!tree.ok) throw new Error('parseTree failed');
+    const milestone = tree.value.milestones[0];
+    const story = tree.value.stories[0];
+
+    const state = await loadState(metaDir);
+    if (!state.ok) throw new Error('loadState failed');
+
+    const fakeIssue: GhIssue = {
+      number: state.value.entities[story.id].github_issue_number ?? 1,
+      title: 'Remote Conflict',
+      body: 'Remote body',
+      state: 'open',
+      assignee: null,
+      labels: [],
+      milestone: null,
+      created_at: '2026-01-01T00:00:00Z',
+      updated_at: '2026-01-01T00:00:00Z',
+    };
+    const fakeMilestone: GhMilestone = {
+      number: state.value.entities[milestone.id].github_milestone_number ?? 1,
+      title: 'Remote MS Conflict',
+      description: 'ms body',
+      state: 'open',
+      due_on: null,
+      created_at: '2026-01-01T00:00:00Z',
+      updated_at: '2026-01-01T00:00:00Z',
+    };
+    mockGetIssue.mockImplementation(async (_o, _r, n) =>
+      n === fakeIssue.number ? fakeIssue : null,
+    );
+    mockGetMilestone.mockImplementation(async (_o, _r, n) =>
+      n === fakeMilestone.number ? fakeMilestone : null,
+    );
+
+    // Both hashes stale → both_changed.
+    state.value.entities[story.id] = {
+      ...state.value.entities[story.id],
+      local_hash: 'sha256:stale-local',
+      remote_hash: 'sha256:stale-remote',
+    };
+    state.value.entities[milestone.id] = {
+      ...state.value.entities[milestone.id],
+      local_hash: 'sha256:stale-local',
+      remote_hash: 'sha256:stale-remote',
+    };
+    await saveState(metaDir, state.value);
+
+    const result = await syncWithGitHub({
+      token: 'test-token',
+      repo: 'test-org/test-repo',
+      metaDir,
+      strategy: 'local-wins',
+    });
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.resolved).toBeGreaterThan(0);
+    }
+    expect(mockUpdateIssue).toHaveBeenCalled();
+    expect(mockUpdateMilestone).toHaveBeenCalled();
+  });
+
+  it('both_changed → remote-wins pulls remote into local', async () => {
+    await importFromGitHub({
+      token: 'test-token',
+      repo: 'test-org/test-repo',
+      metaDir,
+    });
+
+    const tree = await parseTree(metaDir);
+    if (!tree.ok) throw new Error('parseTree failed');
+    const milestone = tree.value.milestones[0];
+    const story = tree.value.stories[0];
+
+    const state = await loadState(metaDir);
+    if (!state.ok) throw new Error('loadState failed');
+
+    const fakeIssue: GhIssue = {
+      number: state.value.entities[story.id].github_issue_number ?? 1,
+      title: 'Remote Conflict',
+      body: 'Remote body',
+      state: 'open',
+      assignee: null,
+      labels: [],
+      milestone: null,
+      created_at: '2026-01-01T00:00:00Z',
+      updated_at: '2026-01-01T00:00:00Z',
+    };
+    const fakeMilestone: GhMilestone = {
+      number: state.value.entities[milestone.id].github_milestone_number ?? 1,
+      title: 'Remote MS Conflict',
+      description: '',
+      state: 'open',
+      due_on: null,
+      created_at: '2026-01-01T00:00:00Z',
+      updated_at: '2026-01-01T00:00:00Z',
+    };
+    mockGetIssue.mockImplementation(async (_o, _r, n) =>
+      n === fakeIssue.number ? fakeIssue : null,
+    );
+    mockGetMilestone.mockImplementation(async (_o, _r, n) =>
+      n === fakeMilestone.number ? fakeMilestone : null,
+    );
+
+    state.value.entities[story.id] = {
+      ...state.value.entities[story.id],
+      local_hash: 'sha256:stale-local',
+      remote_hash: 'sha256:stale-remote',
+    };
+    state.value.entities[milestone.id] = {
+      ...state.value.entities[milestone.id],
+      local_hash: 'sha256:stale-local',
+      remote_hash: 'sha256:stale-remote',
+    };
+    await saveState(metaDir, state.value);
+
+    const result = await syncWithGitHub({
+      token: 'test-token',
+      repo: 'test-org/test-repo',
+      metaDir,
+      strategy: 'remote-wins',
+    });
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.resolved).toBeGreaterThan(0);
+    }
+  });
+
+  it('both_changed → ask strategy records unresolved conflicts', async () => {
+    await importFromGitHub({
+      token: 'test-token',
+      repo: 'test-org/test-repo',
+      metaDir,
+    });
+
+    const tree = await parseTree(metaDir);
+    if (!tree.ok) throw new Error('parseTree failed');
+    const story = tree.value.stories[0];
+
+    const state = await loadState(metaDir);
+    if (!state.ok) throw new Error('loadState failed');
+
+    const fakeIssue: GhIssue = {
+      number: state.value.entities[story.id].github_issue_number ?? 1,
+      title: 'Remote Ask',
+      body: 'Body',
+      state: 'open',
+      assignee: null,
+      labels: [],
+      milestone: null,
+      created_at: '2026-01-01T00:00:00Z',
+      updated_at: '2026-01-01T00:00:00Z',
+    };
+    mockGetIssue.mockImplementation(async (_o, _r, n) =>
+      n === fakeIssue.number ? fakeIssue : null,
+    );
+
+    state.value.entities[story.id] = {
+      ...state.value.entities[story.id],
+      local_hash: 'sha256:stale-local',
+      remote_hash: 'sha256:stale-remote',
+    };
+    await saveState(metaDir, state.value);
+
+    const result = await syncWithGitHub({
+      token: 'test-token',
+      repo: 'test-org/test-repo',
+      metaDir,
+      strategy: 'ask',
+    });
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.conflicts.length).toBeGreaterThan(0);
+      expect(result.value.skipped).toBeGreaterThan(0);
+    }
+  });
+
+  it('closes GitHub resources for entities deleted locally', async () => {
+    await importFromGitHub({
+      token: 'test-token',
+      repo: 'test-org/test-repo',
+      metaDir,
+    });
+
+    const tree = await parseTree(metaDir);
+    if (!tree.ok) throw new Error('parseTree failed');
+    const story = tree.value.stories[0];
+    const milestone = tree.value.milestones[0];
+
+    // Delete the story + milestone files from disk but keep state entries →
+    // sync should treat them as locally-deleted (updateIssue state=closed).
+    await unlink(story.filePath);
+    await unlink(milestone.filePath);
+
+    const result = await syncWithGitHub({
+      token: 'test-token',
+      repo: 'test-org/test-repo',
+      metaDir,
+      strategy: 'local-wins',
+    });
+    expect(result.ok).toBe(true);
+    expect(mockUpdateIssue).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.any(String),
+      expect.any(Number),
+      expect.objectContaining({ state: 'closed' }),
+    );
+    expect(mockUpdateMilestone).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.any(String),
+      expect.any(Number),
+      expect.objectContaining({ state: 'closed' }),
+    );
+  });
+
+  it('creates GitHub resources for new local entities (not in sync state)', async () => {
+    await importFromGitHub({
+      token: 'test-token',
+      repo: 'test-org/test-repo',
+      metaDir,
+    });
+
+    // Add an untracked story + untracked milestone to the .meta tree:
+    // remove their entries from sync state so they are treated as "new".
+    const tree = await parseTree(metaDir);
+    if (!tree.ok) throw new Error('parseTree failed');
+    const story = tree.value.stories.find((s) => s.status !== 'done');
+    const milestone = tree.value.milestones[0];
+    if (!story || !milestone) throw new Error('fixture assumption broken');
+
+    const state = await loadState(metaDir);
+    if (!state.ok) throw new Error('loadState failed');
+    delete state.value.entities[story.id];
+    delete state.value.entities[milestone.id];
+    await saveState(metaDir, state.value);
+
+    // Also force status=done on the story to exercise the close-after-create branch.
+    story.status = 'done';
+    await coreWriteFile(story, story.filePath);
+
+    const result = await syncWithGitHub({
+      token: 'test-token',
+      repo: 'test-org/test-repo',
+      metaDir,
+      strategy: 'local-wins',
+    });
+    expect(result.ok).toBe(true);
+    expect(mockCreateIssue).toHaveBeenCalled();
+    expect(mockCreateMilestone).toHaveBeenCalled();
+    // Since story.status === 'done', updateIssue with state:closed should be called
+    expect(mockUpdateIssue).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.any(String),
+      expect.any(Number),
+      expect.objectContaining({ state: 'closed' }),
+    );
+  });
+
+  it('records failedEntities when a new-entity create fails', async () => {
+    await importFromGitHub({
+      token: 'test-token',
+      repo: 'test-org/test-repo',
+      metaDir,
+    });
+
+    const tree = await parseTree(metaDir);
+    if (!tree.ok) throw new Error('parseTree failed');
+    const story = tree.value.stories[0];
+
+    const state = await loadState(metaDir);
+    if (!state.ok) throw new Error('loadState failed');
+    delete state.value.entities[story.id];
+    await saveState(metaDir, state.value);
+
+    mockCreateIssue.mockRejectedValueOnce(new Error('quota exceeded'));
+
+    const result = await syncWithGitHub({
+      token: 'test-token',
+      repo: 'test-org/test-repo',
+      metaDir,
+      strategy: 'local-wins',
+    });
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.failedEntities.length).toBeGreaterThan(0);
+      expect(result.value.failedEntities[0].error).toContain('quota exceeded');
     }
   });
 


### PR DESCRIPTION
Adds targeted unit tests to bring every file in packages/sync-github
(excluding index.ts / types.ts) past the 80% threshold:

- adapter.ts (0% → 100%): new adapter.test.ts mocks import/export/sync
  modules and asserts credential/repo fallbacks and error branches.
- client.ts (0% → 100%): new client.test.ts mocks @octokit/rest as a
  class and covers pagination, PR filtering, sub-issues fallback, rate
  limit warn/sleep, and the create/update helpers.
- config.ts (50% → 100%): new config.test.ts covers load/save round-trip,
  I/O error paths, and createDefaultConfig merges.
- sync.ts (37% → 92%): new branch tests for local_changed,
  remote_changed, both_changed (per-strategy), local-delete close,
  new-entity create, failedEntities on new-entity API rejection,
  applyRemoteIssue epic branch, and checkpoint-check failure.
- export.ts (67% → 98%): tests for new milestone + closed-issue create,
  local hash-changed update, locally-deleted entity close, milestone_ref
  → params.milestone resolution, and non-Error rejection wrapping.
- import.ts (98% lines, branch fixes): sub-issues strategy path plus
  outer-catch wrapping for Error and non-Error rejections.
- state.ts, checkpoint.ts, diff.ts, linker.ts: add missing error-branch
  tests and default-case coverage.

All 654 tests pass; biome lint clean.

https://claude.ai/code/session_017cUtaTkRjZUMdz7CeZRPpg