### PR TITLE
test(sync-gitlab): add coverage for adapter, client, export, sync to 100%

### DIFF
--- a/.meta/epics/test-coverage-to-100-on-source-code/stories/add-test-coverage-for-packagessync-gitlab-to-100.md
+++ b/.meta/epics/test-coverage-to-100-on-source-code/stories/add-test-coverage-for-packagessync-gitlab-to-100.md
@@ -2,7 +2,7 @@
 type: story
 id: 4wZ38XRM48fw
 title: Add test coverage for packages/sync-gitlab to 100%
-status: todo
+status: in_review
 priority: high
 assignee: null
 labels:
@@ -12,7 +12,7 @@ estimate: null
 epic_ref:
   id: xGG0RMogvzyo
 created_at: 2026-04-12T19:35:00.664Z
-updated_at: 2026-04-12T19:35:00.664Z
+updated_at: 2026-04-19T12:48:47.234Z
 ---
 
 ## Objective

--- a/packages/sync-gitlab/src/__tests__/adapter.test.ts
+++ b/packages/sync-gitlab/src/__tests__/adapter.test.ts
@@ -1,0 +1,252 @@
+import { writeFile as fsWriteFile, mkdir, mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { gitlabAdapter } from '../adapter.js';
+
+vi.mock('../import.js', () => ({
+  importFromGitLab: vi.fn(async () => ({
+    ok: true,
+    value: { milestones: 0, epics: 0, stories: 0, totalFiles: 0 },
+  })),
+}));
+
+vi.mock('../export.js', () => ({
+  exportToGitLab: vi.fn(async () => ({
+    ok: true,
+    value: {
+      created: { milestones: 0, issues: 0 },
+      updated: { milestones: 0, issues: 0 },
+      totalChanges: 0,
+    },
+  })),
+}));
+
+vi.mock('../sync.js', () => ({
+  syncWithGitLab: vi.fn(async () => ({
+    ok: true,
+    value: {
+      pushed: { milestones: 0, issues: 0 },
+      pulled: { milestones: 0, issues: 0 },
+      conflicts: [],
+      resolved: 0,
+      skipped: 0,
+    },
+  })),
+}));
+
+import { exportToGitLab } from '../export.js';
+import { importFromGitLab } from '../import.js';
+import { syncWithGitLab } from '../sync.js';
+
+let metaDir: string;
+
+beforeEach(async () => {
+  metaDir = await mkdtemp(join(tmpdir(), 'gitpm-adapter-'));
+  vi.clearAllMocks();
+});
+
+afterEach(async () => {
+  await rm(metaDir, { recursive: true });
+});
+
+async function writeConfig(): Promise<void> {
+  await mkdir(join(metaDir, 'sync'), { recursive: true });
+  await fsWriteFile(
+    join(metaDir, 'sync', 'gitlab-config.yaml'),
+    [
+      'project: ns/proj',
+      'project_id: 42',
+      'base_url: https://gitlab.com',
+      'group_id: 10',
+      'auto_sync: false',
+      'status_mapping: {}',
+      'label_mapping:',
+      '  epic_labels: [epic]',
+      '',
+    ].join('\n'),
+    'utf-8',
+  );
+}
+
+describe('gitlabAdapter', () => {
+  it('has name and displayName', () => {
+    expect(gitlabAdapter.name).toBe('gitlab');
+    expect(gitlabAdapter.displayName).toBe('GitLab');
+  });
+
+  describe('detect', () => {
+    it('returns false when config file missing', async () => {
+      expect(await gitlabAdapter.detect(metaDir)).toBe(false);
+    });
+
+    it('returns true when config file present', async () => {
+      await writeConfig();
+      expect(await gitlabAdapter.detect(metaDir)).toBe(true);
+    });
+  });
+
+  describe('import', () => {
+    it('returns error when token is missing', async () => {
+      const result = await gitlabAdapter.import({
+        project: 'ns/proj',
+        metaDir,
+      });
+      expect(result.ok).toBe(false);
+      if (!result.ok) expect(result.error.message).toMatch(/token is required/);
+    });
+
+    it('returns error when project is missing', async () => {
+      const result = await gitlabAdapter.import({
+        token: 't',
+        metaDir,
+      });
+      expect(result.ok).toBe(false);
+      if (!result.ok)
+        expect(result.error.message).toMatch(/project is required/);
+    });
+
+    it('delegates to importFromGitLab using top-level token & project', async () => {
+      const result = await gitlabAdapter.import({
+        token: 'tok',
+        project: 'ns/proj',
+        metaDir,
+      });
+      expect(result.ok).toBe(true);
+      expect(importFromGitLab).toHaveBeenCalledWith(
+        expect.objectContaining({
+          token: 'tok',
+          project: 'ns/proj',
+          metaDir,
+        }),
+      );
+    });
+
+    it('uses credentials fallback', async () => {
+      const result = await gitlabAdapter.import({
+        credentials: { token: 'cred-tok', project: 'cred/proj' },
+        metaDir,
+        projectId: 42,
+        groupId: 10,
+        baseUrl: 'https://gl.example.com',
+        linkStrategy: 'body-refs',
+      });
+      expect(result.ok).toBe(true);
+      expect(importFromGitLab).toHaveBeenCalledWith(
+        expect.objectContaining({
+          token: 'cred-tok',
+          project: 'cred/proj',
+          projectId: 42,
+          groupId: 10,
+          baseUrl: 'https://gl.example.com',
+          linkStrategy: 'body-refs',
+        }),
+      );
+    });
+  });
+
+  describe('export', () => {
+    it('returns error when token is missing', async () => {
+      const result = await gitlabAdapter.export({
+        project: 'ns/proj',
+        metaDir,
+      });
+      expect(result.ok).toBe(false);
+    });
+
+    it('returns error when project is missing and no config', async () => {
+      const result = await gitlabAdapter.export({
+        token: 'tok',
+        metaDir,
+      });
+      expect(result.ok).toBe(false);
+      if (!result.ok)
+        expect(result.error.message).toMatch(/project is required/);
+    });
+
+    it('uses config project when no explicit project', async () => {
+      await writeConfig();
+      const result = await gitlabAdapter.export({
+        token: 'tok',
+        metaDir,
+        dryRun: true,
+      });
+      expect(result.ok).toBe(true);
+      expect(exportToGitLab).toHaveBeenCalledWith(
+        expect.objectContaining({
+          token: 'tok',
+          project: 'ns/proj',
+          projectId: 42,
+          groupId: 10,
+          baseUrl: 'https://gitlab.com',
+          metaDir,
+          dryRun: true,
+        }),
+      );
+    });
+
+    it('uses explicit project over config', async () => {
+      await writeConfig();
+      const result = await gitlabAdapter.export({
+        token: 'tok',
+        project: 'other/proj',
+        metaDir,
+      });
+      expect(result.ok).toBe(true);
+      expect(exportToGitLab).toHaveBeenCalledWith(
+        expect.objectContaining({ project: 'other/proj' }),
+      );
+    });
+  });
+
+  describe('sync', () => {
+    it('returns error when token is missing', async () => {
+      const result = await gitlabAdapter.sync({
+        project: 'ns/proj',
+        metaDir,
+      });
+      expect(result.ok).toBe(false);
+    });
+
+    it('returns error when project is missing and no config', async () => {
+      const result = await gitlabAdapter.sync({
+        token: 'tok',
+        metaDir,
+      });
+      expect(result.ok).toBe(false);
+    });
+
+    it('delegates to syncWithGitLab with config values', async () => {
+      await writeConfig();
+      const result = await gitlabAdapter.sync({
+        token: 'tok',
+        metaDir,
+        strategy: 'local-wins',
+        dryRun: false,
+      });
+      expect(result.ok).toBe(true);
+      expect(syncWithGitLab).toHaveBeenCalledWith(
+        expect.objectContaining({
+          token: 'tok',
+          project: 'ns/proj',
+          projectId: 42,
+          groupId: 10,
+          baseUrl: 'https://gitlab.com',
+          strategy: 'local-wins',
+        }),
+      );
+    });
+
+    it('uses credentials fallback for project', async () => {
+      const result = await gitlabAdapter.sync({
+        token: 'tok',
+        credentials: { project: 'cred/proj' },
+        metaDir,
+      });
+      expect(result.ok).toBe(true);
+      expect(syncWithGitLab).toHaveBeenCalledWith(
+        expect.objectContaining({ project: 'cred/proj' }),
+      );
+    });
+  });
+});

--- a/packages/sync-gitlab/src/__tests__/client.test.ts
+++ b/packages/sync-gitlab/src/__tests__/client.test.ts
@@ -1,0 +1,539 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { GlEpic, GlIssue, GlMilestone, GlProject } from '../client.js';
+import { GitLabClient } from '../client.js';
+
+const mockFetch = vi.fn();
+
+beforeEach(() => {
+  mockFetch.mockReset();
+  vi.stubGlobal('fetch', mockFetch);
+  vi.spyOn(console, 'warn').mockImplementation(() => {});
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+function jsonResponse(
+  data: unknown,
+  init?: { status?: number; headers?: Record<string, string> },
+): Response {
+  const headers = new Headers({
+    'Content-Type': 'application/json',
+    ...(init?.headers ?? {}),
+  });
+  return new Response(JSON.stringify(data), {
+    status: init?.status ?? 200,
+    headers,
+  });
+}
+
+describe('GitLabClient', () => {
+  describe('constructor', () => {
+    it('strips trailing slash from baseUrl', async () => {
+      mockFetch.mockResolvedValueOnce(jsonResponse([]));
+      const client = new GitLabClient('tok', 'https://gl.example.com/');
+      await client.listLabels(1);
+      const [url] = mockFetch.mock.calls[0];
+      expect(url).toBe(
+        'https://gl.example.com/api/v4/projects/1/labels?per_page=100&page=1',
+      );
+    });
+
+    it('defaults to gitlab.com', async () => {
+      mockFetch.mockResolvedValueOnce(jsonResponse([]));
+      const client = new GitLabClient('tok');
+      await client.listLabels(1);
+      const [url] = mockFetch.mock.calls[0];
+      expect(url).toContain('https://gitlab.com/api/v4/');
+    });
+  });
+
+  describe('getProject', () => {
+    it('returns project and encodes namespace/path', async () => {
+      const project: GlProject = {
+        id: 42,
+        name: 'proj',
+        path_with_namespace: 'ns/proj',
+        namespace: { id: 10, kind: 'group', full_path: 'ns' },
+      };
+      mockFetch.mockResolvedValueOnce(jsonResponse(project));
+
+      const client = new GitLabClient('tok');
+      const result = await client.getProject('ns/proj');
+      expect(result.id).toBe(42);
+
+      const [url, init] = mockFetch.mock.calls[0];
+      expect(url).toBe('https://gitlab.com/api/v4/projects/ns%2Fproj');
+      expect(init.headers['PRIVATE-TOKEN']).toBe('tok');
+    });
+
+    it('uses numeric project id without encoding', async () => {
+      const project: GlProject = {
+        id: 42,
+        name: 'proj',
+        path_with_namespace: 'ns/proj',
+        namespace: { id: 10, kind: 'user', full_path: 'ns' },
+      };
+      mockFetch.mockResolvedValueOnce(jsonResponse(project));
+
+      const client = new GitLabClient('tok');
+      await client.getProject(42);
+      const [url] = mockFetch.mock.calls[0];
+      expect(url).toBe('https://gitlab.com/api/v4/projects/42');
+    });
+  });
+
+  describe('listMilestones', () => {
+    it('concatenates active and closed milestones', async () => {
+      const activeMs: GlMilestone = {
+        id: 1,
+        iid: 1,
+        title: 'v1',
+        description: null,
+        state: 'active',
+        due_date: null,
+        created_at: '2026-01-01T00:00:00Z',
+        updated_at: '2026-01-01T00:00:00Z',
+      };
+      const closedMs: GlMilestone = { ...activeMs, id: 2, state: 'closed' };
+
+      mockFetch
+        .mockResolvedValueOnce(jsonResponse([activeMs]))
+        .mockResolvedValueOnce(jsonResponse([closedMs]));
+
+      const client = new GitLabClient('tok');
+      const result = await client.listMilestones(1);
+      expect(result).toHaveLength(2);
+      expect(result[0].state).toBe('active');
+      expect(result[1].state).toBe('closed');
+
+      const [, active] = mockFetch.mock.calls[0][0].match(/state=(\w+)/) ?? [];
+      expect(active).toBe('active');
+    });
+  });
+
+  describe('getMilestone', () => {
+    it('returns milestone when found', async () => {
+      const ms: GlMilestone = {
+        id: 1,
+        iid: 1,
+        title: 'v1',
+        description: null,
+        state: 'active',
+        due_date: null,
+        created_at: '2026-01-01T00:00:00Z',
+        updated_at: '2026-01-01T00:00:00Z',
+      };
+      mockFetch.mockResolvedValueOnce(jsonResponse(ms));
+
+      const client = new GitLabClient('tok');
+      const result = await client.getMilestone(1, 1);
+      expect(result?.id).toBe(1);
+    });
+
+    it('returns null on 404', async () => {
+      mockFetch.mockResolvedValueOnce(
+        new Response('not found', { status: 404 }),
+      );
+      const client = new GitLabClient('tok');
+      const result = await client.getMilestone(1, 999);
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('createMilestone', () => {
+    it('POSTs body and returns created', async () => {
+      const ms: GlMilestone = {
+        id: 5,
+        iid: 1,
+        title: 'v2',
+        description: 'desc',
+        state: 'active',
+        due_date: '2026-10-01',
+        created_at: '2026-01-01T00:00:00Z',
+        updated_at: '2026-01-01T00:00:00Z',
+      };
+      mockFetch.mockResolvedValueOnce(jsonResponse(ms));
+
+      const client = new GitLabClient('tok');
+      const result = await client.createMilestone(7, {
+        title: 'v2',
+        description: 'desc',
+        due_date: '2026-10-01',
+      });
+      expect(result.id).toBe(5);
+      const [url, init] = mockFetch.mock.calls[0];
+      expect(url).toBe(
+        'https://gitlab.com/api/v4/projects/7/milestones?per_page=100&page=1'.replace(
+          '?per_page=100&page=1',
+          '',
+        ),
+      );
+      expect(init.method).toBe('POST');
+      expect(JSON.parse(init.body).title).toBe('v2');
+    });
+  });
+
+  describe('updateMilestone', () => {
+    it('PUTs body', async () => {
+      const ms: GlMilestone = {
+        id: 5,
+        iid: 1,
+        title: 'v2',
+        description: 'updated',
+        state: 'closed',
+        due_date: null,
+        created_at: '2026-01-01T00:00:00Z',
+        updated_at: '2026-02-01T00:00:00Z',
+      };
+      mockFetch.mockResolvedValueOnce(jsonResponse(ms));
+
+      const client = new GitLabClient('tok');
+      const result = await client.updateMilestone(7, 5, {
+        state_event: 'close',
+      });
+      expect(result.id).toBe(5);
+      const [url, init] = mockFetch.mock.calls[0];
+      expect(url).toBe('https://gitlab.com/api/v4/projects/7/milestones/5');
+      expect(init.method).toBe('PUT');
+    });
+  });
+
+  describe('listIssues', () => {
+    it('paginates with x-next-page', async () => {
+      const page1: GlIssue[] = Array.from({ length: 100 }, (_, i) => ({
+        id: i,
+        iid: i,
+        title: `t${i}`,
+        description: null,
+        state: 'opened' as const,
+        assignee: null,
+        labels: [],
+        milestone: null,
+        weight: null,
+        epic_iid: null,
+        created_at: '2026-01-01T00:00:00Z',
+        updated_at: '2026-01-01T00:00:00Z',
+      }));
+      const page2: GlIssue[] = [
+        {
+          id: 100,
+          iid: 100,
+          title: 't100',
+          description: null,
+          state: 'opened',
+          assignee: null,
+          labels: [],
+          milestone: null,
+          weight: null,
+          epic_iid: null,
+          created_at: '2026-01-01T00:00:00Z',
+          updated_at: '2026-01-01T00:00:00Z',
+        },
+      ];
+      mockFetch
+        .mockResolvedValueOnce(
+          jsonResponse(page1, { headers: { 'x-next-page': '2' } }),
+        )
+        .mockResolvedValueOnce(jsonResponse(page2));
+
+      const client = new GitLabClient('tok');
+      const result = await client.listIssues(1);
+      expect(result).toHaveLength(101);
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+      const [firstUrl] = mockFetch.mock.calls[0];
+      expect(firstUrl).toContain('state=all');
+      expect(firstUrl).toContain('order_by=created_at');
+    });
+
+    it('respects state option', async () => {
+      mockFetch.mockResolvedValueOnce(jsonResponse([]));
+      const client = new GitLabClient('tok');
+      await client.listIssues(1, { state: 'opened' });
+      const [url] = mockFetch.mock.calls[0];
+      expect(url).toContain('state=opened');
+    });
+  });
+
+  describe('getIssue', () => {
+    it('returns issue when found', async () => {
+      const issue: GlIssue = {
+        id: 1,
+        iid: 1,
+        title: 't',
+        description: null,
+        state: 'opened',
+        assignee: null,
+        labels: [],
+        milestone: null,
+        weight: null,
+        epic_iid: null,
+        created_at: '2026-01-01T00:00:00Z',
+        updated_at: '2026-01-01T00:00:00Z',
+      };
+      mockFetch.mockResolvedValueOnce(jsonResponse(issue));
+
+      const client = new GitLabClient('tok');
+      const result = await client.getIssue(1, 1);
+      expect(result?.iid).toBe(1);
+    });
+
+    it('returns null on error', async () => {
+      mockFetch.mockResolvedValueOnce(
+        new Response('forbidden', { status: 403 }),
+      );
+      const client = new GitLabClient('tok');
+      const result = await client.getIssue(1, 99);
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('createIssue', () => {
+    it('POSTs body', async () => {
+      const created: GlIssue = {
+        id: 10,
+        iid: 10,
+        title: 'new',
+        description: 'd',
+        state: 'opened',
+        assignee: null,
+        labels: [],
+        milestone: null,
+        weight: null,
+        epic_iid: null,
+        created_at: '2026-01-01T00:00:00Z',
+        updated_at: '2026-01-01T00:00:00Z',
+      };
+      mockFetch.mockResolvedValueOnce(jsonResponse(created));
+
+      const client = new GitLabClient('tok');
+      const result = await client.createIssue(1, {
+        title: 'new',
+        description: 'd',
+      });
+      expect(result.iid).toBe(10);
+      const [, init] = mockFetch.mock.calls[0];
+      expect(init.method).toBe('POST');
+      expect(JSON.parse(init.body).title).toBe('new');
+    });
+  });
+
+  describe('updateIssue', () => {
+    it('PUTs body', async () => {
+      const updated: GlIssue = {
+        id: 10,
+        iid: 10,
+        title: 't',
+        description: null,
+        state: 'closed',
+        assignee: null,
+        labels: [],
+        milestone: null,
+        weight: null,
+        epic_iid: null,
+        created_at: '2026-01-01T00:00:00Z',
+        updated_at: '2026-02-01T00:00:00Z',
+      };
+      mockFetch.mockResolvedValueOnce(jsonResponse(updated));
+
+      const client = new GitLabClient('tok');
+      const result = await client.updateIssue(1, 10, { state_event: 'close' });
+      expect(result.state).toBe('closed');
+      const [url, init] = mockFetch.mock.calls[0];
+      expect(url).toBe('https://gitlab.com/api/v4/projects/1/issues/10');
+      expect(init.method).toBe('PUT');
+    });
+  });
+
+  describe('group epics', () => {
+    it('listGroupEpics returns epics on success', async () => {
+      const epic: GlEpic = {
+        id: 1,
+        iid: 1,
+        group_id: 10,
+        title: 'Epic',
+        description: null,
+        state: 'opened',
+        labels: [],
+        created_at: '2026-01-01T00:00:00Z',
+        updated_at: '2026-01-01T00:00:00Z',
+      };
+      mockFetch.mockResolvedValueOnce(jsonResponse([epic]));
+
+      const client = new GitLabClient('tok');
+      const result = await client.listGroupEpics(10);
+      expect(result).toHaveLength(1);
+    });
+
+    it('listGroupEpics returns [] when Premium forbidden', async () => {
+      mockFetch.mockResolvedValueOnce(
+        new Response('forbidden', { status: 403 }),
+      );
+      const client = new GitLabClient('tok');
+      const result = await client.listGroupEpics(10);
+      expect(result).toEqual([]);
+    });
+
+    it('getGroupEpic returns epic or null', async () => {
+      const epic: GlEpic = {
+        id: 1,
+        iid: 1,
+        group_id: 10,
+        title: 'Epic',
+        description: null,
+        state: 'opened',
+        labels: [],
+        created_at: '2026-01-01T00:00:00Z',
+        updated_at: '2026-01-01T00:00:00Z',
+      };
+      mockFetch
+        .mockResolvedValueOnce(jsonResponse(epic))
+        .mockResolvedValueOnce(new Response('not found', { status: 404 }));
+
+      const client = new GitLabClient('tok');
+      expect((await client.getGroupEpic(10, 1))?.iid).toBe(1);
+      expect(await client.getGroupEpic(10, 999)).toBeNull();
+    });
+
+    it('createGroupEpic POSTs body', async () => {
+      const epic: GlEpic = {
+        id: 2,
+        iid: 2,
+        group_id: 10,
+        title: 'New',
+        description: null,
+        state: 'opened',
+        labels: [],
+        created_at: '2026-01-01T00:00:00Z',
+        updated_at: '2026-01-01T00:00:00Z',
+      };
+      mockFetch.mockResolvedValueOnce(jsonResponse(epic));
+
+      const client = new GitLabClient('tok');
+      const result = await client.createGroupEpic(10, { title: 'New' });
+      expect(result.iid).toBe(2);
+      const [, init] = mockFetch.mock.calls[0];
+      expect(init.method).toBe('POST');
+    });
+
+    it('updateGroupEpic PUTs body', async () => {
+      const epic: GlEpic = {
+        id: 2,
+        iid: 2,
+        group_id: 10,
+        title: 'updated',
+        description: null,
+        state: 'closed',
+        labels: [],
+        created_at: '2026-01-01T00:00:00Z',
+        updated_at: '2026-02-01T00:00:00Z',
+      };
+      mockFetch.mockResolvedValueOnce(jsonResponse(epic));
+
+      const client = new GitLabClient('tok');
+      const result = await client.updateGroupEpic(10, 2, {
+        state_event: 'close',
+      });
+      expect(result.state).toBe('closed');
+      const [, init] = mockFetch.mock.calls[0];
+      expect(init.method).toBe('PUT');
+    });
+
+    it('listEpicIssues returns [] on error', async () => {
+      mockFetch.mockResolvedValueOnce(
+        new Response('forbidden', { status: 403 }),
+      );
+      const client = new GitLabClient('tok');
+      const result = await client.listEpicIssues(10, 1);
+      expect(result).toEqual([]);
+    });
+
+    it('listEpicIssues returns issues on success', async () => {
+      mockFetch.mockResolvedValueOnce(jsonResponse([]));
+      const client = new GitLabClient('tok');
+      const result = await client.listEpicIssues(10, 1);
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe('listLabels', () => {
+    it('paginates labels', async () => {
+      mockFetch.mockResolvedValueOnce(jsonResponse([{ id: 1, name: 'bug' }]));
+      const client = new GitLabClient('tok');
+      const result = await client.listLabels(1);
+      expect(result).toHaveLength(1);
+    });
+  });
+
+  describe('paginate params', () => {
+    it('skips undefined params', async () => {
+      mockFetch.mockResolvedValueOnce(jsonResponse([]));
+      const client = new GitLabClient('tok');
+      await client.listIssues(1);
+      const [url] = mockFetch.mock.calls[0];
+      // state=all sort=asc order_by=created_at — no undefined keys
+      expect(url).not.toContain('undefined');
+    });
+  });
+
+  describe('retry behavior', () => {
+    it('retries after 429 using Retry-After', async () => {
+      const retryResp = new Response('rate limited', {
+        status: 429,
+        headers: { 'Retry-After': '0' },
+      });
+      mockFetch
+        .mockResolvedValueOnce(retryResp)
+        .mockResolvedValueOnce(jsonResponse([]));
+
+      const client = new GitLabClient('tok');
+      const result = await client.listLabels(1);
+      expect(result).toEqual([]);
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+    });
+
+    it('retries on 5xx then succeeds', async () => {
+      mockFetch
+        .mockResolvedValueOnce(new Response('err', { status: 500 }))
+        .mockResolvedValueOnce(jsonResponse([]));
+
+      const client = new GitLabClient('tok');
+      const result = await client.listLabels(1);
+      expect(result).toEqual([]);
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+    });
+
+    it('throws after 3 consecutive 5xx failures', async () => {
+      mockFetch.mockResolvedValue(new Response('err', { status: 500 }));
+
+      const client = new GitLabClient('tok');
+      await expect(client.listLabels(1)).rejects.toThrow(
+        /GitLab API error 500/,
+      );
+      expect(mockFetch).toHaveBeenCalledTimes(3);
+    }, 20000);
+
+    it('throws on 4xx non-handled (e.g. 400)', async () => {
+      mockFetch.mockResolvedValueOnce(
+        new Response('bad request', { status: 400 }),
+      );
+
+      const client = new GitLabClient('tok');
+      await expect(client.listLabels(1)).rejects.toThrow(
+        /GitLab API error 400/,
+      );
+    });
+
+    it('warns when remaining rate limit is low', async () => {
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      mockFetch.mockResolvedValueOnce(
+        jsonResponse([], { headers: { 'RateLimit-Remaining': '5' } }),
+      );
+
+      const client = new GitLabClient('tok');
+      await client.listLabels(1);
+      expect(warn).toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/sync-gitlab/src/__tests__/coverage-gaps.test.ts
+++ b/packages/sync-gitlab/src/__tests__/coverage-gaps.test.ts
@@ -1,0 +1,236 @@
+import { writeFile as fsWriteFile, mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { Epic, Prd, Story } from '@gitpm/core';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import type { GlIssue } from '../client.js';
+import { saveConfig } from '../config.js';
+import type { LinkContext } from '../linker.js';
+import { resolveEpicLink } from '../linker.js';
+import { computeContentHash, createInitialState, saveState } from '../state.js';
+import type { SyncState } from '../types.js';
+
+let metaDir: string;
+
+beforeEach(async () => {
+  metaDir = await mkdtemp(join(tmpdir(), 'gitpm-gaps-'));
+});
+
+afterEach(async () => {
+  await rm(metaDir, { recursive: true });
+});
+
+describe('config.saveConfig error path', () => {
+  it('returns error when path is unwritable', async () => {
+    // Pass a metaDir with an invalid nested path — use a file-as-directory trick:
+    const filePath = join(metaDir, 'blocker');
+    await fsWriteFile(filePath, '', 'utf-8');
+    // metaDir/blocker is a file; sync would be blocker/sync/gitlab-config.yaml
+    const result = await saveConfig(join(filePath, 'inner'), {
+      project: 'ns/p',
+      project_id: 1,
+      base_url: 'https://gitlab.com',
+      status_mapping: {},
+      label_mapping: { epic_labels: [] },
+      auto_sync: false,
+    });
+    expect(result.ok).toBe(false);
+  });
+});
+
+describe('state error paths and branches', () => {
+  it('saveState returns error when path invalid', async () => {
+    const filePath = join(metaDir, 'blocker');
+    await fsWriteFile(filePath, '', 'utf-8');
+
+    const result = await saveState(join(filePath, 'inner'), {
+      project: 'ns/p',
+      last_sync: '2026-01-01T00:00:00Z',
+      entities: {},
+    } satisfies SyncState);
+    expect(result.ok).toBe(false);
+  });
+
+  it('computeContentHash covers prd branch', () => {
+    const prd: Prd = {
+      type: 'prd',
+      id: 'p1',
+      title: 'PRD',
+      status: 'in_progress',
+      body: 'content\r\ntrailing  \n',
+      filePath: '.meta/prds/p1.md',
+    } as Prd;
+    const hash = computeContentHash(prd);
+    expect(hash).toMatch(/^sha256:/);
+  });
+
+  it('createInitialState records gitlab_epic_iid for epics with epic_iid', () => {
+    const epic: Epic = {
+      type: 'epic',
+      id: 'e1',
+      title: 'Epic',
+      status: 'todo',
+      priority: 'medium',
+      owner: null,
+      labels: [],
+      milestone_ref: null,
+      body: '',
+      filePath: '.meta/epics/e1/epic.md',
+      gitlab: {
+        issue_iid: 10,
+        epic_iid: 5,
+        project_id: 42,
+        base_url: 'https://gitlab.com',
+        last_sync_hash: '',
+        synced_at: '2026-01-01T00:00:00Z',
+      },
+    } as Epic;
+
+    const state = createInitialState('ns/p', [epic], 42);
+    expect(state.entities.e1.gitlab_epic_iid).toBe(5);
+    expect(state.entities.e1.gitlab_issue_iid).toBe(10);
+  });
+
+  it('createInitialState skips entities without id', () => {
+    const state = createInitialState(
+      'ns/p',
+      [{ type: 'sprint', id: '', title: 'x' } as never],
+      undefined,
+    );
+    expect(Object.keys(state.entities)).toHaveLength(0);
+  });
+});
+
+describe('linker edge cases', () => {
+  function mkEpic(id: string, title: string): Epic {
+    return {
+      type: 'epic',
+      id,
+      title,
+      status: 'todo',
+      priority: 'medium',
+      owner: null,
+      labels: [],
+      milestone_ref: null,
+      body: '',
+      filePath: '',
+    };
+  }
+
+  function mkStory(id: string, title: string): Story {
+    return {
+      type: 'story',
+      id,
+      title,
+      status: 'todo',
+      priority: 'medium',
+      assignee: null,
+      labels: [],
+      estimate: null,
+      epic_ref: null,
+      body: '',
+      filePath: '',
+    };
+  }
+
+  function mkIssue(overrides: Partial<GlIssue> & { iid: number }): GlIssue {
+    return {
+      id: overrides.iid,
+      iid: overrides.iid,
+      title: 'i',
+      description: null,
+      state: 'opened',
+      assignee: null,
+      labels: [],
+      milestone: null,
+      weight: null,
+      epic_iid: null,
+      created_at: '2026-01-01T00:00:00Z',
+      updated_at: '2026-01-01T00:00:00Z',
+      ...overrides,
+    };
+  }
+
+  it('returns null for unknown strategy (default case)', () => {
+    const storyIssue = mkIssue({ iid: 1 });
+    const ctx: LinkContext = {
+      glIssues: [storyIssue],
+      issueIidToEntity: new Map(),
+      epicIssueIidToEpic: new Map(),
+      nativeEpicIssueIids: new Map(),
+    };
+    const result = resolveEpicLink(
+      storyIssue,
+      mkStory('s1', 'S'),
+      ctx,
+      'bogus' as never,
+    );
+    expect(result).toBeNull();
+  });
+
+  it('native-epics strategy links via epic_iid on the issue', () => {
+    const epic = mkEpic('e1', 'Epic One');
+    const epicEntityWithEpicIid: Epic = {
+      ...epic,
+      gitlab: {
+        epic_iid: 7,
+        project_id: 42,
+        base_url: 'https://gitlab.com',
+        last_sync_hash: '',
+        synced_at: '2026-01-01T00:00:00Z',
+      },
+    };
+    const story = mkStory('s1', 'S');
+    const storyIssue = mkIssue({ iid: 100, epic_iid: 7 });
+
+    const ctx: LinkContext = {
+      glIssues: [storyIssue],
+      issueIidToEntity: new Map([
+        [100, story],
+        [200, epicEntityWithEpicIid],
+      ]),
+      epicIssueIidToEpic: new Map(),
+      nativeEpicIssueIids: new Map(),
+    };
+    const result = resolveEpicLink(storyIssue, story, ctx, 'native-epics');
+    expect(result).not.toBeNull();
+    expect(result?.epicRef.id).toBe('e1');
+    expect(result?.parentEpicSlug).toBe('epic-one');
+  });
+
+  it('milestone strategy returns null when no epic shares the milestone', () => {
+    const story = mkStory('s1', 'S');
+    const storyIssue = mkIssue({
+      iid: 10,
+      milestone: { id: 99, iid: 1, title: 'x' },
+    });
+    const ctx: LinkContext = {
+      glIssues: [storyIssue],
+      issueIidToEntity: new Map([[10, story]]),
+      epicIssueIidToEpic: new Map(),
+      nativeEpicIssueIids: new Map(),
+    };
+    const result = resolveEpicLink(storyIssue, story, ctx, 'milestone');
+    expect(result).toBeNull();
+  });
+
+  it('labels strategy returns null when no shared labels', () => {
+    const epic = mkEpic('e1', 'Epic');
+    const epicIssue = mkIssue({ iid: 1, labels: ['epic', 'auth'] });
+    const storyIssue = mkIssue({ iid: 2, labels: ['ui'] });
+    const ctx: LinkContext = {
+      glIssues: [epicIssue, storyIssue],
+      issueIidToEntity: new Map([[2, mkStory('s', 'S')]]),
+      epicIssueIidToEpic: new Map([[1, epic]]),
+      nativeEpicIssueIids: new Map(),
+    };
+    const result = resolveEpicLink(
+      storyIssue,
+      mkStory('s', 'S'),
+      ctx,
+      'labels',
+    );
+    expect(result).toBeNull();
+  });
+});

--- a/packages/sync-gitlab/src/__tests__/diff.test.ts
+++ b/packages/sync-gitlab/src/__tests__/diff.test.ts
@@ -1,8 +1,9 @@
-import type { Story } from '@gitpm/core';
+import type { Epic, Milestone, Prd, Story } from '@gitpm/core';
 import { describe, expect, it } from 'vitest';
 import type { GlIssue, GlMilestone } from '../client.js';
 import {
   diffByHash,
+  diffEntity,
   remoteIssueFields,
   remoteMilestoneFields,
 } from '../diff.js';
@@ -176,5 +177,255 @@ describe('computeContentHash', () => {
     };
 
     expect(computeContentHash(story1)).not.toBe(computeContentHash(story2));
+  });
+});
+
+function makeStory(overrides?: Partial<Story>): Story {
+  return {
+    type: 'story',
+    id: 's1',
+    title: 'Story',
+    status: 'todo',
+    priority: 'medium',
+    assignee: null,
+    labels: [],
+    estimate: null,
+    epic_ref: null,
+    body: '',
+    filePath: '.meta/stories/s1.md',
+    ...overrides,
+  } as Story;
+}
+
+function makeEpic(overrides?: Partial<Epic>): Epic {
+  return {
+    type: 'epic',
+    id: 'e1',
+    title: 'Epic',
+    status: 'todo',
+    priority: 'medium',
+    owner: null,
+    labels: [],
+    milestone_ref: null,
+    body: '',
+    filePath: '.meta/epics/e1/epic.md',
+    ...overrides,
+  } as Epic;
+}
+
+function makeMilestone(overrides?: Partial<Milestone>): Milestone {
+  return {
+    type: 'milestone',
+    id: 'm1',
+    title: 'Milestone',
+    status: 'in_progress',
+    body: '',
+    filePath: '.meta/roadmap/milestones/m1.md',
+    ...overrides,
+  } as Milestone;
+}
+
+describe('diffEntity', () => {
+  it('detects in_sync when nothing changed', () => {
+    const story = makeStory({ title: 'Base', body: 'hi' });
+    const baseline = {
+      title: 'Base',
+      status: 'todo',
+      priority: 'medium',
+      assignee: null,
+      labels: [],
+      body: 'hi',
+    };
+    const remote = { ...baseline };
+    const result = diffEntity(story, remote, baseline, baseline);
+    expect(result.status).toBe('in_sync');
+    expect(result.conflicts).toEqual([]);
+    expect(result.localChanges).toEqual([]);
+    expect(result.remoteChanges).toEqual([]);
+  });
+
+  it('detects local_changed only', () => {
+    const story = makeStory({ title: 'Changed', body: 'hi' });
+    const baselineLocal = {
+      title: 'Base',
+      status: 'todo',
+      priority: 'medium',
+      assignee: null,
+      labels: [],
+      body: 'hi',
+    };
+    const baselineRemote = { ...baselineLocal };
+    const result = diffEntity(
+      story,
+      baselineRemote,
+      baselineLocal,
+      baselineRemote,
+    );
+    expect(result.status).toBe('local_changed');
+    expect(result.localChanges.some((c) => c.field === 'title')).toBe(true);
+  });
+
+  it('detects remote_changed only', () => {
+    const story = makeStory({ title: 'Base' });
+    const baselineLocal = {
+      title: 'Base',
+      status: 'todo',
+      priority: 'medium',
+      assignee: null,
+      labels: [],
+      body: '',
+    };
+    const newRemote = { ...baselineLocal, title: 'Remote Changed' };
+    const result = diffEntity(story, newRemote, baselineLocal, baselineLocal);
+    expect(result.status).toBe('remote_changed');
+    expect(result.remoteChanges.some((c) => c.field === 'title')).toBe(true);
+  });
+
+  it('detects conflict when local and remote change same field to different values', () => {
+    const story = makeStory({ title: 'Local New' });
+    const baselineLocal = {
+      title: 'Base',
+      status: 'todo',
+      priority: 'medium',
+      assignee: null,
+      labels: [],
+      body: '',
+    };
+    const newRemote = { ...baselineLocal, title: 'Remote New' };
+    const result = diffEntity(story, newRemote, baselineLocal, baselineLocal);
+    expect(result.status).toBe('conflict');
+    expect(result.conflicts).toHaveLength(1);
+    expect(result.conflicts[0].field).toBe('title');
+    expect(result.conflicts[0].localValue).toBe('Local New');
+    expect(result.conflicts[0].remoteValue).toBe('Remote New');
+  });
+
+  it('does not conflict when both sides change same field to same value', () => {
+    const story = makeStory({ title: 'Same New' });
+    const baselineLocal = {
+      title: 'Base',
+      status: 'todo',
+      priority: 'medium',
+      assignee: null,
+      labels: [],
+      body: '',
+    };
+    const newRemote = { ...baselineLocal, title: 'Same New' };
+    const result = diffEntity(story, newRemote, baselineLocal, baselineLocal);
+    // fields changed, but to same value → no conflict, both show as changes
+    expect(result.conflicts).toHaveLength(0);
+  });
+
+  it('handles epic entities', () => {
+    const epic = makeEpic({ owner: 'alice' });
+    const baselineLocal = {
+      title: 'Epic',
+      status: 'todo',
+      priority: 'medium',
+      owner: null,
+      labels: [],
+      body: '',
+    };
+    const result = diffEntity(
+      epic,
+      baselineLocal,
+      baselineLocal,
+      baselineLocal,
+    );
+    expect(result.status).toBe('local_changed');
+    expect(result.localChanges.some((c) => c.field === 'owner')).toBe(true);
+  });
+
+  it('handles milestone entities', () => {
+    const ms = makeMilestone({ target_date: '2026-06-30' });
+    const baselineLocal = {
+      title: 'Milestone',
+      status: 'in_progress',
+      target_date: null,
+      body: '',
+    };
+    const result = diffEntity(ms, baselineLocal, baselineLocal, baselineLocal);
+    expect(result.status).toBe('local_changed');
+    expect(result.localChanges.some((c) => c.field === 'target_date')).toBe(
+      true,
+    );
+  });
+
+  it('falls through to title-only for non-story/epic/milestone entities', () => {
+    const prd: Prd = {
+      type: 'prd',
+      id: 'p1',
+      title: 'Prd',
+      status: 'in_progress',
+      body: '',
+      filePath: '.meta/prds/p1.md',
+    } as Prd;
+    const baseline = { title: 'Prd' };
+    const result = diffEntity(prd, baseline, baseline, baseline);
+    expect(result.status).toBe('in_sync');
+  });
+
+  it('treats equal trimmed strings as equal (whitespace tolerance)', () => {
+    const story = makeStory({ body: '  hello  ' });
+    const baselineLocal = {
+      title: 'Story',
+      status: 'todo',
+      priority: 'medium',
+      assignee: null,
+      labels: [],
+      body: 'hello',
+    };
+    const result = diffEntity(
+      story,
+      baselineLocal,
+      baselineLocal,
+      baselineLocal,
+    );
+    // body compared with whitespace-trim — should be equal
+    expect(result.localChanges.find((c) => c.field === 'body')).toBeUndefined();
+  });
+
+  it('treats arrays element-wise', () => {
+    const story = makeStory({ labels: ['a', 'b'] });
+    const baseline = {
+      title: 'Story',
+      status: 'todo',
+      priority: 'medium',
+      assignee: null,
+      labels: ['a', 'b'],
+      body: '',
+    };
+    const result = diffEntity(story, baseline, baseline, baseline);
+    expect(result.status).toBe('in_sync');
+  });
+
+  it('treats arrays of different lengths as different', () => {
+    const story = makeStory({ labels: ['a'] });
+    const baseline = {
+      title: 'Story',
+      status: 'todo',
+      priority: 'medium',
+      assignee: null,
+      labels: ['a', 'b'],
+      body: '',
+    };
+    const result = diffEntity(story, baseline, baseline, baseline);
+    expect(result.localChanges.find((c) => c.field === 'labels')).toBeDefined();
+  });
+
+  it('treats null and undefined as equal', () => {
+    const story = makeStory({ assignee: null });
+    const baseline = {
+      title: 'Story',
+      status: 'todo',
+      priority: 'medium',
+      assignee: undefined,
+      labels: [],
+      body: '',
+    };
+    const result = diffEntity(story, baseline, baseline, baseline);
+    expect(
+      result.localChanges.find((c) => c.field === 'assignee'),
+    ).toBeUndefined();
   });
 });

--- a/packages/sync-gitlab/src/__tests__/export.test.ts
+++ b/packages/sync-gitlab/src/__tests__/export.test.ts
@@ -1,0 +1,585 @@
+import { mkdir, mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { Epic, Milestone, Roadmap, Story } from '@gitpm/core';
+import { writeFile } from '@gitpm/core';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { GlIssue, GlMilestone } from '../client.js';
+import { saveConfig } from '../config.js';
+import { exportToGitLab } from '../export.js';
+import { computeContentHash, saveState } from '../state.js';
+import type { SyncState } from '../types.js';
+
+interface FakeClient {
+  createMilestone: ReturnType<typeof vi.fn>;
+  updateMilestone: ReturnType<typeof vi.fn>;
+  createIssue: ReturnType<typeof vi.fn>;
+  updateIssue: ReturnType<typeof vi.fn>;
+}
+
+const fake: FakeClient = {
+  createMilestone: vi.fn(),
+  updateMilestone: vi.fn(),
+  createIssue: vi.fn(),
+  updateIssue: vi.fn(),
+};
+
+vi.mock('../client.js', () => ({
+  GitLabClient: vi.fn().mockImplementation(function () {
+    return fake;
+  }),
+}));
+
+let metaDir: string;
+
+beforeEach(async () => {
+  metaDir = await mkdtemp(join(tmpdir(), 'gitpm-export-'));
+  fake.createMilestone.mockReset();
+  fake.updateMilestone.mockReset();
+  fake.createIssue.mockReset();
+  fake.updateIssue.mockReset();
+});
+
+afterEach(async () => {
+  await rm(metaDir, { recursive: true });
+});
+
+async function writeMeta(entity: {
+  filePath: string;
+  [k: string]: unknown;
+}): Promise<void> {
+  const resolved = join(metaDir, entity.filePath.replace(/^\.meta\//, ''));
+  await mkdir(join(resolved, '..'), { recursive: true });
+  const result = await writeFile(entity as never, resolved);
+  if (!result.ok) throw result.error;
+}
+
+function makeRoadmap(milestones: { id: string }[] = []): Roadmap {
+  return {
+    type: 'roadmap',
+    id: 'r1',
+    title: 'Roadmap',
+    description: '',
+    milestones,
+    updated_at: '2026-01-01T00:00:00Z',
+    filePath: '.meta/roadmap/roadmap.yaml',
+  };
+}
+
+function makeMilestone(id: string, overrides?: Partial<Milestone>): Milestone {
+  return {
+    type: 'milestone',
+    id,
+    title: `Milestone ${id}`,
+    status: 'in_progress',
+    body: 'desc',
+    target_date: '2026-06-30',
+    filePath: `.meta/roadmap/milestones/${id}.md`,
+    ...overrides,
+  } as Milestone;
+}
+
+function makeEpic(id: string, overrides?: Partial<Epic>): Epic {
+  return {
+    type: 'epic',
+    id,
+    title: `Epic ${id}`,
+    status: 'todo',
+    priority: 'medium',
+    owner: null,
+    labels: [],
+    milestone_ref: null,
+    body: 'epic body',
+    filePath: `.meta/epics/${id}/epic.md`,
+    ...overrides,
+  } as Epic;
+}
+
+function makeStory(id: string, overrides?: Partial<Story>): Story {
+  return {
+    type: 'story',
+    id,
+    title: `Story ${id}`,
+    status: 'todo',
+    priority: 'medium',
+    assignee: null,
+    labels: [],
+    estimate: null,
+    epic_ref: null,
+    body: 'story body',
+    filePath: `.meta/stories/${id}.md`,
+    ...overrides,
+  } as Story;
+}
+
+async function seedConfig(): Promise<void> {
+  await saveConfig(metaDir, {
+    project: 'ns/proj',
+    project_id: 42,
+    base_url: 'https://gitlab.com',
+    status_mapping: {},
+    label_mapping: { epic_labels: ['epic'] },
+    auto_sync: false,
+  });
+}
+
+function makeGlMilestone(overrides: Partial<GlMilestone>): GlMilestone {
+  return {
+    id: 1,
+    iid: 1,
+    title: 't',
+    description: null,
+    state: 'active',
+    due_date: null,
+    created_at: '2026-01-01T00:00:00Z',
+    updated_at: '2026-01-01T00:00:00Z',
+    ...overrides,
+  };
+}
+
+function makeGlIssue(overrides: Partial<GlIssue>): GlIssue {
+  return {
+    id: 1,
+    iid: 1,
+    title: 't',
+    description: null,
+    state: 'opened',
+    assignee: null,
+    labels: [],
+    milestone: null,
+    weight: null,
+    epic_iid: null,
+    created_at: '2026-01-01T00:00:00Z',
+    updated_at: '2026-01-01T00:00:00Z',
+    ...overrides,
+  };
+}
+
+describe('exportToGitLab', () => {
+  it('errors when config missing', async () => {
+    const result = await exportToGitLab({
+      token: 'tok',
+      project: 'ns/proj',
+      metaDir,
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok)
+      expect(result.error.message).toMatch(/No GitLab config found/);
+  });
+
+  it('creates milestones, epics, and stories on first run', async () => {
+    await seedConfig();
+    const ms = makeMilestone('m1');
+    const epic = makeEpic('e1', { milestone_ref: { id: 'm1' } });
+    const story = makeStory('s1');
+    await writeMeta(makeRoadmap([{ id: 'm1' }]));
+    await writeMeta(ms);
+    await writeMeta(epic);
+    await writeMeta(story);
+
+    fake.createMilestone.mockImplementation(async () =>
+      makeGlMilestone({ id: 101 }),
+    );
+    let issueCounter = 10;
+    fake.createIssue.mockImplementation(async () =>
+      makeGlIssue({ id: issueCounter, iid: issueCounter++ }),
+    );
+    fake.updateIssue.mockImplementation(async () => makeGlIssue({}));
+
+    const result = await exportToGitLab({
+      token: 'tok',
+      project: 'ns/proj',
+      metaDir,
+    });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.created.milestones).toBe(1);
+    expect(result.value.created.issues).toBe(2);
+    expect(fake.createMilestone).toHaveBeenCalledTimes(1);
+    expect(fake.createIssue).toHaveBeenCalledTimes(2);
+  });
+
+  it('dryRun does not call client mutation APIs', async () => {
+    await seedConfig();
+    const ms = makeMilestone('m1');
+    await writeMeta(makeRoadmap([{ id: 'm1' }]));
+    await writeMeta(ms);
+
+    const result = await exportToGitLab({
+      token: 'tok',
+      project: 'ns/proj',
+      metaDir,
+      dryRun: true,
+    });
+    expect(result.ok).toBe(true);
+    expect(fake.createMilestone).not.toHaveBeenCalled();
+  });
+
+  it('closes issue after creation when status is done', async () => {
+    await seedConfig();
+    const doneStory = makeStory('s1', { status: 'done' });
+    await writeMeta(makeRoadmap());
+    await writeMeta(doneStory);
+
+    fake.createIssue.mockResolvedValueOnce(makeGlIssue({ iid: 5 }));
+    fake.updateIssue.mockResolvedValueOnce(makeGlIssue({ iid: 5 }));
+
+    const result = await exportToGitLab({
+      token: 'tok',
+      project: 'ns/proj',
+      metaDir,
+    });
+    expect(result.ok).toBe(true);
+    expect(fake.createIssue).toHaveBeenCalledTimes(1);
+    expect(fake.updateIssue).toHaveBeenCalledWith(
+      42,
+      5,
+      expect.objectContaining({ state_event: 'close' }),
+    );
+  });
+
+  it('updates entities whose local hash changed', async () => {
+    await seedConfig();
+    const ms = makeMilestone('m1', {
+      gitlab: {
+        milestone_id: 101,
+        project_id: 42,
+        base_url: 'https://gitlab.com',
+        last_sync_hash: 'sha256:old',
+        synced_at: '2026-01-01T00:00:00Z',
+      },
+    });
+    await writeMeta(makeRoadmap([{ id: 'm1' }]));
+    await writeMeta(ms);
+
+    const state: SyncState = {
+      project: 'ns/proj',
+      project_id: 42,
+      last_sync: '2026-01-01T00:00:00Z',
+      entities: {
+        m1: {
+          gitlab_milestone_id: 101,
+          local_hash: 'sha256:different', // differs from computed → updates
+          remote_hash: 'sha256:different',
+          synced_at: '2026-01-01T00:00:00Z',
+        },
+      },
+    };
+    await saveState(metaDir, state);
+
+    fake.updateMilestone.mockResolvedValueOnce(makeGlMilestone({ id: 101 }));
+
+    const result = await exportToGitLab({
+      token: 'tok',
+      project: 'ns/proj',
+      metaDir,
+    });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.updated.milestones).toBe(1);
+    expect(fake.updateMilestone).toHaveBeenCalled();
+  });
+
+  it('does not update when local hash matches state', async () => {
+    await seedConfig();
+    const ms = makeMilestone('m1', {
+      gitlab: {
+        milestone_id: 101,
+        project_id: 42,
+        base_url: 'https://gitlab.com',
+        last_sync_hash: 'sha256:old',
+        synced_at: '2026-01-01T00:00:00Z',
+      },
+    });
+    await writeMeta(makeRoadmap([{ id: 'm1' }]));
+    await writeMeta(ms);
+
+    // Compute hash from what parseTree actually reads back from disk
+    const { parseTree } = await import('@gitpm/core');
+    const parsed = await parseTree(metaDir);
+    if (!parsed.ok) throw parsed.error;
+    const matchedHash = computeContentHash(parsed.value.milestones[0]);
+
+    await saveState(metaDir, {
+      project: 'ns/proj',
+      project_id: 42,
+      last_sync: '2026-01-01T00:00:00Z',
+      entities: {
+        m1: {
+          gitlab_milestone_id: 101,
+          local_hash: matchedHash,
+          remote_hash: matchedHash,
+          synced_at: '2026-01-01T00:00:00Z',
+        },
+      },
+    });
+
+    const result = await exportToGitLab({
+      token: 'tok',
+      project: 'ns/proj',
+      metaDir,
+    });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.updated.milestones).toBe(0);
+    expect(fake.updateMilestone).not.toHaveBeenCalled();
+  });
+
+  it('closes remote issues for locally deleted entities', async () => {
+    await seedConfig();
+    // Nothing on disk except roadmap
+    await writeMeta(makeRoadmap());
+
+    await saveState(metaDir, {
+      project: 'ns/proj',
+      project_id: 42,
+      last_sync: '2026-01-01T00:00:00Z',
+      entities: {
+        removed: {
+          gitlab_issue_iid: 7,
+          local_hash: 'sha256:x',
+          remote_hash: 'sha256:x',
+          synced_at: '2026-01-01T00:00:00Z',
+        },
+        'removed-ms': {
+          gitlab_milestone_id: 8,
+          local_hash: 'sha256:y',
+          remote_hash: 'sha256:y',
+          synced_at: '2026-01-01T00:00:00Z',
+        },
+      },
+    });
+
+    fake.updateIssue.mockResolvedValue(
+      makeGlIssue({ iid: 7, state: 'closed' }),
+    );
+    fake.updateMilestone.mockResolvedValue(
+      makeGlMilestone({ id: 8, state: 'closed' }),
+    );
+
+    const result = await exportToGitLab({
+      token: 'tok',
+      project: 'ns/proj',
+      metaDir,
+    });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(fake.updateIssue).toHaveBeenCalledWith(
+      42,
+      7,
+      expect.objectContaining({ state_event: 'close' }),
+    );
+    expect(fake.updateMilestone).toHaveBeenCalledWith(
+      42,
+      8,
+      expect.objectContaining({ state_event: 'close' }),
+    );
+    expect(result.value.totalChanges).toBeGreaterThanOrEqual(2);
+  });
+
+  it('resolves epic milestone_ref via state-tracked milestone', async () => {
+    await seedConfig();
+    const ms = makeMilestone('m1');
+    const epic = makeEpic('e1', { milestone_ref: { id: 'm1' } });
+    await writeMeta(makeRoadmap([{ id: 'm1' }]));
+    await writeMeta(ms);
+    await writeMeta(epic);
+
+    await saveState(metaDir, {
+      project: 'ns/proj',
+      project_id: 42,
+      last_sync: '2026-01-01T00:00:00Z',
+      entities: {
+        m1: {
+          gitlab_milestone_id: 101,
+          local_hash: computeContentHash(ms),
+          remote_hash: computeContentHash(ms),
+          synced_at: '2026-01-01T00:00:00Z',
+        },
+      },
+    });
+
+    fake.createIssue.mockResolvedValueOnce(makeGlIssue({ iid: 20 }));
+
+    const result = await exportToGitLab({
+      token: 'tok',
+      project: 'ns/proj',
+      metaDir,
+    });
+    expect(result.ok).toBe(true);
+    expect(fake.createIssue).toHaveBeenCalledWith(
+      42,
+      expect.objectContaining({ milestone_id: 101 }),
+    );
+  });
+
+  it('updates existing issue when hash changed', async () => {
+    await seedConfig();
+    const story = makeStory('s1', {
+      gitlab: {
+        issue_iid: 50,
+        project_id: 42,
+        base_url: 'https://gitlab.com',
+        last_sync_hash: 'sha256:old',
+        synced_at: '2026-01-01T00:00:00Z',
+      },
+    });
+    await writeMeta(makeRoadmap());
+    await writeMeta(story);
+
+    await saveState(metaDir, {
+      project: 'ns/proj',
+      project_id: 42,
+      last_sync: '2026-01-01T00:00:00Z',
+      entities: {
+        s1: {
+          gitlab_issue_iid: 50,
+          local_hash: 'sha256:diff',
+          remote_hash: 'sha256:diff',
+          synced_at: '2026-01-01T00:00:00Z',
+        },
+      },
+    });
+
+    fake.updateIssue.mockResolvedValueOnce(makeGlIssue({ iid: 50 }));
+
+    const result = await exportToGitLab({
+      token: 'tok',
+      project: 'ns/proj',
+      metaDir,
+    });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.updated.issues).toBe(1);
+    expect(fake.updateIssue).toHaveBeenCalled();
+  });
+
+  it('returns error Result when client throws', async () => {
+    await seedConfig();
+    await writeMeta(makeRoadmap());
+    await writeMeta(makeStory('s1'));
+
+    fake.createIssue.mockRejectedValueOnce(new Error('GitLab down'));
+
+    const result = await exportToGitLab({
+      token: 'tok',
+      project: 'ns/proj',
+      metaDir,
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error.message).toMatch(/GitLab down/);
+  });
+
+  it('updates epic with milestone_id resolved via state-tracked milestone', async () => {
+    await seedConfig();
+    const ms = makeMilestone('m1');
+    const epic = makeEpic('e1', {
+      milestone_ref: { id: 'm1' },
+      gitlab: {
+        issue_iid: 20,
+        project_id: 42,
+        base_url: 'https://gitlab.com',
+        last_sync_hash: 'sha256:old',
+        synced_at: '2026-01-01T00:00:00Z',
+      },
+    });
+    await writeMeta(makeRoadmap([{ id: 'm1' }]));
+    await writeMeta(ms);
+    await writeMeta(epic);
+
+    const { parseTree } = await import('@gitpm/core');
+    const parsed = await parseTree(metaDir);
+    if (!parsed.ok) throw parsed.error;
+    const msHash = computeContentHash(parsed.value.milestones[0]);
+
+    await saveState(metaDir, {
+      project: 'ns/proj',
+      project_id: 42,
+      last_sync: '2026-01-01T00:00:00Z',
+      entities: {
+        m1: {
+          gitlab_milestone_id: 101,
+          local_hash: msHash,
+          remote_hash: msHash,
+          synced_at: '2026-01-01T00:00:00Z',
+        },
+        e1: {
+          gitlab_issue_iid: 20,
+          local_hash: 'sha256:diff',
+          remote_hash: 'sha256:diff',
+          synced_at: '2026-01-01T00:00:00Z',
+        },
+      },
+    });
+
+    fake.updateIssue.mockResolvedValueOnce(makeGlIssue({ iid: 20 }));
+
+    const result = await exportToGitLab({
+      token: 'tok',
+      project: 'ns/proj',
+      metaDir,
+    });
+    expect(result.ok).toBe(true);
+    expect(fake.updateIssue).toHaveBeenCalledWith(
+      42,
+      20,
+      expect.objectContaining({ milestone_id: 101 }),
+    );
+  });
+
+  it('respects PRDs in tree (does not close PRDs)', async () => {
+    await seedConfig();
+    const prd = {
+      type: 'prd' as const,
+      id: 'p1',
+      title: 'PRD Document',
+      status: 'in_progress' as const,
+      body: '',
+      filePath: '.meta/prds/p1.md',
+    };
+    await writeMeta(makeRoadmap());
+    await writeMeta(prd);
+
+    await saveState(metaDir, {
+      project: 'ns/proj',
+      project_id: 42,
+      last_sync: '2026-01-01T00:00:00Z',
+      entities: {
+        p1: {
+          gitlab_issue_iid: 99,
+          local_hash: 'sha256:x',
+          remote_hash: 'sha256:x',
+          synced_at: '2026-01-01T00:00:00Z',
+        },
+      },
+    });
+
+    const result = await exportToGitLab({
+      token: 'tok',
+      project: 'ns/proj',
+      metaDir,
+    });
+    expect(result.ok).toBe(true);
+    // PRD id is in tree.prds.map(p=>p.id), so it's not a "deleted" entity,
+    // and no issue close should fire
+    expect(fake.updateIssue).not.toHaveBeenCalled();
+  });
+
+  it('uses baseUrl and projectId overrides from options', async () => {
+    await seedConfig();
+    await writeMeta(makeRoadmap());
+    await writeMeta(makeStory('s1'));
+
+    fake.createIssue.mockResolvedValueOnce(makeGlIssue({ iid: 1 }));
+
+    await exportToGitLab({
+      token: 'tok',
+      project: 'ns/proj',
+      metaDir,
+      projectId: 999,
+      baseUrl: 'https://gl.example.com',
+    });
+    expect(fake.createIssue).toHaveBeenCalledWith(999, expect.any(Object));
+  });
+});

--- a/packages/sync-gitlab/src/__tests__/import.test.ts
+++ b/packages/sync-gitlab/src/__tests__/import.test.ts
@@ -7,21 +7,22 @@ import issueFixtures from '../__fixtures__/gitlab-issues.json';
 import milestoneFixtures from '../__fixtures__/gitlab-milestones.json';
 import { importFromGitLab } from '../import.js';
 
+const getProject = vi.fn();
+const listMilestones = vi.fn();
+const listIssues = vi.fn();
+const listGroupEpics = vi.fn();
+const listEpicIssues = vi.fn();
+
 // Mock GitLabClient
 vi.mock('../client.js', () => {
   return {
     GitLabClient: vi.fn().mockImplementation(function () {
       return {
-        getProject: vi.fn().mockResolvedValue({
-          id: 42,
-          name: 'test-project',
-          path_with_namespace: 'test-ns/test-project',
-          namespace: { id: 10, kind: 'group', full_path: 'test-ns' },
-        }),
-        listMilestones: vi.fn().mockResolvedValue(milestoneFixtures),
-        listIssues: vi.fn().mockResolvedValue(issueFixtures),
-        listGroupEpics: vi.fn().mockResolvedValue([]),
-        listEpicIssues: vi.fn().mockResolvedValue([]),
+        getProject,
+        listMilestones,
+        listIssues,
+        listGroupEpics,
+        listEpicIssues,
       };
     }),
   };
@@ -32,6 +33,22 @@ describe('importFromGitLab', () => {
 
   beforeEach(async () => {
     metaDir = await mkdtemp(join(tmpdir(), 'gitpm-import-'));
+    getProject.mockReset();
+    listMilestones.mockReset();
+    listIssues.mockReset();
+    listGroupEpics.mockReset();
+    listEpicIssues.mockReset();
+
+    getProject.mockResolvedValue({
+      id: 42,
+      name: 'test-project',
+      path_with_namespace: 'test-ns/test-project',
+      namespace: { id: 10, kind: 'group', full_path: 'test-ns' },
+    });
+    listMilestones.mockResolvedValue(milestoneFixtures);
+    listIssues.mockResolvedValue(issueFixtures);
+    listGroupEpics.mockResolvedValue([]);
+    listEpicIssues.mockResolvedValue([]);
   });
 
   afterEach(async () => {
@@ -79,6 +96,111 @@ describe('importFromGitLab', () => {
     if (!resolved.ok) return;
     const validation = validateTree(resolved.value);
     expect(validation.errors).toHaveLength(0);
+  });
+
+  it('fetches and incorporates native GitLab epics with link relationships', async () => {
+    const nativeEpic = {
+      id: 501,
+      iid: 11,
+      group_id: 10,
+      title: 'Platform Migration',
+      description: 'Migrate platform.',
+      state: 'opened' as const,
+      labels: ['platform'],
+      created_at: '2026-01-01T00:00:00Z',
+      updated_at: '2026-01-01T00:00:00Z',
+    };
+    listGroupEpics.mockResolvedValueOnce([nativeEpic]);
+    listEpicIssues.mockResolvedValueOnce([
+      {
+        id: 1,
+        iid: 3,
+        title: 't',
+        description: null,
+        state: 'opened',
+        assignee: null,
+        labels: [],
+        milestone: null,
+        weight: null,
+        epic_iid: 11,
+        created_at: '2026-01-01T00:00:00Z',
+        updated_at: '2026-01-01T00:00:00Z',
+      },
+    ]);
+
+    const result = await importFromGitLab({
+      token: 'test-token',
+      project: 'test-ns/test-project',
+      metaDir,
+      linkStrategy: 'all',
+    });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    // 2 epics from label-based + 1 native epic = 3
+    expect(result.value.epics).toBe(3);
+    expect(listGroupEpics).toHaveBeenCalledWith(10);
+    expect(listEpicIssues).toHaveBeenCalledWith(10, 11);
+  });
+
+  it('skips native epic issue fetching for non-matching strategies', async () => {
+    const nativeEpic = {
+      id: 501,
+      iid: 11,
+      group_id: 10,
+      title: 'Platform',
+      description: null,
+      state: 'opened' as const,
+      labels: [],
+      created_at: '2026-01-01T00:00:00Z',
+      updated_at: '2026-01-01T00:00:00Z',
+    };
+    listGroupEpics.mockResolvedValueOnce([nativeEpic]);
+
+    const result = await importFromGitLab({
+      token: 'test-token',
+      project: 'test-ns/test-project',
+      metaDir,
+      linkStrategy: 'body-refs',
+    });
+    expect(result.ok).toBe(true);
+    expect(listEpicIssues).not.toHaveBeenCalled();
+  });
+
+  it('accepts explicit projectId without resolving via getProject', async () => {
+    const result = await importFromGitLab({
+      token: 'test-token',
+      project: 'test-ns/test-project',
+      projectId: 42,
+      metaDir,
+    });
+    expect(result.ok).toBe(true);
+    expect(getProject).not.toHaveBeenCalled();
+  });
+
+  it('handles user namespace (skips groupId)', async () => {
+    getProject.mockResolvedValueOnce({
+      id: 42,
+      name: 'test-project',
+      path_with_namespace: 'user/test-project',
+      namespace: { id: 99, kind: 'user', full_path: 'user' },
+    });
+    const result = await importFromGitLab({
+      token: 'test-token',
+      project: 'user/test-project',
+      metaDir,
+    });
+    expect(result.ok).toBe(true);
+  });
+
+  it('returns error Result when client rejects', async () => {
+    getProject.mockRejectedValueOnce(new Error('API failed'));
+    const result = await importFromGitLab({
+      token: 'test-token',
+      project: 'test-ns/test-project',
+      metaDir,
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error.message).toMatch(/API failed/);
   });
 
   it('creates config and state files', async () => {

--- a/packages/sync-gitlab/src/__tests__/sync.test.ts
+++ b/packages/sync-gitlab/src/__tests__/sync.test.ts
@@ -1,0 +1,912 @@
+import { createHash } from 'node:crypto';
+import { mkdir, mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { Epic, Milestone, Roadmap, Story } from '@gitpm/core';
+import { parseTree, writeFile } from '@gitpm/core';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { GlIssue, GlMilestone } from '../client.js';
+import { saveConfig } from '../config.js';
+import { remoteIssueFields, remoteMilestoneFields } from '../diff.js';
+import { computeContentHash, saveState } from '../state.js';
+import { syncWithGitLab } from '../sync.js';
+import type { SyncState } from '../types.js';
+
+interface FakeClient {
+  getMilestone: ReturnType<typeof vi.fn>;
+  getIssue: ReturnType<typeof vi.fn>;
+  updateMilestone: ReturnType<typeof vi.fn>;
+  updateIssue: ReturnType<typeof vi.fn>;
+  createMilestone: ReturnType<typeof vi.fn>;
+  createIssue: ReturnType<typeof vi.fn>;
+}
+
+const fake: FakeClient = {
+  getMilestone: vi.fn(),
+  getIssue: vi.fn(),
+  updateMilestone: vi.fn(),
+  updateIssue: vi.fn(),
+  createMilestone: vi.fn(),
+  createIssue: vi.fn(),
+};
+
+vi.mock('../client.js', () => ({
+  GitLabClient: vi.fn().mockImplementation(function () {
+    return fake;
+  }),
+}));
+
+let metaDir: string;
+
+beforeEach(async () => {
+  metaDir = await mkdtemp(join(tmpdir(), 'gitpm-sync-'));
+  for (const f of Object.values(fake)) f.mockReset();
+});
+
+afterEach(async () => {
+  await rm(metaDir, { recursive: true });
+});
+
+async function writeMeta(entity: {
+  filePath: string;
+  [k: string]: unknown;
+}): Promise<void> {
+  const resolved = join(metaDir, entity.filePath.replace(/^\.meta\//, ''));
+  await mkdir(join(resolved, '..'), { recursive: true });
+  const result = await writeFile(entity as never, resolved);
+  if (!result.ok) throw result.error;
+}
+
+function makeRoadmap(milestones: { id: string }[] = []): Roadmap {
+  return {
+    type: 'roadmap',
+    id: 'r1',
+    title: 'Roadmap',
+    description: '',
+    milestones,
+    updated_at: '2026-01-01T00:00:00Z',
+    filePath: '.meta/roadmap/roadmap.yaml',
+  };
+}
+
+function makeMilestone(id: string, overrides?: Partial<Milestone>): Milestone {
+  return {
+    type: 'milestone',
+    id,
+    title: `Milestone ${id}`,
+    status: 'in_progress',
+    body: 'desc',
+    filePath: `.meta/roadmap/milestones/${id}.md`,
+    ...overrides,
+  } as Milestone;
+}
+
+function makeEpic(id: string, overrides?: Partial<Epic>): Epic {
+  return {
+    type: 'epic',
+    id,
+    title: `Epic ${id}`,
+    status: 'todo',
+    priority: 'medium',
+    owner: null,
+    labels: [],
+    milestone_ref: null,
+    body: 'epic body',
+    filePath: `.meta/epics/${id}/epic.md`,
+    ...overrides,
+  } as Epic;
+}
+
+function makeStory(id: string, overrides?: Partial<Story>): Story {
+  return {
+    type: 'story',
+    id,
+    title: `Story ${id}`,
+    status: 'todo',
+    priority: 'medium',
+    assignee: null,
+    labels: [],
+    estimate: null,
+    epic_ref: null,
+    body: 'story body',
+    filePath: `.meta/stories/${id}.md`,
+    ...overrides,
+  } as Story;
+}
+
+function makeGlMilestone(overrides: Partial<GlMilestone>): GlMilestone {
+  return {
+    id: 1,
+    iid: 1,
+    title: 't',
+    description: null,
+    state: 'active',
+    due_date: null,
+    created_at: '2026-01-01T00:00:00Z',
+    updated_at: '2026-01-01T00:00:00Z',
+    ...overrides,
+  };
+}
+
+function makeGlIssue(overrides: Partial<GlIssue>): GlIssue {
+  return {
+    id: 1,
+    iid: 1,
+    title: 't',
+    description: null,
+    state: 'opened',
+    assignee: null,
+    labels: [],
+    milestone: null,
+    weight: null,
+    epic_iid: null,
+    created_at: '2026-01-01T00:00:00Z',
+    updated_at: '2026-01-01T00:00:00Z',
+    ...overrides,
+  };
+}
+
+function remoteMilestoneHash(gl: GlMilestone): string {
+  const fields = remoteMilestoneFields(gl);
+  return `sha256:${createHash('sha256').update(JSON.stringify(fields)).digest('hex')}`;
+}
+
+function remoteIssueHash(gl: GlIssue): string {
+  const fields = remoteIssueFields(gl);
+  return `sha256:${createHash('sha256').update(JSON.stringify(fields)).digest('hex')}`;
+}
+
+async function seedConfig(): Promise<void> {
+  await saveConfig(metaDir, {
+    project: 'ns/proj',
+    project_id: 42,
+    base_url: 'https://gitlab.com',
+    status_mapping: {},
+    label_mapping: { epic_labels: ['epic'] },
+    auto_sync: false,
+  });
+}
+
+describe('syncWithGitLab', () => {
+  it('errors when config missing', async () => {
+    const result = await syncWithGitLab({
+      token: 'tok',
+      project: 'ns/proj',
+      metaDir,
+    });
+    expect(result.ok).toBe(false);
+  });
+
+  it('errors when state missing', async () => {
+    await seedConfig();
+    const result = await syncWithGitLab({
+      token: 'tok',
+      project: 'ns/proj',
+      metaDir,
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error.message).toMatch(/No sync state/);
+  });
+
+  it('closes remote when entity deleted locally', async () => {
+    await seedConfig();
+    await writeMeta(makeRoadmap());
+
+    await saveState(metaDir, {
+      project: 'ns/proj',
+      project_id: 42,
+      last_sync: '2026-01-01T00:00:00Z',
+      entities: {
+        gone: {
+          gitlab_issue_iid: 9,
+          gitlab_milestone_id: 10,
+          local_hash: 'sha256:x',
+          remote_hash: 'sha256:x',
+          synced_at: '2026-01-01T00:00:00Z',
+        },
+      },
+    });
+    fake.updateIssue.mockResolvedValue(makeGlIssue({ state: 'closed' }));
+    fake.updateMilestone.mockResolvedValue(
+      makeGlMilestone({ state: 'closed' }),
+    );
+
+    const result = await syncWithGitLab({
+      token: 'tok',
+      project: 'ns/proj',
+      metaDir,
+    });
+    expect(result.ok).toBe(true);
+    expect(fake.updateIssue).toHaveBeenCalledWith(
+      42,
+      9,
+      expect.objectContaining({ state_event: 'close' }),
+    );
+    expect(fake.updateMilestone).toHaveBeenCalledWith(
+      42,
+      10,
+      expect.objectContaining({ state_event: 'close' }),
+    );
+  });
+
+  it('marks milestone cancelled when remote deleted', async () => {
+    await seedConfig();
+    const ms = makeMilestone('m1');
+    await writeMeta(makeRoadmap([{ id: 'm1' }]));
+    await writeMeta(ms);
+
+    const parsed = await parseTree(metaDir);
+    if (!parsed.ok) throw parsed.error;
+    const msFromDisk = parsed.value.milestones[0];
+    const h = computeContentHash(msFromDisk);
+
+    await saveState(metaDir, {
+      project: 'ns/proj',
+      project_id: 42,
+      last_sync: '2026-01-01T00:00:00Z',
+      entities: {
+        m1: {
+          gitlab_milestone_id: 101,
+          local_hash: h,
+          remote_hash: h,
+          synced_at: '2026-01-01T00:00:00Z',
+        },
+      },
+    });
+    fake.getMilestone.mockResolvedValueOnce(null);
+
+    const result = await syncWithGitLab({
+      token: 'tok',
+      project: 'ns/proj',
+      metaDir,
+    });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.pulled.milestones).toBe(1);
+  });
+
+  it('marks story cancelled when remote issue deleted', async () => {
+    await seedConfig();
+    const story = makeStory('s1');
+    await writeMeta(makeRoadmap());
+    await writeMeta(story);
+
+    const parsed = await parseTree(metaDir);
+    if (!parsed.ok) throw parsed.error;
+    const h = computeContentHash(parsed.value.stories[0]);
+
+    await saveState(metaDir, {
+      project: 'ns/proj',
+      project_id: 42,
+      last_sync: '2026-01-01T00:00:00Z',
+      entities: {
+        s1: {
+          gitlab_issue_iid: 50,
+          local_hash: h,
+          remote_hash: h,
+          synced_at: '2026-01-01T00:00:00Z',
+        },
+      },
+    });
+    fake.getIssue.mockResolvedValueOnce(null);
+
+    const result = await syncWithGitLab({
+      token: 'tok',
+      project: 'ns/proj',
+      metaDir,
+    });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.pulled.issues).toBe(1);
+  });
+
+  it('pushes local milestone changes when only local changed', async () => {
+    await seedConfig();
+    const ms = makeMilestone('m1');
+    await writeMeta(makeRoadmap([{ id: 'm1' }]));
+    await writeMeta(ms);
+
+    // State's local_hash differs from the entity (local changed)
+    // State's remote_hash matches getMilestone response (remote unchanged)
+    const remoteMs = makeGlMilestone({
+      id: 101,
+      title: 'Milestone m1',
+      description: 'desc',
+      state: 'active',
+    });
+    const rh = remoteMilestoneHash(remoteMs);
+
+    await saveState(metaDir, {
+      project: 'ns/proj',
+      project_id: 42,
+      last_sync: '2026-01-01T00:00:00Z',
+      entities: {
+        m1: {
+          gitlab_milestone_id: 101,
+          local_hash: 'sha256:stale-local',
+          remote_hash: rh,
+          synced_at: '2026-01-01T00:00:00Z',
+        },
+      },
+    });
+    fake.getMilestone.mockResolvedValueOnce(remoteMs);
+    fake.updateMilestone.mockResolvedValueOnce(remoteMs);
+
+    const result = await syncWithGitLab({
+      token: 'tok',
+      project: 'ns/proj',
+      metaDir,
+    });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.pushed.milestones).toBe(1);
+    expect(fake.updateMilestone).toHaveBeenCalled();
+  });
+
+  it('pulls remote milestone when only remote changed', async () => {
+    await seedConfig();
+    const ms = makeMilestone('m1');
+    await writeMeta(makeRoadmap([{ id: 'm1' }]));
+    await writeMeta(ms);
+
+    const parsed = await parseTree(metaDir);
+    if (!parsed.ok) throw parsed.error;
+    const lh = computeContentHash(parsed.value.milestones[0]);
+
+    const remoteMs = makeGlMilestone({
+      id: 101,
+      title: 'Updated Remote Title',
+      description: 'new',
+      state: 'closed',
+    });
+
+    await saveState(metaDir, {
+      project: 'ns/proj',
+      project_id: 42,
+      last_sync: '2026-01-01T00:00:00Z',
+      entities: {
+        m1: {
+          gitlab_milestone_id: 101,
+          local_hash: lh,
+          remote_hash: 'sha256:stale-remote',
+          synced_at: '2026-01-01T00:00:00Z',
+        },
+      },
+    });
+    fake.getMilestone.mockResolvedValueOnce(remoteMs);
+
+    const result = await syncWithGitLab({
+      token: 'tok',
+      project: 'ns/proj',
+      metaDir,
+    });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.pulled.milestones).toBe(1);
+  });
+
+  it('conflicts with local-wins strategy pushes local', async () => {
+    await seedConfig();
+    const ms = makeMilestone('m1');
+    await writeMeta(makeRoadmap([{ id: 'm1' }]));
+    await writeMeta(ms);
+
+    const remoteMs = makeGlMilestone({
+      id: 101,
+      title: 'Different Remote',
+      state: 'active',
+    });
+
+    await saveState(metaDir, {
+      project: 'ns/proj',
+      project_id: 42,
+      last_sync: '2026-01-01T00:00:00Z',
+      entities: {
+        m1: {
+          gitlab_milestone_id: 101,
+          local_hash: 'sha256:stale-local',
+          remote_hash: 'sha256:stale-remote',
+          synced_at: '2026-01-01T00:00:00Z',
+        },
+      },
+    });
+    fake.getMilestone.mockResolvedValueOnce(remoteMs);
+    fake.updateMilestone.mockResolvedValue(remoteMs);
+
+    const result = await syncWithGitLab({
+      token: 'tok',
+      project: 'ns/proj',
+      metaDir,
+      strategy: 'local-wins',
+    });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.resolved).toBe(1);
+    expect(fake.updateMilestone).toHaveBeenCalled();
+  });
+
+  it('conflicts with remote-wins strategy pulls remote', async () => {
+    await seedConfig();
+    const ms = makeMilestone('m1');
+    await writeMeta(makeRoadmap([{ id: 'm1' }]));
+    await writeMeta(ms);
+
+    const remoteMs = makeGlMilestone({
+      id: 101,
+      title: 'Different Remote',
+      state: 'active',
+    });
+
+    await saveState(metaDir, {
+      project: 'ns/proj',
+      project_id: 42,
+      last_sync: '2026-01-01T00:00:00Z',
+      entities: {
+        m1: {
+          gitlab_milestone_id: 101,
+          local_hash: 'sha256:stale-local',
+          remote_hash: 'sha256:stale-remote',
+          synced_at: '2026-01-01T00:00:00Z',
+        },
+      },
+    });
+    fake.getMilestone.mockResolvedValueOnce(remoteMs);
+
+    const result = await syncWithGitLab({
+      token: 'tok',
+      project: 'ns/proj',
+      metaDir,
+      strategy: 'remote-wins',
+    });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.resolved).toBe(1);
+  });
+
+  it('conflicts with ask strategy records unresolved', async () => {
+    await seedConfig();
+    const ms = makeMilestone('m1');
+    await writeMeta(makeRoadmap([{ id: 'm1' }]));
+    await writeMeta(ms);
+
+    const remoteMs = makeGlMilestone({
+      id: 101,
+      title: 'Different Remote',
+    });
+
+    await saveState(metaDir, {
+      project: 'ns/proj',
+      project_id: 42,
+      last_sync: '2026-01-01T00:00:00Z',
+      entities: {
+        m1: {
+          gitlab_milestone_id: 101,
+          local_hash: 'sha256:stale-local',
+          remote_hash: 'sha256:stale-remote',
+          synced_at: '2026-01-01T00:00:00Z',
+        },
+      },
+    });
+    fake.getMilestone.mockResolvedValueOnce(remoteMs);
+
+    const result = await syncWithGitLab({
+      token: 'tok',
+      project: 'ns/proj',
+      metaDir,
+      strategy: 'ask',
+    });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.conflicts.length).toBe(1);
+    expect(result.value.skipped).toBe(1);
+  });
+
+  it('pushes local issue when local changed', async () => {
+    await seedConfig();
+    const story = makeStory('s1');
+    await writeMeta(makeRoadmap());
+    await writeMeta(story);
+
+    const remoteIssue = makeGlIssue({
+      iid: 50,
+      title: 'Story s1',
+      description: 'story body',
+      state: 'opened',
+    });
+    const rh = remoteIssueHash(remoteIssue);
+
+    await saveState(metaDir, {
+      project: 'ns/proj',
+      project_id: 42,
+      last_sync: '2026-01-01T00:00:00Z',
+      entities: {
+        s1: {
+          gitlab_issue_iid: 50,
+          local_hash: 'sha256:stale-local',
+          remote_hash: rh,
+          synced_at: '2026-01-01T00:00:00Z',
+        },
+      },
+    });
+    fake.getIssue.mockResolvedValueOnce(remoteIssue);
+    fake.updateIssue.mockResolvedValueOnce(remoteIssue);
+
+    const result = await syncWithGitLab({
+      token: 'tok',
+      project: 'ns/proj',
+      metaDir,
+    });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.pushed.issues).toBe(1);
+  });
+
+  it('pulls remote issue when remote changed', async () => {
+    await seedConfig();
+    const story = makeStory('s1');
+    await writeMeta(makeRoadmap());
+    await writeMeta(story);
+
+    const parsed = await parseTree(metaDir);
+    if (!parsed.ok) throw parsed.error;
+    const lh = computeContentHash(parsed.value.stories[0]);
+
+    const remoteIssue = makeGlIssue({
+      iid: 50,
+      title: 'Remote Updated',
+      description: 'changed',
+      state: 'closed',
+    });
+
+    await saveState(metaDir, {
+      project: 'ns/proj',
+      project_id: 42,
+      last_sync: '2026-01-01T00:00:00Z',
+      entities: {
+        s1: {
+          gitlab_issue_iid: 50,
+          local_hash: lh,
+          remote_hash: 'sha256:stale-remote',
+          synced_at: '2026-01-01T00:00:00Z',
+        },
+      },
+    });
+    fake.getIssue.mockResolvedValueOnce(remoteIssue);
+
+    const result = await syncWithGitLab({
+      token: 'tok',
+      project: 'ns/proj',
+      metaDir,
+    });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.pulled.issues).toBe(1);
+  });
+
+  it('issue conflict with local-wins pushes local', async () => {
+    await seedConfig();
+    const story = makeStory('s1');
+    await writeMeta(makeRoadmap());
+    await writeMeta(story);
+
+    const remoteIssue = makeGlIssue({ iid: 50, title: 'Remote' });
+
+    await saveState(metaDir, {
+      project: 'ns/proj',
+      project_id: 42,
+      last_sync: '2026-01-01T00:00:00Z',
+      entities: {
+        s1: {
+          gitlab_issue_iid: 50,
+          local_hash: 'sha256:stale-local',
+          remote_hash: 'sha256:stale-remote',
+          synced_at: '2026-01-01T00:00:00Z',
+        },
+      },
+    });
+    fake.getIssue.mockResolvedValueOnce(remoteIssue);
+    fake.updateIssue.mockResolvedValue(remoteIssue);
+
+    const result = await syncWithGitLab({
+      token: 'tok',
+      project: 'ns/proj',
+      metaDir,
+      strategy: 'local-wins',
+    });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.resolved).toBe(1);
+    expect(fake.updateIssue).toHaveBeenCalled();
+  });
+
+  it('issue conflict with remote-wins pulls remote', async () => {
+    await seedConfig();
+    const story = makeStory('s1');
+    await writeMeta(makeRoadmap());
+    await writeMeta(story);
+
+    const remoteIssue = makeGlIssue({
+      iid: 50,
+      title: 'Remote',
+      description: 'remote body',
+    });
+
+    await saveState(metaDir, {
+      project: 'ns/proj',
+      project_id: 42,
+      last_sync: '2026-01-01T00:00:00Z',
+      entities: {
+        s1: {
+          gitlab_issue_iid: 50,
+          local_hash: 'sha256:stale-local',
+          remote_hash: 'sha256:stale-remote',
+          synced_at: '2026-01-01T00:00:00Z',
+        },
+      },
+    });
+    fake.getIssue.mockResolvedValueOnce(remoteIssue);
+
+    const result = await syncWithGitLab({
+      token: 'tok',
+      project: 'ns/proj',
+      metaDir,
+      strategy: 'remote-wins',
+    });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.resolved).toBe(1);
+  });
+
+  it('issue conflict with ask adds to conflicts', async () => {
+    await seedConfig();
+    const story = makeStory('s1');
+    await writeMeta(makeRoadmap());
+    await writeMeta(story);
+
+    const remoteIssue = makeGlIssue({ iid: 50, title: 'Remote' });
+
+    await saveState(metaDir, {
+      project: 'ns/proj',
+      project_id: 42,
+      last_sync: '2026-01-01T00:00:00Z',
+      entities: {
+        s1: {
+          gitlab_issue_iid: 50,
+          local_hash: 'sha256:stale-local',
+          remote_hash: 'sha256:stale-remote',
+          synced_at: '2026-01-01T00:00:00Z',
+        },
+      },
+    });
+    fake.getIssue.mockResolvedValueOnce(remoteIssue);
+
+    const result = await syncWithGitLab({
+      token: 'tok',
+      project: 'ns/proj',
+      metaDir,
+      strategy: 'ask',
+    });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.conflicts.length).toBe(1);
+  });
+
+  it('creates new milestone on GitLab when not in state', async () => {
+    await seedConfig();
+    const ms = makeMilestone('m1');
+    await writeMeta(makeRoadmap([{ id: 'm1' }]));
+    await writeMeta(ms);
+
+    await saveState(metaDir, {
+      project: 'ns/proj',
+      project_id: 42,
+      last_sync: '2026-01-01T00:00:00Z',
+      entities: {},
+    } satisfies SyncState);
+    fake.createMilestone.mockResolvedValueOnce(makeGlMilestone({ id: 200 }));
+
+    const result = await syncWithGitLab({
+      token: 'tok',
+      project: 'ns/proj',
+      metaDir,
+    });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.pushed.milestones).toBe(1);
+    expect(fake.createMilestone).toHaveBeenCalled();
+  });
+
+  it('creates new issue on GitLab and closes if done', async () => {
+    await seedConfig();
+    const story = makeStory('s1', { status: 'done' });
+    await writeMeta(makeRoadmap());
+    await writeMeta(story);
+
+    await saveState(metaDir, {
+      project: 'ns/proj',
+      project_id: 42,
+      last_sync: '2026-01-01T00:00:00Z',
+      entities: {},
+    });
+    fake.createIssue.mockResolvedValueOnce(makeGlIssue({ iid: 77 }));
+    fake.updateIssue.mockResolvedValueOnce(makeGlIssue({ iid: 77 }));
+
+    const result = await syncWithGitLab({
+      token: 'tok',
+      project: 'ns/proj',
+      metaDir,
+    });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.pushed.issues).toBe(1);
+    expect(fake.createIssue).toHaveBeenCalled();
+    expect(fake.updateIssue).toHaveBeenCalledWith(
+      42,
+      77,
+      expect.objectContaining({ state_event: 'close' }),
+    );
+  });
+
+  it('dryRun does not call mutation APIs', async () => {
+    await seedConfig();
+    const ms = makeMilestone('m1');
+    await writeMeta(makeRoadmap([{ id: 'm1' }]));
+    await writeMeta(ms);
+
+    await saveState(metaDir, {
+      project: 'ns/proj',
+      project_id: 42,
+      last_sync: '2026-01-01T00:00:00Z',
+      entities: {},
+    });
+    const result = await syncWithGitLab({
+      token: 'tok',
+      project: 'ns/proj',
+      metaDir,
+      dryRun: true,
+    });
+    expect(result.ok).toBe(true);
+    expect(fake.createMilestone).not.toHaveBeenCalled();
+  });
+
+  it('skips entities already in sync', async () => {
+    await seedConfig();
+    const ms = makeMilestone('m1');
+    await writeMeta(makeRoadmap([{ id: 'm1' }]));
+    await writeMeta(ms);
+
+    const parsed = await parseTree(metaDir);
+    if (!parsed.ok) throw parsed.error;
+    const lh = computeContentHash(parsed.value.milestones[0]);
+
+    const remoteMs = makeGlMilestone({
+      id: 101,
+      title: 'Milestone m1',
+      description: 'desc',
+      state: 'active',
+    });
+    const rh = remoteMilestoneHash(remoteMs);
+
+    await saveState(metaDir, {
+      project: 'ns/proj',
+      project_id: 42,
+      last_sync: '2026-01-01T00:00:00Z',
+      entities: {
+        m1: {
+          gitlab_milestone_id: 101,
+          local_hash: lh,
+          remote_hash: rh,
+          synced_at: '2026-01-01T00:00:00Z',
+        },
+      },
+    });
+    fake.getMilestone.mockResolvedValueOnce(remoteMs);
+
+    const result = await syncWithGitLab({
+      token: 'tok',
+      project: 'ns/proj',
+      metaDir,
+    });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.pushed.milestones).toBe(0);
+    expect(result.value.pulled.milestones).toBe(0);
+    expect(fake.updateMilestone).not.toHaveBeenCalled();
+  });
+
+  it('creates new epic on GitLab when not in state', async () => {
+    await seedConfig();
+    const epic = makeEpic('e1');
+    await writeMeta(makeRoadmap());
+    await writeMeta(epic);
+
+    await saveState(metaDir, {
+      project: 'ns/proj',
+      project_id: 42,
+      last_sync: '2026-01-01T00:00:00Z',
+      entities: {},
+    });
+    fake.createIssue.mockResolvedValueOnce(makeGlIssue({ iid: 30 }));
+
+    const result = await syncWithGitLab({
+      token: 'tok',
+      project: 'ns/proj',
+      metaDir,
+    });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.pushed.issues).toBe(1);
+    expect(fake.createIssue).toHaveBeenCalled();
+  });
+
+  it('pulls epic issue (sets owner) when remote changed', async () => {
+    await seedConfig();
+    const epic = makeEpic('e1');
+    await writeMeta(makeRoadmap());
+    await writeMeta(epic);
+
+    const parsed = await parseTree(metaDir);
+    if (!parsed.ok) throw parsed.error;
+    const lh = computeContentHash(parsed.value.epics[0]);
+
+    const remoteIssue = makeGlIssue({
+      iid: 50,
+      title: 'Remote Epic',
+      description: 'remote body',
+      assignee: { id: 1, username: 'alice' },
+      labels: ['epic', 'platform'],
+    });
+
+    await saveState(metaDir, {
+      project: 'ns/proj',
+      project_id: 42,
+      last_sync: '2026-01-01T00:00:00Z',
+      entities: {
+        e1: {
+          gitlab_issue_iid: 50,
+          local_hash: lh,
+          remote_hash: 'sha256:stale',
+          synced_at: '2026-01-01T00:00:00Z',
+        },
+      },
+    });
+    fake.getIssue.mockResolvedValueOnce(remoteIssue);
+
+    const result = await syncWithGitLab({
+      token: 'tok',
+      project: 'ns/proj',
+      metaDir,
+    });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.pulled.issues).toBe(1);
+  });
+
+  it('returns error Result when client throws', async () => {
+    await seedConfig();
+    await writeMeta(makeRoadmap());
+    await saveState(metaDir, {
+      project: 'ns/proj',
+      project_id: 42,
+      last_sync: '2026-01-01T00:00:00Z',
+      entities: {
+        s1: {
+          gitlab_issue_iid: 1,
+          local_hash: 'a',
+          remote_hash: 'b',
+          synced_at: '2026-01-01T00:00:00Z',
+        },
+      },
+    });
+    // entity is "locally deleted" but we want the update to throw
+    fake.updateIssue.mockRejectedValueOnce(new Error('boom'));
+
+    const result = await syncWithGitLab({
+      token: 'tok',
+      project: 'ns/proj',
+      metaDir,
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error.message).toMatch(/boom/);
+  });
+});


### PR DESCRIPTION
Adds test files for adapter.ts, client.ts, export.ts, and sync.ts;
extends diff.test.ts with diffEntity coverage; and closes import/state/
linker/config edge-case gaps via coverage-gaps.test.ts. All sync-gitlab
source files now reach 100% line coverage.

https://claude.ai/code/session_011sNXCYjXDR5Ds7xuamZY9a