### PR TITLE
ci(sync): three-layer guard against stale .meta/ state on master

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# Pre-push hook: block pushes that would leave .meta/ out of sync with
+# GitHub Issues. Mirrors the meta-sync-check CI job in pr-validation.yml.
+#
+# Skips if no .meta/ files changed in the commits being pushed.
+# Skips if GITHUB_TOKEN is unavailable (CI handles it instead).
+# Bypass with GITPM_SKIP_SYNC_CHECK=1.
+
+set -e
+
+if [ "${GITPM_SKIP_SYNC_CHECK:-0}" = "1" ]; then
+  exit 0
+fi
+
+# Determine the diff range for files-changed detection.
+zero="0000000000000000000000000000000000000000"
+range=""
+while read -r local_ref local_sha remote_ref remote_sha; do
+  [ -z "$local_sha" ] && continue
+  [ "$local_sha" = "$zero" ] && continue
+  if [ "$remote_sha" = "$zero" ]; then
+    upstream=$(git rev-parse --verify --quiet origin/master 2>/dev/null || echo "")
+    [ -z "$upstream" ] && continue
+    range="$upstream..$local_sha"
+  else
+    range="$remote_sha..$local_sha"
+  fi
+  if git diff --name-only "$range" 2>/dev/null | grep -q '^\.meta/'; then
+    needs_check=1
+  fi
+done
+
+if [ "${needs_check:-0}" != "1" ]; then
+  exit 0
+fi
+
+if [ -z "${GITHUB_TOKEN:-}" ]; then
+  echo "[pre-push] GITHUB_TOKEN unset; skipping .meta/ sync check (CI will run it)."
+  exit 0
+fi
+
+if [ ! -f packages/cli/dist/index.js ]; then
+  echo "[pre-push] Building gitpm CLI for sync check..."
+  bun run build >/dev/null
+fi
+
+OUTPUT=$(node packages/cli/dist/index.js push --token "$GITHUB_TOKEN" --dry-run 2>&1)
+NEW_ISSUES=$(echo "$OUTPUT" | awk '/^  New issues:/ {print $NF}')
+NEW_MILESTONES=$(echo "$OUTPUT" | awk '/^  New milestones:/ {print $NF}')
+NEW_ISSUES=${NEW_ISSUES:-0}
+NEW_MILESTONES=${NEW_MILESTONES:-0}
+
+if [ "$NEW_ISSUES" -gt 0 ] || [ "$NEW_MILESTONES" -gt 0 ]; then
+  echo
+  echo "[pre-push] Stale .meta/ state: would create $NEW_ISSUES new issues and $NEW_MILESTONES new milestones."
+  echo "[pre-push] Run 'gitpm push' locally to populate github.issue_number, then commit the result."
+  echo "[pre-push] To bypass: GITPM_SKIP_SYNC_CHECK=1 git push ..."
+  exit 1
+fi
+
+echo "[pre-push] .meta/ sync check passed."

--- a/.github/workflows/post-merge-sync.yml
+++ b/.github/workflows/post-merge-sync.yml
@@ -53,9 +53,14 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       # Persist sync writebacks (github.issue_number on entities,
-      # .meta/sync/github-state.json) so the next push doesn't see entities
-      # as new and create duplicate issues. [skip ci] avoids re-triggering.
-      - name: Commit sync writebacks
+      # .meta/sync/github-state.json) to a dedicated snapshot branch.
+      # Master branch protection blocks direct bot pushes (PR + signed
+      # commits required), so this branch is the side-channel record of
+      # the latest sync state — maintainers can cherry-pick or open a PR
+      # from it when reconciliation is needed. PR validation
+      # (`pr-validation.yml`) and the pre-push hook (`.githooks/pre-push`)
+      # block stale `.meta/` from reaching master in the first place.
+      - name: Snapshot sync writebacks
         run: |
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git config user.name "github-actions[bot]"
@@ -64,5 +69,5 @@ jobs:
             echo "No sync writebacks to commit."
             exit 0
           fi
-          git commit -m "chore(pm): persist GitHub sync metadata [skip ci]"
-          git push origin HEAD:master
+          git commit -m "chore(pm): persist GitHub sync metadata"
+          git push -f origin HEAD:chore/sync-state-snapshot

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -94,3 +94,50 @@ jobs:
           name: playwright-traces
           path: packages/ui/test-results/
           retention-days: 7
+
+  meta-sync-check:
+    name: .meta/ Sync Check
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: read
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Install dependencies
+        run: bun install
+
+      - name: Build CLI
+        run: bun run build
+
+      # Detect entities in `.meta/` that lack `github.issue_number` (or
+      # whose state is otherwise out of sync with GitHub). If any such
+      # entity exists, post-merge-sync would create a fresh GitHub issue
+      # for it on merge — historically the source of duplicate issues.
+      # Block the PR; the author should run `gitpm push` locally and
+      # commit the resulting `github.issue_number` blocks.
+      - name: Check for unsynced .meta/ entities
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -e
+          OUTPUT=$(node packages/cli/dist/index.js push --token "$GITHUB_TOKEN" --dry-run 2>&1)
+          echo "$OUTPUT"
+          NEW_ISSUES=$(echo "$OUTPUT" | awk '/^  New issues:/ {print $NF}')
+          NEW_MILESTONES=$(echo "$OUTPUT" | awk '/^  New milestones:/ {print $NF}')
+          NEW_ISSUES=${NEW_ISSUES:-0}
+          NEW_MILESTONES=${NEW_MILESTONES:-0}
+          if [ "$NEW_ISSUES" -gt 0 ] || [ "$NEW_MILESTONES" -gt 0 ]; then
+            echo "::error::Stale .meta/ state: dry-run would create $NEW_ISSUES new issues and $NEW_MILESTONES new milestones."
+            echo "::error::Run 'gitpm push' locally to populate github.issue_number, then commit the resulting frontmatter changes."
+            exit 1
+          fi
+          echo "OK: no new issues/milestones would be created."

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "test": "vitest run",
     "test:coverage": "vitest run --coverage",
     "lint": "biome check .",
-    "dev:ui": "bun run --filter @gitpm/ui dev"
+    "dev:ui": "bun run --filter @gitpm/ui dev",
+    "prepare": "git config core.hooksPath .githooks 2>/dev/null || true"
   },
   "devDependencies": {
     "@biomejs/biome": "^2.4.10",


### PR DESCRIPTION
## Summary
- Replaces the failing direct-bot-push to master (rejected by branch protection: PR + signed commits + required check) with a three-layer guard against stale `.meta/` state.
- **Pre-push hook** (`.githooks/pre-push`) runs `gitpm push --dry-run` and refuses pushes that would create new issues/milestones. Auto-installed via the new `prepare` script in `package.json`. Bypass with `GITPM_SKIP_SYNC_CHECK=1`.
- **PR validation check** (`meta-sync-check` job in `pr-validation.yml`) re-runs the same dry-run gate so PRs that skip the hook get blocked at CI.
- **Post-merge snapshot** (`post-merge-sync.yml`) force-pushes the writeback to `chore/sync-state-snapshot` (a side branch outside master's protection rules) instead of `HEAD:master`. Snapshot is a recoverable record; maintainers can cherry-pick / PR from it when needed.

## Context
After PR #214, the post-merge-sync workflow ran but failed at `git push origin HEAD:master`:
```
GH013: Repository rule violations found for refs/heads/master.
- Required status check "Lint, Test & Build" is expected.
- Changes must be made through a pull request.
- Commits must have verified signatures.
```
The default `GITHUB_TOKEN` can't bypass these. Rather than wire up a PAT, this shifts the enforcement upstream: the writeback is no longer needed *post-*merge because nothing stale ever reaches master.

## Test plan
- [ ] Merge → verify CI runs `meta-sync-check` and reports green.
- [ ] On a follow-up PR that adds a new `.meta/` story without running `gitpm push`, confirm `meta-sync-check` fails with "Stale .meta/ state: would create N new issues".
- [ ] Run `bun install` locally → verify `git config core.hooksPath` returns `.githooks`. Make a `.meta/` change without running `gitpm push`, attempt `git push` → confirm the hook rejects it.
- [ ] Trigger `Post-Merge Sync` manually from Actions → verify it pushes to `chore/sync-state-snapshot` (no master push attempt) and the run is green.

https://claude.ai/code/session_01KhTHd6rM5BtKMjGTjUPZk6

---
_Generated by [Claude Code](https://claude.ai/code/session_01KhTHd6rM5BtKMjGTjUPZk6)_