### PR TITLE
chore: persist GitHub sync metadata and enable write permissions

### DIFF
--- a/.github/workflows/post-merge-sync.yml
+++ b/.github/workflows/post-merge-sync.yml
@@ -14,7 +14,7 @@ on:
       - '.meta/**'
 
 permissions:
-  contents: read
+  contents: write
   issues: write
 
 jobs:
@@ -42,3 +42,18 @@ jobs:
         run: node packages/cli/dist/index.js push --token "$GITHUB_TOKEN" --yes
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # Persist sync writebacks (github.issue_number on entities,
+      # .meta/sync/github-state.json) so the next push doesn't see entities
+      # as new and create duplicate issues. [skip ci] avoids re-triggering.
+      - name: Commit sync writebacks
+        run: |
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git config user.name "github-actions[bot]"
+          git add .meta/
+          if git diff --cached --quiet; then
+            echo "No sync writebacks to commit."
+            exit 0
+          fi
+          git commit -m "chore(pm): persist GitHub sync metadata [skip ci]"
+          git push origin HEAD:master

--- a/.meta/epics/test-coverage-to-100-on-source-code/epic.md
+++ b/.meta/epics/test-coverage-to-100-on-source-code/epic.md
@@ -11,6 +11,9 @@ labels:
 milestone_ref: null
 created_at: 2026-04-12T19:33:41.549Z
 updated_at: 2026-04-12T19:33:41.549Z
+github:
+  issue_number: 164
+  repo: yevheniidehtiar/gitpm
 ---
 
 ## Goal

--- a/.meta/epics/test-coverage-to-100-on-source-code/stories/add-test-coverage-for-packagescli-to-100.md
+++ b/.meta/epics/test-coverage-to-100-on-source-code/stories/add-test-coverage-for-packagescli-to-100.md
@@ -13,6 +13,9 @@ epic_ref:
   id: xGG0RMogvzyo
 created_at: 2026-04-12T19:35:05.843Z
 updated_at: 2026-04-19T12:45:55.337Z
+github:
+  issue_number: 165
+  repo: yevheniidehtiar/gitpm
 ---
 
 ## Objective

--- a/.meta/epics/test-coverage-to-100-on-source-code/stories/add-test-coverage-for-packagescore-to-100.md
+++ b/.meta/epics/test-coverage-to-100-on-source-code/stories/add-test-coverage-for-packagescore-to-100.md
@@ -13,6 +13,9 @@ epic_ref:
   id: xGG0RMogvzyo
 created_at: 2026-04-12T19:34:55.144Z
 updated_at: 2026-04-19T13:29:28.662Z
+github:
+  issue_number: 166
+  repo: yevheniidehtiar/gitpm
 ---
 
 ## Objective

--- a/.meta/epics/test-coverage-to-100-on-source-code/stories/add-test-coverage-for-packagessync-github-to-100.md
+++ b/.meta/epics/test-coverage-to-100-on-source-code/stories/add-test-coverage-for-packagessync-github-to-100.md
@@ -13,6 +13,9 @@ epic_ref:
   id: xGG0RMogvzyo
 created_at: 2026-04-12T19:34:57.917Z
 updated_at: 2026-04-19T12:50:08.430Z
+github:
+  issue_number: 167
+  repo: yevheniidehtiar/gitpm
 ---
 
 ## Objective

--- a/.meta/epics/test-coverage-to-100-on-source-code/stories/add-test-coverage-for-packagessync-gitlab-to-100.md
+++ b/.meta/epics/test-coverage-to-100-on-source-code/stories/add-test-coverage-for-packagessync-gitlab-to-100.md
@@ -13,6 +13,9 @@ epic_ref:
   id: xGG0RMogvzyo
 created_at: 2026-04-12T19:35:00.664Z
 updated_at: 2026-04-19T12:48:47.234Z
+github:
+  issue_number: 168
+  repo: yevheniidehtiar/gitpm
 ---
 
 ## Objective

--- a/.meta/epics/test-coverage-to-100-on-source-code/stories/add-test-coverage-for-packagessync-jira-to-100.md
+++ b/.meta/epics/test-coverage-to-100-on-source-code/stories/add-test-coverage-for-packagessync-jira-to-100.md
@@ -13,6 +13,9 @@ epic_ref:
   id: xGG0RMogvzyo
 created_at: 2026-04-12T19:35:03.249Z
 updated_at: 2026-04-19T12:52:40.695Z
+github:
+  issue_number: 169
+  repo: yevheniidehtiar/gitpm
 ---
 
 ## Objective


### PR DESCRIPTION
## Summary

Enable the post-merge-sync workflow to persist GitHub synchronization metadata (issue numbers and repository references) back to the repository. This prevents duplicate issue creation on subsequent syncs by committing the sync state changes.

## Changes

- Updated `post-merge-sync.yml` workflow permissions from `contents: read` to `contents: write` to allow pushing commits
- Added a new "Commit sync writebacks" step that:
  - Configures git user for the github-actions bot
  - Stages `.meta/` directory changes (sync metadata)
  - Commits changes with `[skip ci]` flag to avoid re-triggering workflows
  - Pushes the commit to master
- Updated sync metadata in epic and story files to include GitHub issue numbers and repository references:
  - Epic: test-coverage-to-100-on-source-code (issue #164)
  - Stories: add-test-coverage for packages/cli, packages/core, packages/sync-github, packages/sync-gitlab, packages/sync-jira (issues #165-169)

## Related GitPM stories

-

## Test plan

N/A - Workflow configuration change with automated commit handling. The `[skip ci]` flag ensures the commit doesn't trigger additional workflow runs.

## Related issues

Closes #

https://claude.ai/code/session_01KhTHd6rM5BtKMjGTjUPZk6