### PR TITLE
ci(post-merge-sync): add workflow_dispatch for manual recovery runs

### DIFF
--- a/.github/workflows/post-merge-sync.yml
+++ b/.github/workflows/post-merge-sync.yml
@@ -6,12 +6,17 @@ name: Post-Merge Sync
 # stories as done` commit written by `release-please.yml`. `gitpm push` then
 # closes every GitHub issue whose story is now `status: done` (mapper at
 # packages/sync-github/src/mapper.ts:232-235 maps done/cancelled → closed).
+#
+# Also exposes `workflow_dispatch` so a maintainer can run the sync manually
+# from the Actions UI — useful when the workflow was disabled or a previous
+# run failed and `.meta/` is out of sync with GitHub Issues.
 
 on:
   push:
     branches: [master]
     paths:
       - '.meta/**'
+  workflow_dispatch:
 
 permissions:
   contents: write

--- a/.github/workflows/post-merge-sync.yml
+++ b/.github/workflows/post-merge-sync.yml
@@ -26,6 +26,10 @@ jobs:
   sync-to-github:
     name: Sync .meta/ to GitHub Issues
     runs-on: ubuntu-latest
+    # workflow_dispatch lets the UI pick any branch, but the writeback step
+    # below pushes to master — guard against a misclick that would overwrite
+    # master with a feature branch's .meta/ state.
+    if: github.ref == 'refs/heads/master'
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
## Summary
- Adds `workflow_dispatch` to `.github/workflows/post-merge-sync.yml` so the sync can be re-run manually from the Actions UI.
- Recovery handle for situations where the workflow was disabled (as just happened) or a prior push-triggered run failed silently — without it, the only way to retrigger was to push an empty `.meta/` change.

## Context
After PR #(prior) merged, the post-merge-sync workflow didn't run because it had been disabled in the Actions UI (likely while the duplicate-creation bug was active). The `paths: ['.meta/**']` filter is correct — `3dca20f` touched 6 `.meta/**` files, so the trigger *would* have fired had the workflow been enabled.

## Test plan
- [ ] Merge to master.
- [ ] Confirm the workflow shows up at https://github.com/yevheniidehtiar/gitpm/actions/workflows/post-merge-sync.yml with a "Run workflow" button.
- [ ] Re-enable the workflow if it's still disabled.
- [ ] Click "Run workflow" against `master`; verify the run completes green and that a follow-up `chore(pm): persist GitHub sync metadata [skip ci]` commit lands on master with an updated `.meta/sync/github-state.json`.
- [ ] If the bot's push back to master is rejected by branch protection, fall back to opening a PR from the workflow instead of pushing direct.

https://claude.ai/code/session_01KhTHd6rM5BtKMjGTjUPZk6

---
_Generated by [Claude Code](https://claude.ai/code/session_01KhTHd6rM5BtKMjGTjUPZk6)_