### PR TITLE
test(core): raise packages/core line coverage to ~100%

### DIFF
--- a/.meta/epics/test-coverage-to-100-on-source-code/stories/add-test-coverage-for-packagescore-to-100.md
+++ b/.meta/epics/test-coverage-to-100-on-source-code/stories/add-test-coverage-for-packagescore-to-100.md
@@ -12,7 +12,7 @@ estimate: null
 epic_ref:
   id: xGG0RMogvzyo
 created_at: 2026-04-12T19:34:55.144Z
-updated_at: 2026-04-19T12:43:41.674Z
+updated_at: 2026-04-19T13:29:28.662Z
 ---
 
 ## Objective

--- a/packages/core/src/parser/parser.test.ts
+++ b/packages/core/src/parser/parser.test.ts
@@ -1,7 +1,7 @@
 import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { describe, expect, it } from 'vitest';
 import { parseFile, parseFileContent } from './parse-file.js';
 import { parseTree } from './parse-tree.js';
 
@@ -124,6 +124,15 @@ milestones:
 ---`;
     const result = parseFileContent(content, '/test/r.md');
     expect(result.ok).toBe(true);
+  });
+
+  it('returns error when frontmatter parses to a non-object scalar', () => {
+    // gray-matter parses `---\n42\n---` into data=42, a number.
+    const content = '---\n42\n---\nbody';
+    const result = parseFileContent(content, '/test/scalar.md');
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.message).toContain('Invalid frontmatter');
   });
 });
 
@@ -276,5 +285,35 @@ describe('parseTree', () => {
     expect(result.ok).toBe(false);
     if (result.ok) return;
     expect(result.error.message).toContain('Failed to parse tree');
+  });
+
+  it('applies schema extensions when schema-extensions.yaml is valid and non-empty', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'gitpm-parse-ext-valid-'));
+    try {
+      const metaDir = join(dir, '.meta');
+      const storiesDir = join(metaDir, 'stories');
+      await mkdir(join(metaDir, '.gitpm'), { recursive: true });
+      await mkdir(storiesDir, { recursive: true });
+
+      await writeFile(
+        join(metaDir, '.gitpm', 'schema-extensions.yaml'),
+        'story:\n  fields:\n    team:\n      type: string\n      required: false\n',
+      );
+      await writeFile(
+        join(storiesDir, 'ext.md'),
+        '---\ntype: story\nid: st_ext\ntitle: With extension\nstatus: todo\npriority: medium\nlabels: []\nteam: platform\ncreated_at: 2026-01-01T00:00:00Z\nupdated_at: 2026-01-01T00:00:00Z\n---\n',
+      );
+
+      const result = await parseTree(metaDir);
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.value.errors).toHaveLength(0);
+      expect(result.value.stories).toHaveLength(1);
+      expect((result.value.stories[0] as Record<string, unknown>).team).toBe(
+        'platform',
+      );
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
   });
 });

--- a/packages/core/src/plugin-loader.test.ts
+++ b/packages/core/src/plugin-loader.test.ts
@@ -131,6 +131,30 @@ describe('loadGitpmConfig', () => {
     const result = await loadGitpmConfig(tmpDir);
     expect(result.ok).toBe(false);
   });
+
+  it('returns error for invalid JS config that fails schema validation', async () => {
+    await writeFile(
+      join(tmpDir, 'gitpm.config.mjs'),
+      'export default { adapters: "not-an-array" };',
+    );
+    const result = await loadGitpmConfig(tmpDir);
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.message).toContain('Invalid config');
+  });
+
+  it('returns error when config file fails to parse (non-ENOENT)', async () => {
+    // Malformed JSON — JSON.parse throws, and the error is not ENOENT or
+    // a module-not-found error, so loadGitpmConfig surfaces it.
+    await writeFile(
+      join(tmpDir, 'gitpm.config.json'),
+      '{ this is not valid json',
+    );
+    const result = await loadGitpmConfig(tmpDir);
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.message).toContain('Failed to load config');
+  });
 });
 
 describe('detectAdapter', () => {

--- a/packages/core/src/quality/config.test.ts
+++ b/packages/core/src/quality/config.test.ts
@@ -83,4 +83,13 @@ template:
     if (result.ok) return;
     expect(result.error.message).toContain('Invalid quality config');
   });
+
+  it('returns error when the config path is unreadable (non-ENOENT)', async () => {
+    // Make the quality.yaml path itself a directory so readFile fails with EISDIR
+    await mkdir(join(testDir, '.gitpm', 'quality.yaml'), { recursive: true });
+    const result = await loadQualityConfig(testDir);
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.message).toContain('Failed to read quality config');
+  });
 });

--- a/packages/core/src/query/format.test.ts
+++ b/packages/core/src/query/format.test.ts
@@ -1,4 +1,4 @@
-import { join, relative } from 'node:path';
+import { join } from 'node:path';
 import { describe, expect, it } from 'vitest';
 import type { ParsedEntity } from '../parser/types.js';
 import { formatEntities } from './format.js';
@@ -168,7 +168,6 @@ describe('formatEntities', () => {
         format: 'json',
       });
       const parsed = JSON.parse(output);
-      expect(parsed[0].filePath).toBe(relative(process.cwd(), absolutePath));
       expect(parsed[0].filePath).toBe(join('pkg', 'story.md'));
     });
 

--- a/packages/core/src/query/format.test.ts
+++ b/packages/core/src/query/format.test.ts
@@ -1,3 +1,4 @@
+import { join, relative } from 'node:path';
 import { describe, expect, it } from 'vitest';
 import type { ParsedEntity } from '../parser/types.js';
 import { formatEntities } from './format.js';
@@ -149,14 +150,26 @@ describe('formatEntities', () => {
     });
 
     it('extracts filePath relative to cwd', () => {
-      const output = formatEntities(mockEntities, {
+      const absolutePath = join(process.cwd(), 'pkg', 'story.md');
+      const entities: ParsedEntity[] = [
+        {
+          type: 'story',
+          id: 'st_fp',
+          title: 'Path story',
+          status: 'todo',
+          priority: 'medium',
+          labels: [],
+          body: '',
+          filePath: absolutePath,
+        } as ParsedEntity,
+      ];
+      const output = formatEntities(entities, {
         fields: ['id', 'filePath'],
         format: 'json',
       });
       const parsed = JSON.parse(output);
-      // The relative path does not start with '/'
-      expect(parsed[0].filePath.startsWith('/')).toBe(false);
-      expect(parsed[0].filePath).toContain('first-story.md');
+      expect(parsed[0].filePath).toBe(relative(process.cwd(), absolutePath));
+      expect(parsed[0].filePath).toBe(join('pkg', 'story.md'));
     });
 
     it('extracts milestone_ref as ID', () => {

--- a/packages/core/src/query/format.test.ts
+++ b/packages/core/src/query/format.test.ts
@@ -147,5 +147,68 @@ describe('formatEntities', () => {
       const parsed = JSON.parse(output);
       expect(parsed[0].estimate).toBe('');
     });
+
+    it('extracts filePath relative to cwd', () => {
+      const output = formatEntities(mockEntities, {
+        fields: ['id', 'filePath'],
+        format: 'json',
+      });
+      const parsed = JSON.parse(output);
+      // The relative path does not start with '/'
+      expect(parsed[0].filePath.startsWith('/')).toBe(false);
+      expect(parsed[0].filePath).toContain('first-story.md');
+    });
+
+    it('extracts milestone_ref as ID', () => {
+      const entities: ParsedEntity[] = [
+        {
+          type: 'epic',
+          id: 'ep_ms',
+          title: 'Epic with milestone',
+          status: 'todo',
+          priority: 'medium',
+          labels: [],
+          milestone_ref: { id: 'ms_001' },
+          body: '',
+          filePath: '/project/.meta/epics/e/epic.md',
+        } as ParsedEntity,
+        {
+          type: 'epic',
+          id: 'ep_no_ms',
+          title: 'Epic without milestone',
+          status: 'todo',
+          priority: 'medium',
+          labels: [],
+          body: '',
+          filePath: '/project/.meta/epics/e2/epic.md',
+        } as ParsedEntity,
+      ];
+      const output = formatEntities(entities, {
+        fields: ['id', 'milestone_ref'],
+        format: 'json',
+      });
+      const parsed = JSON.parse(output);
+      expect(parsed[0].milestone_ref).toBe('ms_001');
+      expect(parsed[1].milestone_ref).toBe('');
+    });
+
+    it('returns empty string for labels on entity types without a labels array', () => {
+      const roadmap: ParsedEntity[] = [
+        {
+          type: 'roadmap',
+          id: 'rm_1',
+          title: 'Roadmap',
+          description: '',
+          milestones: [],
+          filePath: '/project/.meta/roadmap.yaml',
+        } as ParsedEntity,
+      ];
+      const output = formatEntities(roadmap, {
+        fields: ['id', 'labels'],
+        format: 'json',
+      });
+      const parsed = JSON.parse(output);
+      expect(parsed[0].labels).toBe('');
+    });
   });
 });

--- a/packages/core/src/schemas/extensions.test.ts
+++ b/packages/core/src/schemas/extensions.test.ts
@@ -114,6 +114,39 @@ describe('loadSchemaExtensions', () => {
     const result = await loadSchemaExtensions(tmpDir);
     expect(result.ok).toBe(false);
   });
+
+  it('returns empty extensions when YAML parses to null (empty file)', async () => {
+    await writeFile(join(tmpDir, '.gitpm', 'schema-extensions.yaml'), '');
+
+    const result = await loadSchemaExtensions(tmpDir);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value).toEqual({});
+  });
+
+  it('returns empty extensions when YAML parses to a scalar', async () => {
+    await writeFile(
+      join(tmpDir, '.gitpm', 'schema-extensions.yaml'),
+      '"just a string"\n',
+    );
+
+    const result = await loadSchemaExtensions(tmpDir);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value).toEqual({});
+  });
+
+  it('returns error when read fails with a non-ENOENT error (path is a directory)', async () => {
+    // Make the extensions path itself a directory so readFile fails with EISDIR
+    await mkdir(join(tmpDir, '.gitpm', 'schema-extensions.yaml'), {
+      recursive: true,
+    });
+
+    const result = await loadSchemaExtensions(tmpDir);
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.message).toContain('Failed to load schema extensions');
+  });
 });
 
 describe('buildExtensionFields', () => {
@@ -183,6 +216,50 @@ describe('buildExtensionFields', () => {
       'story',
     );
     expect(fields).not.toBeNull();
+  });
+
+  it('skips string enum field with empty enum array', () => {
+    const fields = buildExtensionFields(
+      {
+        story: {
+          fields: {
+            empty_enum: {
+              type: 'string',
+              required: false,
+              enum: [],
+            },
+            keeper: { type: 'string', required: false },
+          },
+        },
+      },
+      'story',
+    );
+    expect(fields).not.toBeNull();
+    expect(fields?.empty_enum).toBeUndefined();
+    expect(fields?.keeper).toBeDefined();
+  });
+
+  it('applies default value to fields when provided', () => {
+    const fields = buildExtensionFields(
+      {
+        story: {
+          fields: {
+            priority_score: {
+              type: 'number',
+              required: false,
+              default: 42,
+            },
+          },
+        },
+      },
+      'story',
+    );
+    expect(fields).not.toBeNull();
+    const parsed = z.object(fields ?? {}).safeParse({});
+    expect(parsed.success).toBe(true);
+    if (parsed.success) {
+      expect(parsed.data.priority_score).toBe(42);
+    }
   });
 });
 

--- a/packages/core/src/validator/validator.test.ts
+++ b/packages/core/src/validator/validator.test.ts
@@ -145,6 +145,58 @@ describe('validateTree', () => {
     expect(result.warnings[0].code).toBe('STATUS_INCONSISTENCY');
   });
 
+  it('detects circular dependencies in the dependency graph', () => {
+    // Create a story and an epic that share the same ID. This causes the
+    // adjacency map (keyed by ID) to produce a self-loop once the story's
+    // epic_ref edge is added: 'X' → 'X'. The cycle detector then surfaces
+    // a CIRCULAR_DEPENDENCY error (alongside a DUPLICATE_ID, which we
+    // also verify is reported).
+    const tree: MetaTree = {
+      stories: [
+        {
+          type: 'story',
+          id: 'X',
+          title: 'Self-ref story',
+          status: 'todo',
+          priority: 'medium',
+          labels: [],
+          epic_ref: { id: 'X' },
+          body: '',
+          filePath: '/test/st.md',
+        },
+      ],
+      epics: [
+        {
+          type: 'epic',
+          id: 'X',
+          title: 'Duplicate-id epic',
+          status: 'todo',
+          priority: 'medium',
+          labels: [],
+          body: '',
+          filePath: '/test/ep.md',
+        },
+      ],
+      milestones: [],
+      roadmaps: [],
+      prds: [],
+      sprints: [],
+      errors: [],
+    };
+
+    const resolved = resolveRefs(tree);
+    expect(resolved.ok).toBe(true);
+    if (!resolved.ok) return;
+
+    const result = validateTree(resolved.value);
+    expect(result.valid).toBe(false);
+    const cycleErrors = result.errors.filter(
+      (e) => e.code === 'CIRCULAR_DEPENDENCY',
+    );
+    expect(cycleErrors.length).toBeGreaterThan(0);
+    expect(cycleErrors[0].message).toContain('Circular dependency');
+  });
+
   it('passes when epic is done and all stories are done', () => {
     const tree: MetaTree = {
       stories: [

--- a/packages/core/src/validator/validator.test.ts
+++ b/packages/core/src/validator/validator.test.ts
@@ -195,6 +195,8 @@ describe('validateTree', () => {
     );
     expect(cycleErrors.length).toBeGreaterThan(0);
     expect(cycleErrors[0].message).toContain('Circular dependency');
+    const dupErrors = result.errors.filter((e) => e.code === 'DUPLICATE_ID');
+    expect(dupErrors.length).toBeGreaterThan(0);
   });
 
   it('passes when epic is done and all stories are done', () => {

--- a/packages/core/src/writer/create-entity.test.ts
+++ b/packages/core/src/writer/create-entity.test.ts
@@ -117,6 +117,18 @@ describe('createStory', () => {
     expect(r1.value.filePath).not.toBe(r2.value.filePath);
   });
 
+  it('increments suffix when multiple numbered variants already exist', async () => {
+    const r1 = await createStory(metaDir, { title: 'Repeat' });
+    const r2 = await createStory(metaDir, { title: 'Repeat' });
+    const r3 = await createStory(metaDir, { title: 'Repeat' });
+
+    expect(r1.ok && r2.ok && r3.ok).toBe(true);
+    if (!r1.ok || !r2.ok || !r3.ok) return;
+    expect(r1.value.filePath).toContain('repeat.md');
+    expect(r2.value.filePath).toContain('repeat-2.md');
+    expect(r3.value.filePath).toContain('repeat-3.md');
+  });
+
   it('includes body content when provided', async () => {
     const result = await createStory(metaDir, {
       title: 'Story with body',
@@ -129,6 +141,17 @@ describe('createStory', () => {
     const raw = await readFile(result.value.filePath, 'utf-8');
     expect(raw).toContain('## Description');
     expect(raw).toContain('Some content here.');
+  });
+
+  it('returns a Result error when input triggers a thrown exception', async () => {
+    // Pass an options object with a non-string title — toSlug() calls
+    // title.toLowerCase() and throws, exercising the outer catch block.
+    const result = await createStory(metaDir, {
+      title: null as unknown as string,
+    });
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.message).toContain('Failed to create story');
   });
 });
 
@@ -206,6 +229,15 @@ describe('createEpic', () => {
     if (result.ok) return;
     expect(result.error.message).toContain('Failed to write');
   });
+
+  it('returns a Result error when input triggers a thrown exception', async () => {
+    const result = await createEpic(metaDir, {
+      title: null as unknown as string,
+    });
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.message).toContain('Failed to create epic');
+  });
 });
 
 describe('createMilestone', () => {
@@ -260,6 +292,15 @@ describe('createMilestone', () => {
     await writeFile(metaDir, 'not-a-directory');
     const result = await createMilestone(metaDir, { title: 'Blocked' });
     expect(result.ok).toBe(false);
+  });
+
+  it('returns a Result error when input triggers a thrown exception', async () => {
+    const result = await createMilestone(metaDir, {
+      title: null as unknown as string,
+    });
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.message).toContain('Failed to create milestone');
   });
 });
 
@@ -350,5 +391,16 @@ describe('createSprint', () => {
       endDate: '2026-07-14',
     });
     expect(result.ok).toBe(false);
+  });
+
+  it('returns a Result error when input triggers a thrown exception', async () => {
+    const result = await createSprint(metaDir, {
+      title: null as unknown as string,
+      startDate: '2026-07-01',
+      endDate: '2026-07-14',
+    });
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.message).toContain('Failed to create sprint');
   });
 });

--- a/packages/core/src/writer/move-entity.test.ts
+++ b/packages/core/src/writer/move-entity.test.ts
@@ -157,15 +157,11 @@ describe('moveStory', () => {
   });
 
   it('returns a Result error when move logic throws unexpectedly', async () => {
-    // Create a standalone story so parseFile succeeds.
     const storyResult = await createStory(metaDir, { title: 'Throwy story' });
     expect(storyResult.ok).toBe(true);
     if (!storyResult.ok) return;
 
-    // Force a throw deep inside the move logic by passing a Symbol as
-    // toEpic. Template literal interpolation (used by the epic-matching
-    // check) rejects Symbol values with a TypeError, exercising the
-    // outer catch block.
+    // Symbols trigger TypeError when interpolated into a template literal.
     const moveResult = await moveStory(metaDir, storyResult.value.filePath, {
       toEpic: Symbol('unconvertible') as unknown as string,
     });

--- a/packages/core/src/writer/move-entity.test.ts
+++ b/packages/core/src/writer/move-entity.test.ts
@@ -156,6 +156,24 @@ describe('moveStory', () => {
     expect(moveResult.error.message).toContain('--to-epic or --to-orphan');
   });
 
+  it('returns a Result error when move logic throws unexpectedly', async () => {
+    // Create a standalone story so parseFile succeeds.
+    const storyResult = await createStory(metaDir, { title: 'Throwy story' });
+    expect(storyResult.ok).toBe(true);
+    if (!storyResult.ok) return;
+
+    // Force a throw deep inside the move logic by passing a Symbol as
+    // toEpic. Template literal interpolation (used by the epic-matching
+    // check) rejects Symbol values with a TypeError, exercising the
+    // outer catch block.
+    const moveResult = await moveStory(metaDir, storyResult.value.filePath, {
+      toEpic: Symbol('unconvertible') as unknown as string,
+    });
+    expect(moveResult.ok).toBe(false);
+    if (moveResult.ok) return;
+    expect(moveResult.error.message).toContain('Failed to move story');
+  });
+
   it('updates updated_at timestamp', async () => {
     const epicResult = await createEpic(metaDir, { title: 'Time Epic' });
     expect(epicResult.ok).toBe(true);

--- a/packages/core/src/writer/set-fields.test.ts
+++ b/packages/core/src/writer/set-fields.test.ts
@@ -300,6 +300,24 @@ describe('applyAssignments', () => {
     if (result.ok) return;
     expect(result.error.message).toContain('Dangerous field name');
   });
+
+  it('updates a nested field when the intermediate object already exists', () => {
+    // baseStory has no epic_ref, so the first nested set creates the object.
+    // Verify that a subsequent nested set traverses the existing object
+    // (exercising the "existing is an object, reuse it" branch).
+    const withEpic = {
+      ...baseStory,
+      epic_ref: { id: 'ep_old' } as Record<string, unknown>,
+    } as ParsedEntity;
+    const result = applyAssignments(withEpic, [
+      { field: 'epic_ref.id', operator: '=', value: 'ep_new' },
+    ]);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect((result.value as Record<string, unknown>).epic_ref).toEqual({
+      id: 'ep_new',
+    });
+  });
 });
 
 describe('applyAssignments schema dispatch', () => {

--- a/packages/core/src/writer/set-fields.test.ts
+++ b/packages/core/src/writer/set-fields.test.ts
@@ -302,9 +302,9 @@ describe('applyAssignments', () => {
   });
 
   it('updates a nested field when the intermediate object already exists', () => {
-    // baseStory has no epic_ref, so the first nested set creates the object.
-    // Verify that a subsequent nested set traverses the existing object
-    // (exercising the "existing is an object, reuse it" branch).
+    // Seed the entity with a populated epic_ref so setNestedField traverses
+    // the existing object (exercising the "existing is an object, reuse it"
+    // branch) instead of creating a fresh intermediate.
     const withEpic = {
       ...baseStory,
       epic_ref: { id: 'ep_old' } as Record<string, unknown>,

--- a/packages/core/src/writer/writer.test.ts
+++ b/packages/core/src/writer/writer.test.ts
@@ -207,4 +207,19 @@ describe('scaffoldMeta', () => {
       await rm(tmpDir, { recursive: true });
     }
   });
+
+  it('returns a Result error when input triggers a thrown exception', async () => {
+    // Pass a non-string projectName — toSlug() calls .toLowerCase() on it
+    // and throws, exercising the outer catch block.
+    const tmpDir = await mkdtemp(join(tmpdir(), 'gitpm-scaffold-err-'));
+    try {
+      const metaDir = join(tmpDir, '.meta');
+      const result = await scaffoldMeta(metaDir, null as unknown as string);
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+      expect(result.error.message).toContain('Failed to scaffold');
+    } finally {
+      await rm(tmpDir, { recursive: true, force: true });
+    }
+  });
 });


### PR DESCRIPTION
## Summary

This PR significantly expands test coverage across the codebase by adding tests for error handling paths, edge cases, and exception scenarios that were previously untested. The changes ensure that error conditions are properly caught and returned as `Result` errors rather than thrown exceptions, and that edge cases like empty YAML files, circular dependencies, and invalid inputs are handled gracefully.

## Changes

- **Schema extensions** (`extensions.test.ts`): Added tests for empty YAML files, scalar YAML values, and non-ENOENT read errors; added tests for empty enum arrays and default field values in `buildExtensionFields`
- **Entity formatting** (`format.test.ts`): Added tests for relative file path extraction, milestone reference extraction, and label handling for entity types without labels
- **Validation** (`validator.test.ts`): Added test for circular dependency detection in the dependency graph
- **Entity creation** (`create-entity.test.ts`): Added tests for multiple numbered variant handling and exception handling in `createStory`, `createEpic`, `createMilestone`, and `createSprint`
- **File parsing** (`parser.test.ts`): Added test for non-object scalar frontmatter and test for schema extension application during tree parsing
- **Config loading** (`plugin-loader.test.ts`): Added tests for invalid JS config schema validation and malformed JSON parsing errors
- **Entity movement** (`move-entity.test.ts`): Added test for exception handling in move logic
- **Field assignment** (`set-fields.test.ts`): Added test for nested field updates when intermediate objects already exist
- **Meta scaffolding** (`writer.test.ts`): Added test for exception handling in `scaffoldMeta`
- **Quality config** (`config.test.ts`): Added test for unreadable quality config files (non-ENOENT errors)
- **Test cleanup** (`parser.test.ts`): Removed unused `afterEach` and `beforeEach` imports

## Related GitPM stories

- `.meta/epics/test-coverage-to-100-on-source-code/stories/add-test-coverage-for-packagescore-to-100.md`

## Test plan

- [x] Added 20+ new unit tests covering error paths and edge cases
- [x] All tests follow existing patterns and use proper error assertions
- [x] `bun run test` passes with new test coverage

https://claude.ai/code/session_01XhjgY7EQ4GJjPg6r7SE4pq