### PR TITLE
test(cli): add coverage for commands and utils to reach 100% lines

### DIFF
--- a/.meta/epics/test-coverage-to-100-on-source-code/stories/add-test-coverage-for-packagescli-to-100.md
+++ b/.meta/epics/test-coverage-to-100-on-source-code/stories/add-test-coverage-for-packagescli-to-100.md
@@ -2,7 +2,7 @@
 type: story
 id: U6BKvIRC58Dp
 title: Add test coverage for packages/cli to 100%
-status: todo
+status: in_review
 priority: high
 assignee: null
 labels:
@@ -12,7 +12,7 @@ estimate: null
 epic_ref:
   id: xGG0RMogvzyo
 created_at: 2026-04-12T19:35:05.843Z
-updated_at: 2026-04-12T19:35:05.843Z
+updated_at: 2026-04-19T12:45:55.337Z
 ---
 
 ## Objective

--- a/packages/cli/src/__tests__/adapters.test.ts
+++ b/packages/cli/src/__tests__/adapters.test.ts
@@ -1,0 +1,161 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// --- Mocks ---
+
+const mockLoadGitpmConfig = vi.fn();
+const mockLoadAdapters = vi.fn();
+const mockFindAdapterByName = vi.fn();
+const mockDetectAdapter = vi.fn();
+
+vi.mock('@gitpm/core', () => ({
+  loadGitpmConfig: (...args: unknown[]) => mockLoadGitpmConfig(...args),
+  loadAdapters: (...args: unknown[]) => mockLoadAdapters(...args),
+  findAdapterByName: (...args: unknown[]) => mockFindAdapterByName(...args),
+  detectAdapter: (...args: unknown[]) => mockDetectAdapter(...args),
+}));
+
+let _logSpy: ReturnType<typeof vi.spyOn>;
+let errorSpy: ReturnType<typeof vi.spyOn>;
+let exitSpy: ReturnType<typeof vi.spyOn>;
+
+function makeAdapter(name: string) {
+  return {
+    name,
+    displayName: name,
+    detect: vi.fn(),
+    import: vi.fn(),
+    export: vi.fn(),
+    sync: vi.fn(),
+  };
+}
+
+describe('resolveAdapter', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.resetAllMocks();
+    _logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => {
+      throw new Error('process.exit');
+    }) as never);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('exits 1 when loadGitpmConfig fails', async () => {
+    mockLoadGitpmConfig.mockResolvedValue({
+      ok: false,
+      error: { message: 'bad config' },
+    });
+    const { resolveAdapter } = await import('../utils/adapters.js');
+    await expect(resolveAdapter('/tmp/m/.meta')).rejects.toThrow(
+      'process.exit',
+    );
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    const errOutput = errorSpy.mock.calls.map((c) => c.join(' ')).join('\n');
+    expect(errOutput).toContain('bad config');
+  });
+
+  it('exits 1 when loadAdapters fails', async () => {
+    mockLoadGitpmConfig.mockResolvedValue({
+      ok: true,
+      value: { adapters: [], hooks: {} },
+    });
+    mockLoadAdapters.mockResolvedValue({
+      ok: false,
+      error: { message: 'load failed' },
+    });
+    const { resolveAdapter } = await import('../utils/adapters.js');
+    await expect(resolveAdapter('/tmp/m/.meta')).rejects.toThrow(
+      'process.exit',
+    );
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    const errOutput = errorSpy.mock.calls.map((c) => c.join(' ')).join('\n');
+    expect(errOutput).toContain('load failed');
+  });
+
+  it('exits 1 when no adapters are installed', async () => {
+    mockLoadGitpmConfig.mockResolvedValue({
+      ok: true,
+      value: { adapters: [], hooks: {} },
+    });
+    mockLoadAdapters.mockResolvedValue({ ok: true, value: [] });
+    const { resolveAdapter } = await import('../utils/adapters.js');
+    await expect(resolveAdapter('/tmp/m/.meta')).rejects.toThrow(
+      'process.exit',
+    );
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    const errOutput = errorSpy.mock.calls.map((c) => c.join(' ')).join('\n');
+    expect(errOutput).toContain('No sync adapters installed');
+  });
+
+  it('exits 1 when adapter name is given but not found', async () => {
+    mockLoadGitpmConfig.mockResolvedValue({
+      ok: true,
+      value: { adapters: [], hooks: {} },
+    });
+    const gh = makeAdapter('github');
+    mockLoadAdapters.mockResolvedValue({ ok: true, value: [gh] });
+    mockFindAdapterByName.mockReturnValue(null);
+
+    const { resolveAdapter } = await import('../utils/adapters.js');
+    await expect(resolveAdapter('/tmp/m/.meta', 'bitbucket')).rejects.toThrow(
+      'process.exit',
+    );
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    const errOutput = errorSpy.mock.calls.map((c) => c.join(' ')).join('\n');
+    expect(errOutput).toContain('not found');
+    expect(errOutput).toContain('github');
+  });
+
+  it('returns adapter when name is provided and found', async () => {
+    const cfg = { adapters: [], hooks: {} };
+    mockLoadGitpmConfig.mockResolvedValue({ ok: true, value: cfg });
+    const gh = makeAdapter('github');
+    mockLoadAdapters.mockResolvedValue({ ok: true, value: [gh] });
+    mockFindAdapterByName.mockReturnValue(gh);
+
+    const { resolveAdapter } = await import('../utils/adapters.js');
+    const result = await resolveAdapter('/tmp/m/.meta', 'github');
+
+    expect(result.adapter).toBe(gh);
+    expect(result.config).toBe(cfg);
+    expect(exitSpy).not.toHaveBeenCalled();
+  });
+
+  it('auto-detects adapter when name is omitted', async () => {
+    mockLoadGitpmConfig.mockResolvedValue({
+      ok: true,
+      value: { adapters: [], hooks: {} },
+    });
+    const gl = makeAdapter('gitlab');
+    mockLoadAdapters.mockResolvedValue({ ok: true, value: [gl] });
+    mockDetectAdapter.mockResolvedValue(gl);
+
+    const { resolveAdapter } = await import('../utils/adapters.js');
+    const result = await resolveAdapter('/tmp/m/.meta');
+
+    expect(mockDetectAdapter).toHaveBeenCalled();
+    expect(result.adapter).toBe(gl);
+  });
+
+  it('exits 1 when auto-detection finds no adapter', async () => {
+    mockLoadGitpmConfig.mockResolvedValue({
+      ok: true,
+      value: { adapters: [], hooks: {} },
+    });
+    const gh = makeAdapter('github');
+    mockLoadAdapters.mockResolvedValue({ ok: true, value: [gh] });
+    mockDetectAdapter.mockResolvedValue(null);
+
+    const { resolveAdapter } = await import('../utils/adapters.js');
+    await expect(resolveAdapter('/tmp/m/.meta')).rejects.toThrow(
+      'process.exit',
+    );
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    const errOutput = errorSpy.mock.calls.map((c) => c.join(' ')).join('\n');
+    expect(errOutput).toContain('No sync config found');
+  });
+});

--- a/packages/cli/src/__tests__/archive.test.ts
+++ b/packages/cli/src/__tests__/archive.test.ts
@@ -1,0 +1,206 @@
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { Command } from 'commander';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// --- Mocks ---
+
+const mockArchiveOldEntities = vi.fn();
+
+vi.mock('@gitpm/core', () => ({
+  archiveOldEntities: (...args: unknown[]) => mockArchiveOldEntities(...args),
+}));
+
+let logSpy: ReturnType<typeof vi.spyOn>;
+let errorSpy: ReturnType<typeof vi.spyOn>;
+let warnSpy: ReturnType<typeof vi.spyOn>;
+let exitSpy: ReturnType<typeof vi.spyOn>;
+
+async function run(...args: string[]) {
+  const { archiveCommand } = await import('../commands/archive.js');
+  const program = new Command();
+  program.option('--meta-dir <path>', 'Path to .meta directory', '.meta');
+  program.addCommand(archiveCommand);
+  await program.parseAsync(['node', 'gitpm', 'archive', ...args]);
+}
+
+// --- Tests ---
+
+describe('gitpm archive', () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    vi.resetModules();
+    vi.resetAllMocks();
+    tmpDir = await mkdtemp(join(tmpdir(), 'gitpm-cli-archive-'));
+    logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => {
+      throw new Error('process.exit');
+    }) as never);
+  });
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    await rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it('exits with code 1 when --days is negative', async () => {
+    await expect(run('--days', '-1', '--meta-dir', tmpDir)).rejects.toThrow(
+      'process.exit',
+    );
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    const errOutput = errorSpy.mock.calls.map((c) => c.join(' ')).join('\n');
+    expect(errOutput).toContain('non-negative');
+  });
+
+  it('exits with code 1 when --days is not a number', async () => {
+    await expect(run('--days', 'abc', '--meta-dir', tmpDir)).rejects.toThrow(
+      'process.exit',
+    );
+    expect(exitSpy).toHaveBeenCalledWith(1);
+  });
+
+  it('prints dry-run warning and "would archive" label when --dry-run', async () => {
+    mockArchiveOldEntities.mockResolvedValue({
+      ok: true,
+      value: {
+        archivedFiles: ['.meta/stories/x.md'],
+        archivedEntityIds: ['st_1'],
+      },
+    });
+
+    await run('--dry-run', '--meta-dir', tmpDir);
+
+    expect(mockArchiveOldEntities).toHaveBeenCalledWith(tmpDir, {
+      daysOld: 7,
+      dryRun: true,
+    });
+    const warnOutput = warnSpy.mock.calls.map((c) => c.join(' ')).join('\n');
+    expect(warnOutput).toContain('Dry run');
+    const logOutput = logSpy.mock.calls.map((c) => c.join(' ')).join('\n');
+    expect(logOutput).toContain('would archive');
+  });
+
+  it('exits with code 1 when archiveOldEntities fails', async () => {
+    mockArchiveOldEntities.mockResolvedValue({
+      ok: false,
+      error: { message: 'cannot archive' },
+    });
+
+    await expect(run('--meta-dir', tmpDir)).rejects.toThrow('process.exit');
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    const errOutput = errorSpy.mock.calls.map((c) => c.join(' ')).join('\n');
+    expect(errOutput).toContain('cannot archive');
+  });
+
+  it('prints "no entities" message when nothing archived', async () => {
+    mockArchiveOldEntities.mockResolvedValue({
+      ok: true,
+      value: { archivedFiles: [], archivedEntityIds: [] },
+    });
+
+    await run('--meta-dir', tmpDir);
+
+    const logOutput = logSpy.mock.calls.map((c) => c.join(' ')).join('\n');
+    expect(logOutput).toContain('No done/cancelled entities older than');
+    expect(exitSpy).not.toHaveBeenCalled();
+  });
+
+  it('archives files and cleans up sync state', async () => {
+    const syncDir = join(tmpDir, 'sync');
+    await mkdir(syncDir, { recursive: true });
+    const statePath = join(syncDir, 'github-state.json');
+    await writeFile(
+      statePath,
+      JSON.stringify({
+        entities: {
+          st_1: { number: 1 },
+          st_2: { number: 2 },
+          st_3: { number: 3 },
+        },
+      }),
+      'utf-8',
+    );
+
+    mockArchiveOldEntities.mockResolvedValue({
+      ok: true,
+      value: {
+        archivedFiles: ['.meta/stories/a.md', '.meta/stories/b.md'],
+        archivedEntityIds: ['st_1', 'st_2'],
+      },
+    });
+
+    await run('--days', '30', '--meta-dir', tmpDir);
+
+    const logOutput = logSpy.mock.calls.map((c) => c.join(' ')).join('\n');
+    expect(logOutput).toContain('archived');
+    expect(logOutput).toContain('removed 2 entries from sync state');
+    expect(logOutput).toContain('Archived 2 file(s)');
+
+    // Verify sync state was rewritten
+    const raw = await readFile(statePath, 'utf-8');
+    const state = JSON.parse(raw);
+    expect(state.entities.st_1).toBeUndefined();
+    expect(state.entities.st_2).toBeUndefined();
+    expect(state.entities.st_3).toEqual({ number: 3 });
+  });
+
+  it('archives files but skips sync state cleanup when state file missing', async () => {
+    mockArchiveOldEntities.mockResolvedValue({
+      ok: true,
+      value: {
+        archivedFiles: ['.meta/stories/x.md'],
+        archivedEntityIds: ['st_1'],
+      },
+    });
+
+    await run('--meta-dir', tmpDir);
+
+    const logOutput = logSpy.mock.calls.map((c) => c.join(' ')).join('\n');
+    expect(logOutput).toContain('Archived 1 file(s)');
+    // No removed entries message when state file missing
+    expect(logOutput).not.toContain('removed');
+  });
+
+  it('does not remove anything from sync state when no IDs match', async () => {
+    const syncDir = join(tmpDir, 'sync');
+    await mkdir(syncDir, { recursive: true });
+    const statePath = join(syncDir, 'github-state.json');
+    await writeFile(
+      statePath,
+      JSON.stringify({ entities: { other_id: { number: 1 } } }),
+      'utf-8',
+    );
+
+    mockArchiveOldEntities.mockResolvedValue({
+      ok: true,
+      value: {
+        archivedFiles: ['.meta/stories/x.md'],
+        archivedEntityIds: ['st_1'],
+      },
+    });
+
+    await run('--meta-dir', tmpDir);
+
+    const logOutput = logSpy.mock.calls.map((c) => c.join(' ')).join('\n');
+    expect(logOutput).not.toContain('removed');
+  });
+
+  it('prints dry-run summary when --dry-run with files', async () => {
+    mockArchiveOldEntities.mockResolvedValue({
+      ok: true,
+      value: {
+        archivedFiles: ['.meta/stories/x.md', '.meta/stories/y.md'],
+        archivedEntityIds: ['st_1', 'st_2'],
+      },
+    });
+
+    await run('--dry-run', '--meta-dir', tmpDir);
+
+    const warnOutput = warnSpy.mock.calls.map((c) => c.join(' ')).join('\n');
+    expect(warnOutput).toContain('2 file(s) would be archived (dry run)');
+  });
+});

--- a/packages/cli/src/__tests__/audit.test.ts
+++ b/packages/cli/src/__tests__/audit.test.ts
@@ -1,0 +1,190 @@
+import { Command } from 'commander';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// --- Mocks ---
+
+const mockParseTree = vi.fn();
+const mockResolveRefs = vi.fn();
+const mockAuditTree = vi.fn();
+
+vi.mock('@gitpm/core', () => ({
+  parseTree: (...args: unknown[]) => mockParseTree(...args),
+  resolveRefs: (...args: unknown[]) => mockResolveRefs(...args),
+  auditTree: (...args: unknown[]) => mockAuditTree(...args),
+}));
+
+let logSpy: ReturnType<typeof vi.spyOn>;
+let errorSpy: ReturnType<typeof vi.spyOn>;
+let exitSpy: ReturnType<typeof vi.spyOn>;
+
+async function run(...args: string[]) {
+  const { auditCommand } = await import('../commands/audit.js');
+  const program = new Command();
+  program.option('--meta-dir <path>', 'Path to .meta directory', '.meta');
+  program.addCommand(auditCommand);
+  await program.parseAsync(['node', 'gitpm', 'audit', ...args]);
+}
+
+function emptyReport() {
+  return {
+    summary: { total: 5, issues: 0 },
+    stale: [],
+    orphans: [],
+    emptyBodies: [],
+    zombieEpics: [],
+    duplicates: [],
+  };
+}
+
+function fullReport() {
+  return {
+    summary: { total: 10, issues: 6 },
+    stale: [
+      {
+        id: 'st_1',
+        title: 'Stale story',
+        reason: '120 days old',
+        filePath: '/tmp/.meta/stories/stale.md',
+      },
+    ],
+    orphans: [
+      {
+        id: 'st_2',
+        title: 'Orphan story',
+        reason: 'no epic',
+        filePath: '/tmp/.meta/stories/orphan.md',
+      },
+    ],
+    emptyBodies: [
+      {
+        id: 'st_3',
+        title: 'Empty body',
+        reason: 'empty body',
+        filePath: '/tmp/.meta/stories/empty.md',
+      },
+    ],
+    zombieEpics: [
+      {
+        id: 'ep_1',
+        title: 'Zombie epic',
+        reason: 'all stories done',
+        filePath: '/tmp/.meta/epics/zombie/epic.md',
+      },
+    ],
+    duplicates: [
+      {
+        a: { id: 'st_4', title: 'Duplicate A' },
+        b: { id: 'st_5', title: 'Duplicate B' },
+        similarity: 0.92,
+      },
+      {
+        a: { id: 'st_6', title: 'Dup A2' },
+        b: { id: 'st_7', title: 'Dup B2' },
+        similarity: 0.8,
+      },
+    ],
+  };
+}
+
+// --- Tests ---
+
+describe('gitpm audit', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.resetAllMocks();
+    logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => {
+      throw new Error('process.exit');
+    }) as never);
+    mockParseTree.mockResolvedValue({ ok: true, value: {} });
+    mockResolveRefs.mockReturnValue({ ok: true, value: {} });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('exits 1 when parseTree fails', async () => {
+    mockParseTree.mockResolvedValue({
+      ok: false,
+      error: { message: 'parse failed' },
+    });
+
+    await expect(run('--meta-dir', '/tmp/meta')).rejects.toThrow(
+      'process.exit',
+    );
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    const errOutput = errorSpy.mock.calls.map((c) => c.join(' ')).join('\n');
+    expect(errOutput).toContain('parse failed');
+  });
+
+  it('exits 1 when resolveRefs fails', async () => {
+    mockResolveRefs.mockReturnValue({
+      ok: false,
+      error: { message: 'resolve failed' },
+    });
+
+    await expect(run('--meta-dir', '/tmp/meta')).rejects.toThrow(
+      'process.exit',
+    );
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    const errOutput = errorSpy.mock.calls.map((c) => c.join(' ')).join('\n');
+    expect(errOutput).toContain('resolve failed');
+  });
+
+  it('prints success when no issues found', async () => {
+    mockAuditTree.mockReturnValue(emptyReport());
+
+    await run('--meta-dir', '/tmp/meta');
+
+    const logOutput = logSpy.mock.calls.map((c) => c.join(' ')).join('\n');
+    expect(logOutput).toContain('No issues found');
+    expect(exitSpy).not.toHaveBeenCalled();
+  });
+
+  it('outputs JSON when --json is set', async () => {
+    const report = fullReport();
+    mockAuditTree.mockReturnValue(report);
+
+    await expect(run('--json', '--meta-dir', '/tmp/meta')).rejects.toThrow(
+      'process.exit',
+    );
+
+    const logOutput = logSpy.mock.calls.map((c) => c.join(' ')).join('\n');
+    const parsed = JSON.parse(logOutput);
+    expect(parsed.summary.issues).toBe(6);
+    expect(exitSpy).toHaveBeenCalledWith(1);
+  });
+
+  it('prints sections and exits 1 when issues found', async () => {
+    mockAuditTree.mockReturnValue(fullReport());
+
+    await expect(run('--meta-dir', '/tmp/meta')).rejects.toThrow(
+      'process.exit',
+    );
+    expect(exitSpy).toHaveBeenCalledWith(1);
+
+    const logOutput = logSpy.mock.calls.map((c) => c.join(' ')).join('\n');
+    expect(logOutput).toContain('Project Audit');
+    expect(logOutput).toContain('Stale Stories');
+    expect(logOutput).toContain('Orphan Stories');
+    expect(logOutput).toContain('Empty Bodies');
+    expect(logOutput).toContain('Zombie Epics');
+    expect(logOutput).toContain('Duplicate Candidates');
+    expect(logOutput).toContain('Stale story');
+    expect(logOutput).toContain('Duplicate A');
+    expect(logOutput).toContain('92%');
+  });
+
+  it('passes staleDays to auditTree', async () => {
+    mockAuditTree.mockReturnValue(emptyReport());
+
+    await run('--meta-dir', '/tmp/meta');
+
+    expect(mockAuditTree).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ staleDays: expect.anything() }),
+    );
+  });
+});

--- a/packages/cli/src/__tests__/auth.test.ts
+++ b/packages/cli/src/__tests__/auth.test.ts
@@ -1,0 +1,69 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// --- Mocks ---
+
+const mockExecSync = vi.fn();
+
+vi.mock('node:child_process', () => ({
+  execSync: (...args: unknown[]) => mockExecSync(...args),
+}));
+
+describe('resolveToken', () => {
+  const originalEnv = process.env.GITHUB_TOKEN;
+
+  beforeEach(() => {
+    vi.resetModules();
+    vi.resetAllMocks();
+    process.env.GITHUB_TOKEN = undefined;
+    delete process.env.GITHUB_TOKEN;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    if (originalEnv !== undefined) {
+      process.env.GITHUB_TOKEN = originalEnv;
+    } else {
+      delete process.env.GITHUB_TOKEN;
+    }
+  });
+
+  it('returns the CLI token when provided', async () => {
+    const { resolveToken } = await import('../utils/auth.js');
+    const token = await resolveToken('my-cli-token');
+    expect(token).toBe('my-cli-token');
+    expect(mockExecSync).not.toHaveBeenCalled();
+  });
+
+  it('returns GITHUB_TOKEN env var when no CLI token', async () => {
+    process.env.GITHUB_TOKEN = 'env-token';
+    const { resolveToken } = await import('../utils/auth.js');
+    const token = await resolveToken();
+    expect(token).toBe('env-token');
+    expect(mockExecSync).not.toHaveBeenCalled();
+  });
+
+  it('falls back to gh auth token when env and CLI are missing', async () => {
+    mockExecSync.mockReturnValue('gh-cli-token\n');
+    const { resolveToken } = await import('../utils/auth.js');
+    const token = await resolveToken();
+    expect(token).toBe('gh-cli-token');
+    expect(mockExecSync).toHaveBeenCalledWith(
+      'gh auth token',
+      expect.any(Object),
+    );
+  });
+
+  it('throws when gh returns an empty string', async () => {
+    mockExecSync.mockReturnValue('   ');
+    const { resolveToken } = await import('../utils/auth.js');
+    await expect(resolveToken()).rejects.toThrow('No GitHub token found');
+  });
+
+  it('throws when gh auth token fails', async () => {
+    mockExecSync.mockImplementation(() => {
+      throw new Error('gh not installed');
+    });
+    const { resolveToken } = await import('../utils/auth.js');
+    await expect(resolveToken()).rejects.toThrow('No GitHub token found');
+  });
+});

--- a/packages/cli/src/__tests__/conflict-ui.test.ts
+++ b/packages/cli/src/__tests__/conflict-ui.test.ts
@@ -1,0 +1,98 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// --- Mocks ---
+
+const mockSelect = vi.fn();
+
+vi.mock('@inquirer/prompts', () => ({
+  select: (...args: unknown[]) => mockSelect(...args),
+}));
+
+let logSpy: ReturnType<typeof vi.spyOn>;
+
+const sampleConflict = {
+  entityId: 'st_1',
+  entityTitle: 'Story Title',
+  entityType: 'story' as const,
+  field: 'status',
+  localValue: 'todo',
+  remoteValue: 'done',
+};
+
+describe('promptConflictResolution', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.resetAllMocks();
+    logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('returns empty array when no conflicts', async () => {
+    const { promptConflictResolution } = await import(
+      '../utils/conflict-ui.js'
+    );
+    const result = await promptConflictResolution([]);
+    expect(result).toEqual([]);
+    expect(mockSelect).not.toHaveBeenCalled();
+  });
+
+  it('prints conflict details and returns resolution for "local" pick', async () => {
+    mockSelect.mockResolvedValue('local');
+
+    const { promptConflictResolution } = await import(
+      '../utils/conflict-ui.js'
+    );
+    const result = await promptConflictResolution([sampleConflict]);
+
+    expect(result).toEqual([
+      { entityId: 'st_1', field: 'status', pick: 'local' },
+    ]);
+    const logOutput = logSpy.mock.calls.map((c) => c.join(' ')).join('\n');
+    expect(logOutput).toContain('CONFLICT');
+    expect(logOutput).toContain('Story Title');
+    expect(logOutput).toContain('st_1');
+    expect(logOutput).toContain('story');
+    expect(logOutput).toContain('status');
+    expect(logOutput).toContain('todo');
+    expect(logOutput).toContain('done');
+  });
+
+  it('returns resolution with "remote" pick', async () => {
+    mockSelect.mockResolvedValue('remote');
+
+    const { promptConflictResolution } = await import(
+      '../utils/conflict-ui.js'
+    );
+    const result = await promptConflictResolution([sampleConflict]);
+
+    expect(result).toEqual([
+      { entityId: 'st_1', field: 'status', pick: 'remote' },
+    ]);
+  });
+
+  it('omits skipped conflicts from result', async () => {
+    mockSelect
+      .mockResolvedValueOnce('skip')
+      .mockResolvedValueOnce('local')
+      .mockResolvedValueOnce('remote');
+
+    const conflicts = [
+      { ...sampleConflict, entityId: 'a' },
+      { ...sampleConflict, entityId: 'b' },
+      { ...sampleConflict, entityId: 'c' },
+    ];
+
+    const { promptConflictResolution } = await import(
+      '../utils/conflict-ui.js'
+    );
+    const result = await promptConflictResolution(conflicts);
+
+    expect(result).toEqual([
+      { entityId: 'b', field: 'status', pick: 'local' },
+      { entityId: 'c', field: 'status', pick: 'remote' },
+    ]);
+  });
+});

--- a/packages/cli/src/__tests__/create.test.ts
+++ b/packages/cli/src/__tests__/create.test.ts
@@ -219,6 +219,40 @@ describe('gitpm create epic', () => {
       expect.objectContaining({ milestoneId: 'ms_abc' }),
     );
   });
+
+  it('exits 1 when createEpic fails', async () => {
+    mockCreateEpic.mockResolvedValue({
+      ok: false,
+      error: { message: 'epic error' },
+    });
+
+    await expect(
+      run('epic', '--title', 'Broken', '--meta-dir', '/tmp'),
+    ).rejects.toThrow('process.exit');
+    expect(exitSpy).toHaveBeenCalledWith(1);
+  });
+
+  it('parses labels for epic', async () => {
+    mockCreateEpic.mockResolvedValue({
+      ok: true,
+      value: { filePath: '/tmp/.meta/epics/test/epic.md', id: 'ep_003' },
+    });
+
+    await run(
+      'epic',
+      '--title',
+      'Labeled',
+      '--labels',
+      'auth, ui',
+      '--meta-dir',
+      '/tmp',
+    );
+
+    expect(mockCreateEpic).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({ labels: ['auth', 'ui'] }),
+    );
+  });
 });
 
 describe('gitpm create milestone', () => {
@@ -272,5 +306,110 @@ describe('gitpm create milestone', () => {
       expect.any(String),
       expect.objectContaining({ targetDate: '2026-06-01' }),
     );
+  });
+
+  it('exits 1 when createMilestone fails', async () => {
+    mockCreateMilestone.mockResolvedValue({
+      ok: false,
+      error: { message: 'milestone error' },
+    });
+
+    await expect(
+      run('milestone', '--title', 'Bad', '--meta-dir', '/tmp'),
+    ).rejects.toThrow('process.exit');
+    expect(exitSpy).toHaveBeenCalledWith(1);
+  });
+});
+
+describe('gitpm create story — epic lookup', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.resetAllMocks();
+    logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    _errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => {
+      throw new Error('process.exit');
+    }) as never);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('exits 1 when parseTree fails during epic lookup', async () => {
+    mockParseTree.mockResolvedValue({
+      ok: false,
+      error: { message: 'parse tree error' },
+    });
+
+    await expect(
+      run('story', '--title', 'X', '--epic', 'ep_x', '--meta-dir', '/tmp'),
+    ).rejects.toThrow('process.exit');
+    expect(exitSpy).toHaveBeenCalledWith(1);
+  });
+
+  it('finds epic by slug when ID does not match', async () => {
+    mockParseTree.mockResolvedValue({
+      ok: true,
+      value: {
+        epics: [
+          {
+            id: 'ep_abc',
+            filePath: '/tmp/.meta/epics/auth-flow/epic.md',
+          },
+        ],
+        stories: [],
+        milestones: [],
+        roadmaps: [],
+        prds: [],
+        sprints: [],
+        errors: [],
+      },
+    });
+    mockCreateStory.mockResolvedValue({
+      ok: true,
+      value: {
+        filePath: '/tmp/.meta/epics/auth-flow/stories/x.md',
+        id: 'st_1',
+      },
+    });
+
+    await run(
+      'story',
+      '--title',
+      'X',
+      '--epic',
+      'auth-flow',
+      '--meta-dir',
+      '/tmp',
+    );
+
+    expect(mockCreateStory).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        epicId: 'ep_abc',
+        epicSlug: 'auth-flow',
+      }),
+    );
+  });
+
+  it('exits 1 when epic cannot be resolved by ID or slug', async () => {
+    mockParseTree.mockResolvedValue({
+      ok: true,
+      value: {
+        epics: [],
+        stories: [],
+        milestones: [],
+        roadmaps: [],
+        prds: [],
+        sprints: [],
+        errors: [],
+      },
+    });
+
+    await expect(
+      run('story', '--title', 'X', '--epic', 'missing', '--meta-dir', '/tmp'),
+    ).rejects.toThrow('process.exit');
+    expect(exitSpy).toHaveBeenCalledWith(1);
   });
 });

--- a/packages/cli/src/__tests__/import.test.ts
+++ b/packages/cli/src/__tests__/import.test.ts
@@ -222,4 +222,73 @@ describe('gitpm import', () => {
       expect.objectContaining({ event: 'post-import' }),
     );
   });
+
+  it('exits 1 when loadGitpmConfig fails', async () => {
+    mockLoadGitpmConfig.mockResolvedValue({
+      ok: false,
+      error: { message: 'bad config' },
+    });
+
+    await expect(
+      run('--repo', 'owner/repo', '--meta-dir', '/tmp/meta'),
+    ).rejects.toThrow('process.exit');
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    const errOutput = errorSpy.mock.calls.map((c) => c.join(' ')).join('\n');
+    expect(errOutput).toContain('Failed to load config');
+  });
+
+  it('exits 1 when loadAdapters fails', async () => {
+    mockLoadAdapters.mockResolvedValue({
+      ok: false,
+      error: { message: 'adapters broken' },
+    });
+
+    await expect(
+      run('--repo', 'owner/repo', '--meta-dir', '/tmp/meta'),
+    ).rejects.toThrow('process.exit');
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    const errOutput = errorSpy.mock.calls.map((c) => c.join(' ')).join('\n');
+    expect(errOutput).toContain('Failed to load adapters');
+  });
+
+  it('exits 1 with install hint when no adapters installed', async () => {
+    mockLoadAdapters.mockResolvedValue({ ok: true, value: [] });
+    mockFindAdapterByName.mockReturnValue(null);
+
+    await expect(
+      run('--repo', 'owner/repo', '--meta-dir', '/tmp/meta'),
+    ).rejects.toThrow('process.exit');
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    const errOutput = errorSpy.mock.calls.map((c) => c.join(' ')).join('\n');
+    expect(errOutput).toContain('is not installed');
+  });
+
+  it('exits 1 when pre-import hook fails', async () => {
+    mockRunHooks.mockResolvedValueOnce({
+      ok: false,
+      error: { message: 'hook failed' },
+    });
+
+    await expect(
+      run('--repo', 'owner/repo', '--meta-dir', '/tmp/meta'),
+    ).rejects.toThrow('process.exit');
+    expect(exitSpy).toHaveBeenCalledWith(1);
+  });
+
+  it('passes --project numeric as projectNumber', async () => {
+    mockAdapterImport.mockResolvedValue({ ok: true, value: importSummary });
+
+    await run(
+      '--repo',
+      'owner/repo',
+      '--project',
+      '42',
+      '--meta-dir',
+      '/tmp/meta',
+    );
+
+    expect(mockAdapterImport).toHaveBeenCalledWith(
+      expect.objectContaining({ projectNumber: 42 }),
+    );
+  });
 });

--- a/packages/cli/src/__tests__/init.test.ts
+++ b/packages/cli/src/__tests__/init.test.ts
@@ -39,6 +39,16 @@ async function seedMetaDir(metaDir: string): Promise<void> {
   await writeFile(join(metaDir, 'roadmap.yaml'), '');
 }
 
+async function seedMetaDirWithSubtree(metaDir: string): Promise<void> {
+  await mkdir(join(metaDir, 'epics', 'auth', 'stories'), { recursive: true });
+  await writeFile(join(metaDir, 'roadmap.yaml'), '');
+  await writeFile(join(metaDir, 'epics', 'auth', 'epic.md'), '# Auth epic');
+  await writeFile(
+    join(metaDir, 'epics', 'auth', 'stories', 'login.md'),
+    '# Login story',
+  );
+}
+
 // --- Tests ---
 
 describe('gitpm init', () => {
@@ -112,6 +122,23 @@ describe('gitpm init', () => {
     await run('test-proj', '--meta-dir', customDir);
 
     expect(mockScaffoldMeta).toHaveBeenCalledWith(customDir, 'test-proj');
+  });
+
+  it('prints nested directory tree (covers collectFiles recursion)', async () => {
+    const metaDir = join(tmpDir, '.meta');
+    mockScaffoldMeta.mockResolvedValue({ ok: true, value: undefined });
+    await seedMetaDirWithSubtree(metaDir);
+
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    await run('my-project', '--meta-dir', metaDir);
+
+    const output = logSpy.mock.calls.map((c) => c.join(' ')).join('\n');
+    expect(output).toContain('epics/');
+    expect(output).toContain('auth/');
+    expect(output).toContain('stories/');
+    expect(output).toContain('epic.md');
+    expect(output).toContain('login.md');
   });
 
   describe('Claude Code skill scaffolding', () => {

--- a/packages/cli/src/__tests__/next.test.ts
+++ b/packages/cli/src/__tests__/next.test.ts
@@ -1,0 +1,216 @@
+import { Command } from 'commander';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// --- Mocks ---
+
+const mockParseTree = vi.fn();
+
+vi.mock('@gitpm/core', () => ({
+  parseTree: (...args: unknown[]) => mockParseTree(...args),
+}));
+
+let logSpy: ReturnType<typeof vi.spyOn>;
+let errorSpy: ReturnType<typeof vi.spyOn>;
+let exitSpy: ReturnType<typeof vi.spyOn>;
+
+async function run(...args: string[]) {
+  const { nextCommand } = await import('../commands/next.js');
+  const program = new Command();
+  program.option('--meta-dir <path>', 'Path to .meta directory', '.meta');
+  program.addCommand(nextCommand);
+  await program.parseAsync(['node', 'gitpm', 'next', ...args]);
+}
+
+function makeStory(id: string, overrides: Record<string, unknown> = {}) {
+  return {
+    type: 'story',
+    id,
+    title: `Story ${id}`,
+    status: 'todo',
+    priority: 'medium',
+    labels: [],
+    body: '',
+    filePath: `/tmp/.meta/stories/${id}.md`,
+    assignee: undefined,
+    ...overrides,
+  };
+}
+
+// --- Tests ---
+
+describe('gitpm next', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.resetAllMocks();
+    logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => {
+      throw new Error('process.exit');
+    }) as never);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('exits 1 when parseTree fails', async () => {
+    mockParseTree.mockResolvedValue({
+      ok: false,
+      error: { message: 'no tree' },
+    });
+
+    await expect(run('--meta-dir', '/tmp/meta')).rejects.toThrow(
+      'process.exit',
+    );
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    const errOutput = errorSpy.mock.calls.map((c) => c.join(' ')).join('\n');
+    expect(errOutput).toContain('no tree');
+  });
+
+  it('prints "no stories" when none are pickable', async () => {
+    mockParseTree.mockResolvedValue({
+      ok: true,
+      value: {
+        stories: [makeStory('s1', { status: 'done' })],
+        epics: [],
+        milestones: [],
+        roadmaps: [],
+        prds: [],
+        sprints: [],
+        errors: [],
+      },
+    });
+
+    await run('--meta-dir', '/tmp/meta');
+
+    const logOutput = logSpy.mock.calls.map((c) => c.join(' ')).join('\n');
+    expect(logOutput).toContain('No stories ready');
+  });
+
+  it('sorts by priority, todo before backlog', async () => {
+    mockParseTree.mockResolvedValue({
+      ok: true,
+      value: {
+        stories: [
+          makeStory('low', { priority: 'low', status: 'backlog' }),
+          makeStory('crit', { priority: 'critical' }),
+          makeStory('high-backlog', { priority: 'high', status: 'backlog' }),
+          makeStory('high-todo', { priority: 'high', status: 'todo' }),
+          makeStory('med', { priority: 'medium' }),
+        ],
+        epics: [],
+        milestones: [],
+        roadmaps: [],
+        prds: [],
+        sprints: [],
+        errors: [],
+      },
+    });
+
+    await run('--count', '2', '--meta-dir', '/tmp/meta');
+
+    const logOutput = logSpy.mock.calls.map((c) => c.join(' ')).join('\n');
+    // Critical first, then high-todo before high-backlog (within same priority)
+    const critIdx = logOutput.indexOf('Story crit');
+    const highTodoIdx = logOutput.indexOf('Story high-todo');
+    const highBacklogIdx = logOutput.indexOf('Story high-backlog');
+    expect(critIdx).toBeGreaterThanOrEqual(0);
+    expect(highTodoIdx).toBeGreaterThan(critIdx);
+    expect(highBacklogIdx).toBe(-1); // count=2 excludes it
+    expect(logOutput).toContain('Next 2 stories');
+  });
+
+  it('handles unknown priority via default bullet', async () => {
+    mockParseTree.mockResolvedValue({
+      ok: true,
+      value: {
+        stories: [makeStory('s1', { priority: 'weird' })],
+        epics: [],
+        milestones: [],
+        roadmaps: [],
+        prds: [],
+        sprints: [],
+        errors: [],
+      },
+    });
+
+    await run('--meta-dir', '/tmp/meta');
+
+    const logOutput = logSpy.mock.calls.map((c) => c.join(' ')).join('\n');
+    expect(logOutput).toContain('Story s1');
+  });
+
+  it('filters by assignee case-insensitively', async () => {
+    mockParseTree.mockResolvedValue({
+      ok: true,
+      value: {
+        stories: [
+          makeStory('s1', { assignee: 'Alice' }),
+          makeStory('s2', { assignee: 'bob' }),
+          makeStory('s3', { assignee: null }),
+        ],
+        epics: [],
+        milestones: [],
+        roadmaps: [],
+        prds: [],
+        sprints: [],
+        errors: [],
+      },
+    });
+
+    await run('--assignee', 'alice', '--meta-dir', '/tmp/meta');
+
+    const logOutput = logSpy.mock.calls.map((c) => c.join(' ')).join('\n');
+    expect(logOutput).toContain('Story s1');
+    expect(logOutput).toContain('@Alice');
+    expect(logOutput).not.toContain('Story s2');
+  });
+
+  it('renders all priority bullets (critical, high, medium, low, default)', async () => {
+    mockParseTree.mockResolvedValue({
+      ok: true,
+      value: {
+        stories: [
+          makeStory('c', { priority: 'critical' }),
+          makeStory('h', { priority: 'high' }),
+          makeStory('m', { priority: 'medium' }),
+          makeStory('l', { priority: 'low' }),
+        ],
+        epics: [],
+        milestones: [],
+        roadmaps: [],
+        prds: [],
+        sprints: [],
+        errors: [],
+      },
+    });
+
+    await run('--meta-dir', '/tmp/meta');
+
+    const logOutput = logSpy.mock.calls.map((c) => c.join(' ')).join('\n');
+    expect(logOutput).toContain('Story c');
+    expect(logOutput).toContain('Story h');
+    expect(logOutput).toContain('Story m');
+    expect(logOutput).toContain('Story l');
+  });
+
+  it('shows "unassigned" for stories without assignee', async () => {
+    mockParseTree.mockResolvedValue({
+      ok: true,
+      value: {
+        stories: [makeStory('s1', { assignee: null })],
+        epics: [],
+        milestones: [],
+        roadmaps: [],
+        prds: [],
+        sprints: [],
+        errors: [],
+      },
+    });
+
+    await run('--meta-dir', '/tmp/meta');
+
+    const logOutput = logSpy.mock.calls.map((c) => c.join(' ')).join('\n');
+    expect(logOutput).toContain('unassigned');
+  });
+});

--- a/packages/cli/src/__tests__/output.test.ts
+++ b/packages/cli/src/__tests__/output.test.ts
@@ -1,0 +1,92 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  printError,
+  printSuccess,
+  printTree,
+  printWarning,
+  progressBar,
+} from '../utils/output.js';
+
+let logSpy: ReturnType<typeof vi.spyOn>;
+let errorSpy: ReturnType<typeof vi.spyOn>;
+let warnSpy: ReturnType<typeof vi.spyOn>;
+
+describe('output utils', () => {
+  beforeEach(() => {
+    logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('printSuccess writes to stdout with checkmark', () => {
+    printSuccess('ok');
+    const out = logSpy.mock.calls.map((c) => c.join(' ')).join('\n');
+    expect(out).toContain('✓ ok');
+  });
+
+  it('printError writes to stderr with cross', () => {
+    printError('bad');
+    const out = errorSpy.mock.calls.map((c) => c.join(' ')).join('\n');
+    expect(out).toContain('✗ bad');
+  });
+
+  it('printWarning writes to stderr with warn glyph', () => {
+    printWarning('watch out');
+    const out = warnSpy.mock.calls.map((c) => c.join(' ')).join('\n');
+    expect(out).toContain('⚠ watch out');
+  });
+
+  describe('progressBar', () => {
+    it('renders green for ratio ≥ 0.75', () => {
+      const bar = progressBar(0.8, 10);
+      expect(bar).toMatch(/█+░*/);
+    });
+
+    it('renders yellow for ratio between 0.25 and 0.75', () => {
+      const bar = progressBar(0.5, 10);
+      expect(bar).toMatch(/█+░*/);
+    });
+
+    it('renders red for ratio below 0.25', () => {
+      const bar = progressBar(0.1, 10);
+      expect(bar).toMatch(/█*░+/);
+    });
+
+    it('computes correct fill for full bar', () => {
+      const bar = progressBar(1, 5);
+      // Strip ANSI to count fills
+      // biome-ignore lint/suspicious/noControlCharactersInRegex: stripping ANSI escape sequences
+      const stripped = bar.replace(/\u001b\[[0-9;]*m/g, '');
+      expect(stripped).toBe('█'.repeat(5));
+    });
+
+    it('computes correct fill for empty bar', () => {
+      const bar = progressBar(0, 5);
+      // biome-ignore lint/suspicious/noControlCharactersInRegex: stripping ANSI escape sequences
+      const stripped = bar.replace(/\u001b\[[0-9;]*m/g, '');
+      expect(stripped).toBe('░'.repeat(5));
+    });
+  });
+
+  describe('printTree', () => {
+    it('prints nested files with indentation', () => {
+      printTree(['dir', 'dir/sub', 'dir/sub/file.md', 'other.md']);
+
+      const out = logSpy.mock.calls.map((c) => c.join(' ')).join('\n');
+      expect(out).toContain('dir/');
+      expect(out).toContain('sub/');
+      expect(out).toContain('file.md');
+      expect(out).toContain('other.md');
+    });
+
+    it('treats files without an extension as directories', () => {
+      printTree(['only-dir']);
+      const out = logSpy.mock.calls.map((c) => c.join(' ')).join('\n');
+      expect(out).toContain('only-dir/');
+    });
+  });
+});

--- a/packages/cli/src/__tests__/pull.test.ts
+++ b/packages/cli/src/__tests__/pull.test.ts
@@ -192,4 +192,25 @@ describe('gitpm pull', () => {
       expect.objectContaining({ event: 'post-sync' }),
     );
   });
+
+  it('exits 1 on invalid strategy', async () => {
+    await expect(
+      run('--strategy', 'xyz', '--meta-dir', '/tmp/meta'),
+    ).rejects.toThrow('process.exit');
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    const errOutput = errorSpy.mock.calls.map((c) => c.join(' ')).join('\n');
+    expect(errOutput).toContain('Invalid strategy');
+  });
+
+  it('exits 1 when pre-sync hook fails', async () => {
+    mockRunHooks.mockResolvedValueOnce({
+      ok: false,
+      error: { message: 'hook failed' },
+    });
+
+    await expect(run('--meta-dir', '/tmp/meta')).rejects.toThrow(
+      'process.exit',
+    );
+    expect(exitSpy).toHaveBeenCalledWith(1);
+  });
 });

--- a/packages/cli/src/__tests__/push.test.ts
+++ b/packages/cli/src/__tests__/push.test.ts
@@ -208,4 +208,47 @@ describe('gitpm push', () => {
       expect.objectContaining({ event: 'post-export' }),
     );
   });
+
+  it('exits 1 when dry-run export fails', async () => {
+    mockAdapterExport.mockResolvedValue({
+      ok: false,
+      error: { message: 'dry err' },
+    });
+
+    await expect(run('--dry-run', '--meta-dir', '/tmp/meta')).rejects.toThrow(
+      'process.exit',
+    );
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    const errOutput = errorSpy.mock.calls.map((c) => c.join(' ')).join('\n');
+    expect(errOutput).toContain('dry err');
+  });
+
+  it('exits 1 when preview calculation fails', async () => {
+    mockAdapterExport.mockResolvedValue({
+      ok: false,
+      error: { message: 'preview err' },
+    });
+
+    await expect(run('--yes', '--meta-dir', '/tmp/meta')).rejects.toThrow(
+      'process.exit',
+    );
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    const errOutput = errorSpy.mock.calls.map((c) => c.join(' ')).join('\n');
+    expect(errOutput).toContain('preview err');
+  });
+
+  it('exits 1 when pre-export hook fails', async () => {
+    mockAdapterExport
+      .mockResolvedValueOnce({ ok: true, value: exportResult }) // preview
+      .mockResolvedValueOnce({ ok: true, value: exportResult });
+    mockRunHooks.mockResolvedValueOnce({
+      ok: false,
+      error: { message: 'hook err' },
+    });
+
+    await expect(run('--yes', '--meta-dir', '/tmp/meta')).rejects.toThrow(
+      'process.exit',
+    );
+    expect(exitSpy).toHaveBeenCalledWith(1);
+  });
 });

--- a/packages/cli/src/__tests__/quality.test.ts
+++ b/packages/cli/src/__tests__/quality.test.ts
@@ -1,0 +1,221 @@
+import { Command } from 'commander';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// --- Mocks ---
+
+const mockParseTree = vi.fn();
+const mockResolveRefs = vi.fn();
+const mockLoadQualityConfig = vi.fn();
+const mockScoreEntities = vi.fn();
+
+vi.mock('@gitpm/core', () => ({
+  parseTree: (...args: unknown[]) => mockParseTree(...args),
+  resolveRefs: (...args: unknown[]) => mockResolveRefs(...args),
+  loadQualityConfig: (...args: unknown[]) => mockLoadQualityConfig(...args),
+  scoreEntities: (...args: unknown[]) => mockScoreEntities(...args),
+}));
+
+let logSpy: ReturnType<typeof vi.spyOn>;
+let errorSpy: ReturnType<typeof vi.spyOn>;
+let exitSpy: ReturnType<typeof vi.spyOn>;
+
+async function run(...args: string[]) {
+  const { qualityCommand } = await import('../commands/quality.js');
+  const program = new Command();
+  program.option('--meta-dir <path>', 'Path to .meta directory', '.meta');
+  program.addCommand(qualityCommand);
+  await program.parseAsync(['node', 'gitpm', 'quality', ...args]);
+}
+
+function makeReport(overrides: Record<string, unknown> = {}) {
+  return {
+    distribution: { A: 2, B: 3, C: 1, D: 1, F: 1 },
+    average: 6.5,
+    entities: [
+      {
+        id: 'st_1',
+        score: 3,
+        maxScore: 9,
+        grade: 'D',
+        filePath: '/tmp/.meta/stories/low.md',
+      },
+      {
+        id: 'st_2',
+        score: 1,
+        maxScore: 9,
+        grade: 'F',
+        filePath: '/tmp/.meta/stories/fail.md',
+      },
+      {
+        id: 'st_3',
+        score: 8,
+        maxScore: 9,
+        grade: 'A',
+        filePath: '/tmp/.meta/stories/good.md',
+      },
+    ],
+    ...overrides,
+  };
+}
+
+// --- Tests ---
+
+describe('gitpm quality', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.resetAllMocks();
+    logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => {
+      throw new Error('process.exit');
+    }) as never);
+    mockParseTree.mockResolvedValue({ ok: true, value: {} });
+    mockResolveRefs.mockReturnValue({ ok: true, value: {} });
+    mockLoadQualityConfig.mockResolvedValue({ ok: true, value: null });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('exits 1 when parseTree fails', async () => {
+    mockParseTree.mockResolvedValue({
+      ok: false,
+      error: { message: 'parse err' },
+    });
+    await expect(run('--meta-dir', '/tmp/m')).rejects.toThrow('process.exit');
+    expect(exitSpy).toHaveBeenCalledWith(1);
+  });
+
+  it('exits 1 when resolveRefs fails', async () => {
+    mockResolveRefs.mockReturnValue({
+      ok: false,
+      error: { message: 'resolve err' },
+    });
+    await expect(run('--meta-dir', '/tmp/m')).rejects.toThrow('process.exit');
+    expect(exitSpy).toHaveBeenCalledWith(1);
+  });
+
+  it('exits 1 when loadQualityConfig fails', async () => {
+    mockLoadQualityConfig.mockResolvedValue({
+      ok: false,
+      error: { message: 'config err' },
+    });
+    await expect(run('--meta-dir', '/tmp/m')).rejects.toThrow('process.exit');
+    expect(exitSpy).toHaveBeenCalledWith(1);
+  });
+
+  it('prints "no entities" when report is empty', async () => {
+    mockScoreEntities.mockReturnValue({
+      distribution: { A: 0, B: 0, C: 0, D: 0, F: 0 },
+      average: 0,
+      entities: [],
+    });
+
+    await run('--meta-dir', '/tmp/m');
+
+    const logOutput = logSpy.mock.calls.map((c) => c.join(' ')).join('\n');
+    expect(logOutput).toContain('No scorable entities');
+    expect(exitSpy).not.toHaveBeenCalled();
+  });
+
+  it('prints report with grades and lowest-scoring entities', async () => {
+    mockScoreEntities.mockReturnValue(makeReport());
+
+    await run('--meta-dir', '/tmp/m');
+
+    const logOutput = logSpy.mock.calls.map((c) => c.join(' ')).join('\n');
+    expect(logOutput).toContain('Entity Quality Report');
+    expect(logOutput).toContain('A (8-9)');
+    expect(logOutput).toContain('B (6-7)');
+    expect(logOutput).toContain('C (4-5)');
+    expect(logOutput).toContain('D (2-3)');
+    expect(logOutput).toContain('F (0-1)');
+    expect(logOutput).toContain('Average:');
+    expect(logOutput).toContain('Lowest scoring');
+    expect(logOutput).toContain('st_1');
+    expect(logOutput).toContain('st_2');
+    // st_3 scored 8, above 6 threshold, not in lowest
+    expect(logOutput).not.toContain('st_3');
+  });
+
+  it('uses singular "entity" for a distribution of 1', async () => {
+    mockScoreEntities.mockReturnValue({
+      distribution: { A: 1, B: 2, C: 0, D: 0, F: 0 },
+      average: 7,
+      entities: [
+        {
+          id: 'st_1',
+          score: 7,
+          maxScore: 9,
+          grade: 'B',
+          filePath: '/tmp/x.md',
+        },
+      ],
+    });
+
+    await run('--meta-dir', '/tmp/m');
+
+    const logOutput = logSpy.mock.calls.map((c) => c.join(' ')).join('\n');
+    expect(logOutput).toMatch(/A \(8-9\):\s+1 entity\b/);
+    expect(logOutput).toMatch(/B \(6-7\):\s+2 entities\b/);
+  });
+
+  it('renders all grade buckets for averages (A/B/C/D/F)', async () => {
+    const stubEntity = {
+      id: 'e',
+      score: 5,
+      maxScore: 9,
+      grade: 'C',
+      filePath: '/tmp/x.md',
+    };
+    const averages = [9, 7, 5, 3, 0];
+    for (const avg of averages) {
+      vi.resetAllMocks();
+      mockParseTree.mockResolvedValue({ ok: true, value: {} });
+      mockResolveRefs.mockReturnValue({ ok: true, value: {} });
+      mockLoadQualityConfig.mockResolvedValue({ ok: true, value: null });
+      mockScoreEntities.mockReturnValue({
+        distribution: { A: 0, B: 0, C: 0, D: 0, F: 0 },
+        average: avg,
+        entities: [stubEntity],
+      });
+      await run('--meta-dir', '/tmp/m');
+      const logOutput = logSpy.mock.calls.map((c) => c.join(' ')).join('\n');
+      expect(logOutput).toContain(`${avg}.0`);
+    }
+  });
+
+  it('exits 1 when average is below --threshold', async () => {
+    mockScoreEntities.mockReturnValue(makeReport({ average: 3 }));
+
+    await expect(
+      run('--threshold', '5', '--meta-dir', '/tmp/m'),
+    ).rejects.toThrow('process.exit');
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    const errOutput = errorSpy.mock.calls.map((c) => c.join(' ')).join('\n');
+    expect(errOutput).toContain('below threshold');
+  });
+
+  it('uses config threshold when --threshold is not set', async () => {
+    mockLoadQualityConfig.mockResolvedValue({
+      ok: true,
+      value: { threshold: { min_average: 8 } },
+    });
+    mockScoreEntities.mockReturnValue(makeReport({ average: 6 }));
+
+    await expect(run('--meta-dir', '/tmp/m')).rejects.toThrow('process.exit');
+    expect(exitSpy).toHaveBeenCalledWith(1);
+  });
+
+  it('passes config to scoreEntities', async () => {
+    const cfg = { threshold: { min_average: 5 } };
+    mockLoadQualityConfig.mockResolvedValue({ ok: true, value: cfg });
+    mockScoreEntities.mockReturnValue(makeReport({ average: 8 }));
+
+    await run('--meta-dir', '/tmp/m');
+
+    expect(mockScoreEntities).toHaveBeenCalledWith(expect.anything(), cfg);
+    expect(exitSpy).not.toHaveBeenCalled();
+  });
+});

--- a/packages/cli/src/__tests__/query.test.ts
+++ b/packages/cli/src/__tests__/query.test.ts
@@ -165,4 +165,17 @@ describe('gitpm query', () => {
       expect.objectContaining({ search: 'responsive' }),
     );
   });
+
+  it('parses assignee filter', async () => {
+    mockParseTree.mockResolvedValue({ ok: true, value: makeTree() });
+    mockFilterEntities.mockReturnValue([]);
+    mockFormatEntities.mockReturnValue('');
+
+    await run('--assignee', 'alice', '--meta-dir', '/tmp/test');
+
+    expect(mockFilterEntities).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ assignee: 'alice' }),
+    );
+  });
 });

--- a/packages/cli/src/__tests__/show.test.ts
+++ b/packages/cli/src/__tests__/show.test.ts
@@ -210,4 +210,213 @@ describe('gitpm show', () => {
     );
     expect(exitSpy).toHaveBeenCalledWith(1);
   });
+
+  it('exits with code 1 when resolveRefs fails (epic mode)', async () => {
+    mockParseTree.mockResolvedValue({ ok: true, value: makeTree() });
+    mockResolveRefs.mockReturnValue({
+      ok: false,
+      error: { message: 'resolve err' },
+    });
+
+    await expect(run('--epic', 'ep_1', '--meta-dir', '/tmp')).rejects.toThrow(
+      'process.exit',
+    );
+    expect(exitSpy).toHaveBeenCalledWith(1);
+  });
+
+  it('shows a milestone with its epics (pretty mode)', async () => {
+    mockParseTree.mockResolvedValue({ ok: true, value: makeTree() });
+    mockResolveRefs.mockReturnValue({
+      ok: true,
+      value: {
+        ...makeResolvedTree(),
+        milestones: [
+          {
+            type: 'milestone',
+            id: 'ms_1',
+            title: 'v1.0',
+            status: 'in_progress',
+            body: '',
+            filePath: '/tmp/.meta/roadmap/milestones/v1.md',
+            resolvedEpics: [
+              {
+                type: 'epic',
+                id: 'ep_1',
+                title: 'Linked Epic',
+                status: 'todo',
+                priority: 'high',
+              },
+            ],
+          },
+        ],
+      },
+    });
+
+    await run('--milestone', 'ms_1', '--meta-dir', '/tmp');
+
+    const output = logSpy.mock.calls.map((c) => c.join(' ')).join('\n');
+    expect(output).toContain('v1.0');
+    expect(output).toContain('Epics (1)');
+    expect(output).toContain('Linked Epic');
+  });
+
+  it('shows a milestone in JSON format', async () => {
+    mockParseTree.mockResolvedValue({ ok: true, value: makeTree() });
+    mockResolveRefs.mockReturnValue({ ok: true, value: makeResolvedTree() });
+
+    await run('--milestone', 'ms_1', '--format', 'json', '--meta-dir', '/tmp');
+
+    const output = logSpy.mock.calls.map((c) => c.join(' ')).join('\n');
+    const parsed = JSON.parse(output);
+    expect(parsed.milestone.id).toBe('ms_1');
+    expect(Array.isArray(parsed.epics)).toBe(true);
+  });
+
+  it('exits with code 1 when milestone not found', async () => {
+    mockParseTree.mockResolvedValue({ ok: true, value: makeTree() });
+    mockResolveRefs.mockReturnValue({ ok: true, value: makeResolvedTree() });
+
+    await expect(
+      run('--milestone', 'missing', '--meta-dir', '/tmp'),
+    ).rejects.toThrow('process.exit');
+    expect(exitSpy).toHaveBeenCalledWith(1);
+  });
+
+  it('outputs JSON for a single entity when --format json', async () => {
+    mockParseTree.mockResolvedValue({ ok: true, value: makeTree() });
+    mockResolveRefs.mockReturnValue({ ok: true, value: makeResolvedTree() });
+
+    await run('st_1', '--format', 'json', '--meta-dir', '/tmp');
+
+    const output = logSpy.mock.calls.map((c) => c.join(' ')).join('\n');
+    const parsed = JSON.parse(output);
+    expect(parsed.id).toBe('st_1');
+  });
+
+  it('renders entity body when --full is set', async () => {
+    mockParseTree.mockResolvedValue({ ok: true, value: makeTree() });
+    mockResolveRefs.mockReturnValue({ ok: true, value: makeResolvedTree() });
+
+    await run('st_1', '--full', '--meta-dir', '/tmp');
+
+    const output = logSpy.mock.calls.map((c) => c.join(' ')).join('\n');
+    expect(output).toContain('Test body');
+  });
+
+  it('renders all status/priority values in formatFieldValue', async () => {
+    mockParseTree.mockResolvedValue({
+      ok: true,
+      value: {
+        ...makeTree(),
+        stories: [
+          {
+            type: 'story',
+            id: 'st_a',
+            title: 'A',
+            status: 'done',
+            priority: 'critical',
+            labels: [],
+            body: '',
+            filePath: '/tmp/.meta/stories/a.md',
+            meta: { nested: { deep: true } },
+          },
+        ],
+      },
+    });
+
+    await run('st_a', '--meta-dir', '/tmp');
+
+    const output = logSpy.mock.calls.map((c) => c.join(' ')).join('\n');
+    expect(output).toContain('A');
+    expect(output).toContain('done');
+    expect(output).toContain('critical');
+    // Object serialized to JSON
+    expect(output).toContain('nested');
+  });
+
+  it('renders medium priority and cancelled status', async () => {
+    mockParseTree.mockResolvedValue({
+      ok: true,
+      value: {
+        ...makeTree(),
+        stories: [
+          {
+            type: 'story',
+            id: 'st_b',
+            title: 'B',
+            status: 'cancelled',
+            priority: 'medium',
+            labels: [],
+            body: '',
+            filePath: '/tmp/.meta/stories/b.md',
+          },
+        ],
+      },
+    });
+
+    await run('st_b', '--meta-dir', '/tmp');
+
+    const output = logSpy.mock.calls.map((c) => c.join(' ')).join('\n');
+    expect(output).toContain('cancelled');
+    expect(output).toContain('medium');
+  });
+
+  it('renders low priority (default bullet branch)', async () => {
+    mockParseTree.mockResolvedValue({
+      ok: true,
+      value: {
+        ...makeTree(),
+        stories: [
+          {
+            type: 'story',
+            id: 'st_c',
+            title: 'C',
+            status: 'todo',
+            priority: 'low',
+            labels: [],
+            body: '',
+            filePath: '/tmp/.meta/stories/c.md',
+          },
+        ],
+      },
+    });
+
+    await run('st_c', '--meta-dir', '/tmp');
+
+    const output = logSpy.mock.calls.map((c) => c.join(' ')).join('\n');
+    expect(output).toContain('low');
+  });
+
+  it('displays all priority bullets in epic stories list', async () => {
+    mockParseTree.mockResolvedValue({ ok: true, value: makeTree() });
+    mockResolveRefs.mockReturnValue({
+      ok: true,
+      value: {
+        ...makeResolvedTree(),
+        epics: [
+          {
+            type: 'epic',
+            id: 'ep_1',
+            title: 'E',
+            status: 'todo',
+            priority: 'high',
+            labels: [],
+            body: '',
+            filePath: '/tmp/.meta/epics/e/epic.md',
+            resolvedStories: [
+              { id: 'c', title: 'C', status: 'todo', priority: 'critical' },
+              { id: 'h', title: 'H', status: 'todo', priority: 'high' },
+              { id: 'm', title: 'M', status: 'todo', priority: 'medium' },
+              { id: 'l', title: 'L', status: 'done', priority: 'low' },
+            ],
+          },
+        ],
+      },
+    });
+
+    await run('--epic', 'ep_1', '--meta-dir', '/tmp');
+
+    const output = logSpy.mock.calls.map((c) => c.join(' ')).join('\n');
+    expect(output).toContain('Stories (4)');
+  });
 });

--- a/packages/cli/src/__tests__/sprint.test.ts
+++ b/packages/cli/src/__tests__/sprint.test.ts
@@ -1,0 +1,354 @@
+import { Command } from 'commander';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// --- Mocks ---
+
+const mockCreateSprint = vi.fn();
+const mockParseTree = vi.fn();
+const mockResolveRefs = vi.fn();
+
+vi.mock('@gitpm/core', () => ({
+  createSprint: (...args: unknown[]) => mockCreateSprint(...args),
+  parseTree: (...args: unknown[]) => mockParseTree(...args),
+  resolveRefs: (...args: unknown[]) => mockResolveRefs(...args),
+}));
+
+let logSpy: ReturnType<typeof vi.spyOn>;
+let errorSpy: ReturnType<typeof vi.spyOn>;
+let exitSpy: ReturnType<typeof vi.spyOn>;
+
+async function run(...args: string[]) {
+  const { sprintCommand } = await import('../commands/sprint.js');
+  const program = new Command();
+  program.option('--meta-dir <path>', 'Path to .meta directory', '.meta');
+  program.addCommand(sprintCommand);
+  await program.parseAsync(['node', 'gitpm', 'sprint', ...args]);
+}
+
+function sprintRecord(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'sp_1',
+    type: 'sprint',
+    title: 'Sprint 1',
+    status: 'active',
+    start_date: '2026-04-01',
+    end_date: '2026-04-14',
+    capacity: 20,
+    resolvedStories: [
+      { id: 's1', title: 'Story 1', status: 'done' },
+      { id: 's2', title: 'Story 2', status: 'in_progress' },
+      { id: 's3', title: 'Story 3', status: 'backlog' },
+    ],
+    ...overrides,
+  };
+}
+
+// --- Tests ---
+
+describe('gitpm sprint create', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.resetAllMocks();
+    logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => {
+      throw new Error('process.exit');
+    }) as never);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('creates a sprint', async () => {
+    mockCreateSprint.mockResolvedValue({
+      ok: true,
+      value: { filePath: '/tmp/.meta/sprints/sp1.md', id: 'sp_1' },
+    });
+
+    await run(
+      'create',
+      '--title',
+      'Sprint 1',
+      '--start',
+      '2026-04-01',
+      '--end',
+      '2026-04-14',
+      '--capacity',
+      '20',
+      '--meta-dir',
+      '/tmp/m',
+    );
+
+    expect(mockCreateSprint).toHaveBeenCalledWith(
+      '/tmp/m',
+      expect.objectContaining({
+        title: 'Sprint 1',
+        startDate: '2026-04-01',
+        endDate: '2026-04-14',
+        capacity: 20,
+      }),
+    );
+    const logOutput = logSpy.mock.calls.map((c) => c.join(' ')).join('\n');
+    expect(logOutput).toContain('Created sprint');
+  });
+
+  it('exits 1 when createSprint fails', async () => {
+    mockCreateSprint.mockResolvedValue({
+      ok: false,
+      error: { message: 'already exists' },
+    });
+
+    await expect(
+      run(
+        'create',
+        '--title',
+        'Sprint',
+        '--start',
+        '2026-04-01',
+        '--end',
+        '2026-04-14',
+        '--meta-dir',
+        '/tmp/m',
+      ),
+    ).rejects.toThrow('process.exit');
+    expect(exitSpy).toHaveBeenCalledWith(1);
+  });
+});
+
+describe('gitpm sprint list', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.resetAllMocks();
+    logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => {
+      throw new Error('process.exit');
+    }) as never);
+    mockParseTree.mockResolvedValue({ ok: true, value: {} });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('exits 1 when parseTree fails', async () => {
+    mockParseTree.mockResolvedValue({
+      ok: false,
+      error: { message: 'parse err' },
+    });
+    await expect(run('list', '--meta-dir', '/tmp/m')).rejects.toThrow(
+      'process.exit',
+    );
+    expect(exitSpy).toHaveBeenCalledWith(1);
+  });
+
+  it('exits 1 when resolveRefs fails', async () => {
+    mockResolveRefs.mockReturnValue({
+      ok: false,
+      error: { message: 'resolve err' },
+    });
+    await expect(run('list', '--meta-dir', '/tmp/m')).rejects.toThrow(
+      'process.exit',
+    );
+    expect(exitSpy).toHaveBeenCalledWith(1);
+  });
+
+  it('prints message when no sprints exist', async () => {
+    mockResolveRefs.mockReturnValue({
+      ok: true,
+      value: { sprints: [] },
+    });
+
+    await run('list', '--meta-dir', '/tmp/m');
+
+    const logOutput = logSpy.mock.calls.map((c) => c.join(' ')).join('\n');
+    expect(logOutput).toContain('No sprints found');
+  });
+
+  it('prints sprint list with progress', async () => {
+    mockResolveRefs.mockReturnValue({
+      ok: true,
+      value: { sprints: [sprintRecord()] },
+    });
+
+    await run('list', '--meta-dir', '/tmp/m');
+
+    const logOutput = logSpy.mock.calls.map((c) => c.join(' ')).join('\n');
+    expect(logOutput).toContain('Sprints');
+    expect(logOutput).toContain('Sprint 1');
+    expect(logOutput).toContain('1/3 stories');
+    expect(logOutput).toContain('cap: 20');
+  });
+
+  it('prints sprint list without capacity when capacity is undefined', async () => {
+    mockResolveRefs.mockReturnValue({
+      ok: true,
+      value: { sprints: [sprintRecord({ capacity: undefined })] },
+    });
+
+    await run('list', '--meta-dir', '/tmp/m');
+
+    const logOutput = logSpy.mock.calls.map((c) => c.join(' ')).join('\n');
+    expect(logOutput).toContain('Sprint 1');
+    expect(logOutput).not.toContain('cap:');
+  });
+
+  it('outputs JSON when --json is set', async () => {
+    mockResolveRefs.mockReturnValue({
+      ok: true,
+      value: { sprints: [sprintRecord()] },
+    });
+
+    await run('list', '--json', '--meta-dir', '/tmp/m');
+
+    const logOutput = logSpy.mock.calls.map((c) => c.join(' ')).join('\n');
+    const parsed = JSON.parse(logOutput);
+    expect(parsed).toHaveLength(1);
+    expect(parsed[0]).toMatchObject({
+      id: 'sp_1',
+      title: 'Sprint 1',
+      stories: 3,
+      done: 1,
+    });
+  });
+
+  it('handles sprint with no stories (zero ratio)', async () => {
+    mockResolveRefs.mockReturnValue({
+      ok: true,
+      value: {
+        sprints: [sprintRecord({ resolvedStories: [] })],
+      },
+    });
+
+    await run('list', '--meta-dir', '/tmp/m');
+
+    const logOutput = logSpy.mock.calls.map((c) => c.join(' ')).join('\n');
+    expect(logOutput).toContain('0/0 stories');
+  });
+});
+
+describe('gitpm sprint show', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.resetAllMocks();
+    logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => {
+      throw new Error('process.exit');
+    }) as never);
+    mockParseTree.mockResolvedValue({ ok: true, value: {} });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('exits 1 when parseTree fails', async () => {
+    mockParseTree.mockResolvedValue({
+      ok: false,
+      error: { message: 'parse err' },
+    });
+    await expect(run('show', 'sp_1', '--meta-dir', '/tmp/m')).rejects.toThrow(
+      'process.exit',
+    );
+    expect(exitSpy).toHaveBeenCalledWith(1);
+  });
+
+  it('exits 1 when resolveRefs fails', async () => {
+    mockResolveRefs.mockReturnValue({
+      ok: false,
+      error: { message: 'resolve err' },
+    });
+    await expect(run('show', 'sp_1', '--meta-dir', '/tmp/m')).rejects.toThrow(
+      'process.exit',
+    );
+    expect(exitSpy).toHaveBeenCalledWith(1);
+  });
+
+  it('exits 1 when sprint is not found', async () => {
+    mockResolveRefs.mockReturnValue({
+      ok: true,
+      value: { sprints: [] },
+    });
+
+    await expect(
+      run('show', 'missing', '--meta-dir', '/tmp/m'),
+    ).rejects.toThrow('process.exit');
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    const errOutput = errorSpy.mock.calls.map((c) => c.join(' ')).join('\n');
+    expect(errOutput).toContain('Sprint not found');
+  });
+
+  it('shows sprint details with stories and capacity', async () => {
+    mockResolveRefs.mockReturnValue({
+      ok: true,
+      value: { sprints: [sprintRecord()] },
+    });
+
+    await run('show', 'sp_1', '--meta-dir', '/tmp/m');
+
+    const logOutput = logSpy.mock.calls.map((c) => c.join(' ')).join('\n');
+    expect(logOutput).toContain('Sprint 1');
+    expect(logOutput).toContain('Status:');
+    expect(logOutput).toContain('Period:');
+    expect(logOutput).toContain('Capacity: 20');
+    expect(logOutput).toContain('Progress:');
+    expect(logOutput).toContain('Stories:');
+    expect(logOutput).toContain('Story 1');
+    expect(logOutput).toContain('Story 2');
+    expect(logOutput).toContain('Story 3');
+  });
+
+  it('shows "No stories assigned" when sprint has no stories', async () => {
+    mockResolveRefs.mockReturnValue({
+      ok: true,
+      value: { sprints: [sprintRecord({ resolvedStories: [] })] },
+    });
+
+    await run('show', 'sp_1', '--meta-dir', '/tmp/m');
+
+    const logOutput = logSpy.mock.calls.map((c) => c.join(' ')).join('\n');
+    expect(logOutput).toContain('No stories assigned');
+  });
+
+  it('omits Capacity row when capacity not set', async () => {
+    mockResolveRefs.mockReturnValue({
+      ok: true,
+      value: {
+        sprints: [sprintRecord({ capacity: undefined })],
+      },
+    });
+
+    await run('show', 'sp_1', '--meta-dir', '/tmp/m');
+
+    const logOutput = logSpy.mock.calls.map((c) => c.join(' ')).join('\n');
+    expect(logOutput).not.toContain('Capacity:');
+  });
+
+  it('renders cancelled and in_progress statuses differently', async () => {
+    mockResolveRefs.mockReturnValue({
+      ok: true,
+      value: {
+        sprints: [
+          sprintRecord({
+            resolvedStories: [
+              { id: 's1', title: 'Done', status: 'done' },
+              { id: 's2', title: 'Cancelled', status: 'cancelled' },
+              { id: 's3', title: 'InProgress', status: 'in_progress' },
+              { id: 's4', title: 'Other', status: 'backlog' },
+            ],
+          }),
+        ],
+      },
+    });
+
+    await run('show', 'sp_1', '--meta-dir', '/tmp/m');
+
+    const logOutput = logSpy.mock.calls.map((c) => c.join(' ')).join('\n');
+    expect(logOutput).toContain('Done');
+    expect(logOutput).toContain('Cancelled');
+    expect(logOutput).toContain('InProgress');
+    expect(logOutput).toContain('Other');
+  });
+});

--- a/packages/cli/src/__tests__/status.test.ts
+++ b/packages/cli/src/__tests__/status.test.ts
@@ -1,0 +1,161 @@
+import { Command } from 'commander';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// --- Mocks ---
+
+const mockParseTree = vi.fn();
+const mockResolveRefs = vi.fn();
+const mockComputeProjectProgress = vi.fn();
+
+vi.mock('@gitpm/core', () => ({
+  parseTree: (...args: unknown[]) => mockParseTree(...args),
+  resolveRefs: (...args: unknown[]) => mockResolveRefs(...args),
+  computeProjectProgress: (...args: unknown[]) =>
+    mockComputeProjectProgress(...args),
+}));
+
+let logSpy: ReturnType<typeof vi.spyOn>;
+let errorSpy: ReturnType<typeof vi.spyOn>;
+let exitSpy: ReturnType<typeof vi.spyOn>;
+
+async function run(...args: string[]) {
+  const { statusCommand } = await import('../commands/status.js');
+  const program = new Command();
+  program.option('--meta-dir <path>', 'Path to .meta directory', '.meta');
+  program.addCommand(statusCommand);
+  await program.parseAsync(['node', 'gitpm', 'status', ...args]);
+}
+
+function makeProgress(overrides: Record<string, unknown> = {}) {
+  return {
+    overall: { total: 10, done: 4, progress: 0.4 },
+    milestones: [
+      {
+        title: 'v1',
+        targetDate: '2026-06-01T00:00:00Z',
+        progress: 0.5,
+        epics: [
+          {
+            title: 'Auth',
+            total: 4,
+            done: 2,
+            inProgress: 1,
+            blocked: 1,
+            progress: 0.5,
+          },
+        ],
+      },
+      {
+        title: 'v2',
+        targetDate: null,
+        progress: 0,
+        epics: [],
+      },
+    ],
+    orphanEpics: [
+      {
+        title: 'Misc',
+        total: 2,
+        done: 1,
+        inProgress: 0,
+        blocked: 0,
+        progress: 0.5,
+      },
+    ],
+    ...overrides,
+  };
+}
+
+// --- Tests ---
+
+describe('gitpm status', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.resetAllMocks();
+    logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => {
+      throw new Error('process.exit');
+    }) as never);
+    mockParseTree.mockResolvedValue({ ok: true, value: {} });
+    mockResolveRefs.mockReturnValue({ ok: true, value: {} });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('exits 1 when parseTree fails', async () => {
+    mockParseTree.mockResolvedValue({
+      ok: false,
+      error: { message: 'parse err' },
+    });
+    await expect(run('--meta-dir', '/tmp/m')).rejects.toThrow('process.exit');
+    expect(exitSpy).toHaveBeenCalledWith(1);
+  });
+
+  it('exits 1 when resolveRefs fails', async () => {
+    mockResolveRefs.mockReturnValue({
+      ok: false,
+      error: { message: 'resolve err' },
+    });
+    await expect(run('--meta-dir', '/tmp/m')).rejects.toThrow('process.exit');
+    expect(exitSpy).toHaveBeenCalledWith(1);
+  });
+
+  it('outputs JSON when --json is set', async () => {
+    const progress = makeProgress();
+    mockComputeProjectProgress.mockReturnValue(progress);
+
+    await run('--json', '--meta-dir', '/tmp/m');
+
+    const logOutput = logSpy.mock.calls.map((c) => c.join(' ')).join('\n');
+    const parsed = JSON.parse(logOutput);
+    expect(parsed.overall.total).toBe(10);
+  });
+
+  it('prints message when no stories exist', async () => {
+    mockComputeProjectProgress.mockReturnValue({
+      overall: { total: 0, done: 0, progress: 0 },
+      milestones: [],
+      orphanEpics: [],
+    });
+
+    await run('--meta-dir', '/tmp/m');
+
+    const logOutput = logSpy.mock.calls.map((c) => c.join(' ')).join('\n');
+    expect(logOutput).toContain('No stories found');
+  });
+
+  it('prints project progress with milestones, epics, and orphans', async () => {
+    mockComputeProjectProgress.mockReturnValue(makeProgress());
+
+    await run('--meta-dir', '/tmp/m');
+
+    const logOutput = logSpy.mock.calls.map((c) => c.join(' ')).join('\n');
+    expect(logOutput).toContain('Project Status');
+    expect(logOutput).toContain('40%');
+    expect(logOutput).toContain('4/10 stories');
+    expect(logOutput).toContain('v1');
+    expect(logOutput).toContain('due 2026-06-01');
+    expect(logOutput).toContain('Auth');
+    expect(logOutput).toContain('2/4 done');
+    expect(logOutput).toContain('1 active');
+    expect(logOutput).toContain('1 blocked');
+    expect(logOutput).toContain('v2');
+    expect(logOutput).toContain('(no epics linked)');
+    expect(logOutput).toContain('Unlinked Epics');
+    expect(logOutput).toContain('Misc');
+  });
+
+  it('omits "Unlinked Epics" when no orphan epics', async () => {
+    mockComputeProjectProgress.mockReturnValue(
+      makeProgress({ orphanEpics: [] }),
+    );
+
+    await run('--meta-dir', '/tmp/m');
+
+    const logOutput = logSpy.mock.calls.map((c) => c.join(' ')).join('\n');
+    expect(logOutput).not.toContain('Unlinked Epics');
+  });
+});

--- a/packages/cli/src/__tests__/sync.test.ts
+++ b/packages/cli/src/__tests__/sync.test.ts
@@ -244,4 +244,61 @@ describe('gitpm sync', () => {
       expect.objectContaining({ event: 'post-sync' }),
     );
   });
+
+  it('exits 1 on invalid strategy', async () => {
+    await expect(
+      run('--strategy', 'xyz', '--meta-dir', '/tmp/meta'),
+    ).rejects.toThrow('process.exit');
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    const errOutput = errorSpy.mock.calls.map((c) => c.join(' ')).join('\n');
+    expect(errOutput).toContain('Invalid strategy');
+  });
+
+  it('exits 1 when dry-run sync fails', async () => {
+    mockAdapterSync.mockResolvedValue({
+      ok: false,
+      error: { message: 'dry failed' },
+    });
+
+    await expect(run('--dry-run', '--meta-dir', '/tmp/meta')).rejects.toThrow(
+      'process.exit',
+    );
+    expect(exitSpy).toHaveBeenCalledWith(1);
+  });
+
+  it('exits 1 when pre-sync hook fails', async () => {
+    mockRunHooks.mockResolvedValueOnce({
+      ok: false,
+      error: { message: 'hook failed' },
+    });
+
+    await expect(run('--yes', '--meta-dir', '/tmp/meta')).rejects.toThrow(
+      'process.exit',
+    );
+    expect(exitSpy).toHaveBeenCalledWith(1);
+  });
+
+  it('prints resumedFromCheckpoint and failedEntities summary', async () => {
+    mockAdapterSync.mockResolvedValue({
+      ok: true,
+      value: {
+        ...syncResult,
+        resumedFromCheckpoint: true,
+        failedEntities: [
+          { entityId: 'e1', error: 'boom' },
+          { entityId: 'e2', error: 'kaboom' },
+        ],
+      },
+    });
+    mockConfirm.mockResolvedValue(true);
+
+    await run('--meta-dir', '/tmp/meta');
+
+    const logOutput = logSpy.mock.calls.map((c) => c.join(' ')).join('\n');
+    expect(logOutput).toContain('Resumed from previous checkpoint');
+    expect(logOutput).toContain('Failed');
+    expect(logOutput).toContain('e1: boom');
+    expect(logOutput).toContain('e2: kaboom');
+    expect(logOutput).toContain('checkpoint was saved');
+  });
 });


### PR DESCRIPTION
Adds tests for previously-uncovered CLI commands (archive, audit, next,
quality, sprint, status) and utils (adapters, auth, conflict-ui, output),
and extends existing tests for create, import, init, pull, push, query,
show, and sync to cover error paths and edge branches.

All CLI source files now report 100% line coverage.