### PR TITLE
ci(review): reduce Claude Review + Autofix Loop runner costs

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -11,6 +11,19 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
     branches: [master]
+    # Skip the workflow entirely on docs-only / .meta-only / license-only
+    # PRs. There's nothing for Claude to review or autofix in those, and
+    # spinning up two runners costs real money at scale. NOTE: if you
+    # ever mark "Claude Review" as a required status check, switch this
+    # to a per-job `paths-changed` pre-step instead — required checks
+    # that never get triggered will block merge on filtered PRs.
+    paths-ignore:
+      - '**/*.md'
+      - 'docs/**'
+      - '.meta/**'
+      - 'LICENSE'
+      - '.gitignore'
+      - '.editorconfig'
 
 concurrency:
   group: claude-review-${{ github.event.pull_request.number }}
@@ -29,6 +42,11 @@ jobs:
     # Review historically finishes in 5–6 min; 20 min leaves headroom
     # for a slow run while preventing a hung session from tying up CI.
     timeout-minutes: 20
+    outputs:
+      # Surface the cache decision so `autofix-loop` can short-circuit
+      # without spinning up a runner when there's nothing new to fix.
+      cache_hit: ${{ steps.cache.outputs.hit }}
+      diff_hash: ${{ steps.cache.outputs.new_hash }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -105,6 +123,15 @@ jobs:
         if: steps.cache.outputs.hit != 'true'
         with:
           node-version: '22'
+
+      - name: Cache bun install
+        if: steps.cache.outputs.hit != 'true'
+        uses: actions/cache@v4
+        with:
+          path: ~/.bun/install/cache
+          key: ${{ runner.os }}-bun-${{ hashFiles('**/bun.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-bun-
 
       - name: Install dependencies
         if: steps.cache.outputs.hit != 'true'
@@ -457,8 +484,15 @@ jobs:
   autofix-loop:
     name: Claude Autofix Loop
     runs-on: ubuntu-latest
-    # Skip PRs from forks — we can't push to a fork branch from this workflow.
-    if: github.event.pull_request.head.repo.full_name == github.repository
+    # Wait for `review` so the autofix runner doesn't get billed for the
+    # 5–6 minutes it would otherwise sleep through review's run.
+    # `if: always()` is required because we want autofix to run even
+    # when review fails — that's the whole point.
+    needs: review
+    if: |
+      always() &&
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      needs.review.outputs.cache_hit != 'true'
     timeout-minutes: 60
     # Override workflow-level permissions with the broader set this job
     # needs: `contents: write` to push fix commits, plus `checks: read`
@@ -471,6 +505,34 @@ jobs:
       checks: read
       actions: read
     steps:
+      # Cheap up-front check: if every other CI job on HEAD is already
+      # complete and green, there's nothing to fix — exit before paying
+      # for the App token mint, checkout, bun install, and Claude CLI
+      # install. This catches the common "PR is green on first try" case
+      # where the loop would otherwise wake up, spin for 45 s, and exit.
+      - name: Pre-check — skip if everything is already green
+        id: precheck
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+          SELF_JOBS='["Claude Autofix Loop"]'
+          CHECK_RUNS=$(gh api "repos/$REPO/commits/$HEAD_SHA/check-runs" --paginate \
+            | jq --argjson self "$SELF_JOBS" \
+                '[.check_runs[] | select(.name as $n | $self | index($n) | not)]')
+          TOTAL=$(echo "$CHECK_RUNS" | jq 'length')
+          PENDING=$(echo "$CHECK_RUNS" | jq '[.[] | select(.status != "completed")] | length')
+          FAILING=$(echo "$CHECK_RUNS" | jq '[.[] | select(.conclusion == "failure" or .conclusion == "timed_out" or .conclusion == "cancelled")] | length')
+          echo "checks=$TOTAL pending=$PENDING failing=$FAILING"
+          if [ "$TOTAL" -gt 0 ] && [ "$PENDING" -eq 0 ] && [ "$FAILING" -eq 0 ]; then
+            echo "All non-self checks already green — skipping autofix loop."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
       # Generate a GitHub App token so autofix commits trigger new workflow
       # runs. The default GITHUB_TOKEN is subject to anti-loop protection —
       # pushes made with it do NOT dispatch new `pull_request` events, which
@@ -479,6 +541,7 @@ jobs:
       # secrets are the same GitHub App release-please.yml uses for its own
       # post-merge commits.
       - name: Generate GitHub App Token
+        if: steps.precheck.outputs.skip != 'true'
         id: app-token
         uses: actions/create-github-app-token@v1
         with:
@@ -486,28 +549,43 @@ jobs:
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
 
       - uses: actions/checkout@v4
+        if: steps.precheck.outputs.skip != 'true'
         with:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.ref }}
           token: ${{ steps.app-token.outputs.token }}
 
       - uses: oven-sh/setup-bun@v2
+        if: steps.precheck.outputs.skip != 'true'
         with:
           bun-version: latest
 
       - uses: actions/setup-node@v4
+        if: steps.precheck.outputs.skip != 'true'
         with:
           node-version: '22'
 
+      - name: Cache bun install
+        if: steps.precheck.outputs.skip != 'true'
+        uses: actions/cache@v4
+        with:
+          path: ~/.bun/install/cache
+          key: ${{ runner.os }}-bun-${{ hashFiles('**/bun.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-bun-
+
       - name: Install dependencies
+        if: steps.precheck.outputs.skip != 'true'
         run: bun install
 
       - name: Configure git identity
+        if: steps.precheck.outputs.skip != 'true'
         run: |
           git config user.name "claude-autofix[bot]"
           git config user.email "claude-autofix@users.noreply.github.com"
 
       - name: Wait-and-fix loop
+        if: steps.precheck.outputs.skip != 'true'
         env:
           CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           # Use the App token so `git push` below triggers new workflow runs

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -519,9 +519,14 @@ jobs:
         run: |
           set -euo pipefail
           SELF_JOBS='["Claude Autofix Loop"]'
-          CHECK_RUNS=$(gh api "repos/$REPO/commits/$HEAD_SHA/check-runs" --paginate \
-            | jq --argjson self "$SELF_JOBS" \
-                '[.check_runs[] | select(.name as $n | $self | index($n) | not)]')
+          # `gh api --paginate --jq '.check_runs[]'` flattens every page into
+          # one ndjson stream; `jq -s` then slurps the lot into a single array
+          # so TOTAL/PENDING/FAILING are accurate when there are >100 runs.
+          # (Without `--jq`, paginate emits one wrapper object per page and
+          # downstream filters silently see only the last page.)
+          CHECK_RUNS=$(gh api "repos/$REPO/commits/$HEAD_SHA/check-runs" --paginate --jq '.check_runs[]' \
+            | jq -s --argjson self "$SELF_JOBS" \
+                '[.[] | select(.name as $n | $self | index($n) | not)]')
           TOTAL=$(echo "$CHECK_RUNS" | jq 'length')
           PENDING=$(echo "$CHECK_RUNS" | jq '[.[] | select(.status != "completed")] | length')
           FAILING=$(echo "$CHECK_RUNS" | jq '[.[] | select(.conclusion == "failure" or .conclusion == "timed_out" or .conclusion == "cancelled")] | length')
@@ -637,10 +642,13 @@ jobs:
             echo "Current HEAD: $HEAD_SHA"
 
             # Fetch all check runs for this commit, excluding this workflow's
-            # own jobs so we don't wait on ourselves.
-            CHECK_RUNS=$(gh api "repos/$REPO/commits/$HEAD_SHA/check-runs" --paginate \
-              | jq --argjson self "$SELF_JOBS" \
-                  '[.check_runs[] | select(.name as $n | $self | index($n) | not)]')
+            # own jobs so we don't wait on ourselves. Use `--jq '.check_runs[]'`
+            # + `jq -s` so pagination above 100 runs collapses into one array
+            # (without it, each page becomes a separate jq input and the
+            # downstream length/select filters only see the last page).
+            CHECK_RUNS=$(gh api "repos/$REPO/commits/$HEAD_SHA/check-runs" --paginate --jq '.check_runs[]' \
+              | jq -s --argjson self "$SELF_JOBS" \
+                  '[.[] | select(.name as $n | $self | index($n) | not)]')
 
             TOTAL=$(echo "$CHECK_RUNS" | jq 'length')
             if [ "$TOTAL" -eq 0 ]; then

--- a/.meta/epics/epic-analytics-project-intelligence/stories/feat-add-issue-quality-scoring-for-ai-agent-context.md
+++ b/.meta/epics/epic-analytics-project-intelligence/stories/feat-add-issue-quality-scoring-for-ai-agent-context.md
@@ -15,8 +15,8 @@ epic_ref:
 github:
   issue_number: 43
   repo: yevheniidehtiar/gitpm
-  last_sync_hash: sha256:c82c2510bf6e5991f3732c93525f0d4ed9e42b4925bd1ef4456bd9e496c4b73d
-  synced_at: 2026-04-05T17:24:12.493Z
+  last_sync_hash: sha256:5995670c628d76f2f7646a4d4e13e59075f2214e378e6c77d4563e688963d10f
+  synced_at: 2026-04-26T09:40:16.698Z
 created_at: 2026-04-05T09:49:45.000Z
 updated_at: 2026-04-12T16:06:36.793Z
 ---

--- a/.meta/epics/epic-cicd-pipelines-build-system/stories/reduce-claude-review-runner-costs.md
+++ b/.meta/epics/epic-cicd-pipelines-build-system/stories/reduce-claude-review-runner-costs.md
@@ -1,0 +1,81 @@
+---
+type: story
+id: rXKv8mPq2WZc
+title: Reduce GitHub runner cost of Claude Review + Autofix Loop
+status: in_progress
+priority: medium
+assignee: null
+labels:
+  - ci/cd
+  - cost
+  - story
+estimate: null
+epic_ref:
+  id: 0KmESSRSd002
+github: null
+created_at: 2026-04-26T00:00:00.000Z
+updated_at: 2026-04-26T00:00:00.000Z
+---
+
+## Problem
+
+`.github/workflows/claude-review.yml` runs on every PR push. Worst case
+per push on a private-repo Linux runner:
+
+- `review` job: up to 20 min cap (~5–6 min typical).
+- `autofix-loop` job: up to 60 min cap, mostly **paid sleep** while the
+  45 s polling loop waits for other CI to finish.
+
+At ~$0.008/min for Linux 2-core, the loop alone can cost ~$0.48 per
+push. Multiply by every push to every PR and the bill scales linearly
+with developer activity, even when there is nothing for autofix to do.
+
+## Plan
+
+Stack the cheap wins first on this branch, defer the structural change
+to a follow-up.
+
+### Cheap wins (this branch)
+
+1. **`paths-ignore`** on `claude-review.yml`: skip the workflow entirely
+   for docs-only / `.meta/`-only / `*.md` / `LICENSE` PRs. These don't
+   need a Claude review or autofix.
+2. **`actions/cache`** for `~/.bun/install/cache` keyed on `bun.lock`.
+   Both jobs currently do a fresh `bun install` and `bun run build` —
+   caching the install shaves ~30 s off every job.
+3. **Pre-check in `autofix-loop`** that exits the job before installing
+   anything if either:
+   - The `review` job's cache step already short-circuited (diff hash
+     matches a known-green sentinel), or
+   - All non-self check-runs on HEAD are already complete and green.
+
+   This avoids paying for a runner that would otherwise spend the full
+   45 s × N polling window discovering it has nothing to do.
+
+### Structural change (separate PR)
+
+Convert `autofix-loop` from a polling sleep loop into a job triggered
+by the `workflow_run` event when the other PR workflows complete.
+Eliminates billable idle time entirely. Tradeoffs:
+
+- `workflow_run` always uses the workflow definition from the default
+  branch (security feature) — wiring is fiddlier than `pull_request`.
+- The job needs to map `workflow_run.pull_requests[0].number` back to
+  the PR for context.
+- App-token push pattern stays the same.
+
+## Acceptance criteria
+
+- [ ] Docs-only PRs do not trigger any `claude-review.yml` runner.
+- [ ] `bun install` step in both jobs reports a cache hit on the second
+      consecutive PR push.
+- [ ] When `review` short-circuits via cache, `autofix-loop` exits in
+      under 30 s without installing dependencies or sleeping.
+- [ ] Worst-case end-to-end runner-minutes per push (measured on a
+      red PR with one failing check) is unchanged or lower.
+
+## Notes
+
+The `workflow_run` migration is the bigger lever (eliminates the entire
+polling window). Tracked here as the "next step" so we can ship the
+cheap wins first and measure impact before committing to the rewrite.

--- a/.meta/epics/epic-cicd-pipelines-build-system/stories/reduce-claude-review-runner-costs.md
+++ b/.meta/epics/epic-cicd-pipelines-build-system/stories/reduce-claude-review-runner-costs.md
@@ -15,8 +15,8 @@ epic_ref:
 github:
   issue_number: 216
   repo: yevheniidehtiar/gitpm
-  last_sync_hash: sha256:2f9c09de0c5d7b88783ca6d7c613b1c9316e07c21449a41bbb69e4d21706ad89
-  synced_at: 2026-04-26T09:40:17.063Z
+  last_sync_hash: sha256:99fda7a1c47d29932697759c1eafea4f1175f9e78cd492408b1a4e0e72897aee
+  synced_at: 2026-04-26T19:23:28.129Z
 created_at: 2026-04-26T00:00:00.000Z
 updated_at: 2026-04-26T00:00:00.000Z
 ---

--- a/.meta/epics/epic-cicd-pipelines-build-system/stories/reduce-claude-review-runner-costs.md
+++ b/.meta/epics/epic-cicd-pipelines-build-system/stories/reduce-claude-review-runner-costs.md
@@ -2,7 +2,7 @@
 type: story
 id: rXKv8mPq2WZc
 title: Reduce GitHub runner cost of Claude Review + Autofix Loop
-status: in_progress
+status: in_review
 priority: medium
 assignee: null
 labels:

--- a/.meta/epics/epic-cicd-pipelines-build-system/stories/reduce-claude-review-runner-costs.md
+++ b/.meta/epics/epic-cicd-pipelines-build-system/stories/reduce-claude-review-runner-costs.md
@@ -12,7 +12,11 @@ labels:
 estimate: null
 epic_ref:
   id: 0KmESSRSd002
-github: null
+github:
+  issue_number: 216
+  repo: yevheniidehtiar/gitpm
+  last_sync_hash: sha256:2f9c09de0c5d7b88783ca6d7c613b1c9316e07c21449a41bbb69e4d21706ad89
+  synced_at: 2026-04-26T09:40:17.063Z
 created_at: 2026-04-26T00:00:00.000Z
 updated_at: 2026-04-26T00:00:00.000Z
 ---

--- a/.meta/epics/epic-ui-core-experience/stories/feat-add-markdown-previewsplit-view-in-entity-editor.md
+++ b/.meta/epics/epic-ui-core-experience/stories/feat-add-markdown-previewsplit-view-in-entity-editor.md
@@ -14,8 +14,8 @@ epic_ref:
 github:
   issue_number: 40
   repo: yevheniidehtiar/gitpm
-  last_sync_hash: sha256:16f5cd41e90e8749ddd20a436c2d851a75fc05f82a7a826a3c9411815c956a6b
-  synced_at: 2026-04-12T11:18:13.347Z
+  last_sync_hash: sha256:f9a28266beaeac138b049ebf480496b33a7d83c97b16b35f022688f7256d08bc
+  synced_at: 2026-04-26T09:40:17.465Z
 created_at: 2026-04-05T09:48:53.000Z
 updated_at: 2026-04-12T12:58:26.397Z
 ---

--- a/.meta/epics/epic-ui-core-experience/stories/feat-add-virtual-scrolling-to-tree-browser-for-large-project.md
+++ b/.meta/epics/epic-ui-core-experience/stories/feat-add-virtual-scrolling-to-tree-browser-for-large-project.md
@@ -14,8 +14,8 @@ epic_ref:
 github:
   issue_number: 37
   repo: yevheniidehtiar/gitpm
-  last_sync_hash: sha256:0b7df3f466d1b46defdbd1ad3f131e69541d64507c92b72ef438eada7ad0998f
-  synced_at: 2026-04-12T11:18:13.708Z
+  last_sync_hash: sha256:1de780b3b5e99d58682bc32eaa6f2aadb03f7b844f1a597f538df92441e48641
+  synced_at: 2026-04-26T09:40:17.830Z
 created_at: 2026-04-05T09:48:51.000Z
 updated_at: 2026-04-12T14:26:19.389Z
 ---

--- a/.meta/sync/github-state.json
+++ b/.meta/sync/github-state.json
@@ -1,6 +1,6 @@
 {
   "repo": "yevheniidehtiar/gitpm",
-  "last_sync": "2026-04-26T09:40:17.833Z",
+  "last_sync": "2026-04-26T19:23:28.136Z",
   "entities": {
     "lFNL-hn79Edx": {
       "local_hash": "sha256:c80c6ddae59254da17317bbd45064a97651fe108ae1dab77453d97afbae58c85",
@@ -255,9 +255,9 @@
     },
     "rXKv8mPq2WZc": {
       "github_issue_number": 216,
-      "local_hash": "sha256:2f9c09de0c5d7b88783ca6d7c613b1c9316e07c21449a41bbb69e4d21706ad89",
-      "remote_hash": "sha256:2f9c09de0c5d7b88783ca6d7c613b1c9316e07c21449a41bbb69e4d21706ad89",
-      "synced_at": "2026-04-26T09:40:17.065Z"
+      "local_hash": "sha256:99fda7a1c47d29932697759c1eafea4f1175f9e78cd492408b1a4e0e72897aee",
+      "remote_hash": "sha256:99fda7a1c47d29932697759c1eafea4f1175f9e78cd492408b1a4e0e72897aee",
+      "synced_at": "2026-04-26T19:23:28.135Z"
     }
   }
 }

--- a/.meta/sync/github-state.json
+++ b/.meta/sync/github-state.json
@@ -1,6 +1,6 @@
 {
   "repo": "yevheniidehtiar/gitpm",
-  "last_sync": "2026-04-12T11:18:14.065Z",
+  "last_sync": "2026-04-26T09:40:17.833Z",
   "entities": {
     "lFNL-hn79Edx": {
       "local_hash": "sha256:c80c6ddae59254da17317bbd45064a97651fe108ae1dab77453d97afbae58c85",
@@ -189,10 +189,11 @@
       "closed_on_remote": true
     },
     "DZS1X4xTJkZj": {
-      "local_hash": "sha256:0b7df3f466d1b46defdbd1ad3f131e69541d64507c92b72ef438eada7ad0998f",
-      "remote_hash": "sha256:0b7df3f466d1b46defdbd1ad3f131e69541d64507c92b72ef438eada7ad0998f",
-      "synced_at": "2026-04-12T11:18:13.712Z",
-      "github_issue_number": 37
+      "local_hash": "sha256:1de780b3b5e99d58682bc32eaa6f2aadb03f7b844f1a597f538df92441e48641",
+      "remote_hash": "sha256:1de780b3b5e99d58682bc32eaa6f2aadb03f7b844f1a597f538df92441e48641",
+      "synced_at": "2026-04-26T09:40:17.833Z",
+      "github_issue_number": 37,
+      "closed_on_remote": true
     },
     "e6Mnoo3iNwiv": {
       "local_hash": "sha256:b9bf81aaa9228d0f33fb932f25d48685e0c4427cc6622f82753c6012ca6e7680",
@@ -209,10 +210,11 @@
       "closed_on_remote": true
     },
     "eb-9Va_neAdh": {
-      "local_hash": "sha256:16f5cd41e90e8749ddd20a436c2d851a75fc05f82a7a826a3c9411815c956a6b",
-      "remote_hash": "sha256:16f5cd41e90e8749ddd20a436c2d851a75fc05f82a7a826a3c9411815c956a6b",
-      "synced_at": "2026-04-12T11:18:13.351Z",
-      "github_issue_number": 40
+      "local_hash": "sha256:f9a28266beaeac138b049ebf480496b33a7d83c97b16b35f022688f7256d08bc",
+      "remote_hash": "sha256:f9a28266beaeac138b049ebf480496b33a7d83c97b16b35f022688f7256d08bc",
+      "synced_at": "2026-04-26T09:40:17.467Z",
+      "github_issue_number": 40,
+      "closed_on_remote": true
     },
     "EWHnNnW4rAWN": {
       "local_hash": "sha256:5f5aab7038b3fa32d51e4e2f42382efce42e714aaca75f68374b863e45c44029",
@@ -221,10 +223,11 @@
       "github_issue_number": 41
     },
     "YTEAoETh3A7C": {
-      "local_hash": "sha256:c82c2510bf6e5991f3732c93525f0d4ed9e42b4925bd1ef4456bd9e496c4b73d",
-      "remote_hash": "sha256:c82c2510bf6e5991f3732c93525f0d4ed9e42b4925bd1ef4456bd9e496c4b73d",
-      "synced_at": "2026-04-05T17:24:12.531Z",
-      "github_issue_number": 43
+      "local_hash": "sha256:5995670c628d76f2f7646a4d4e13e59075f2214e378e6c77d4563e688963d10f",
+      "remote_hash": "sha256:5995670c628d76f2f7646a4d4e13e59075f2214e378e6c77d4563e688963d10f",
+      "synced_at": "2026-04-26T09:40:16.706Z",
+      "github_issue_number": 43,
+      "closed_on_remote": true
     },
     "XDbbOigUWenB": {
       "local_hash": "sha256:da2d36ac16494c4e674dc1b73e2b7cfc7917e7ab1d46549a13b90397a809993f",
@@ -249,6 +252,12 @@
       "remote_hash": "sha256:aad005e68721c882ea37c1a8ea0124746fc9b1c72235ad43de16c68d591ff356",
       "synced_at": "2026-04-05T17:24:12.531Z",
       "github_issue_number": 46
+    },
+    "rXKv8mPq2WZc": {
+      "github_issue_number": 216,
+      "local_hash": "sha256:2f9c09de0c5d7b88783ca6d7c613b1c9316e07c21449a41bbb69e4d21706ad89",
+      "remote_hash": "sha256:2f9c09de0c5d7b88783ca6d7c613b1c9316e07c21449a41bbb69e4d21706ad89",
+      "synced_at": "2026-04-26T09:40:17.065Z"
     }
   }
 }

--- a/docs/ci-claude-review.md
+++ b/docs/ci-claude-review.md
@@ -1,0 +1,106 @@
+# Claude Review + Autofix Loop CI
+
+This page documents `.github/workflows/claude-review.yml`, the workflow that runs Claude against every PR push to `master` to (a) post a code review and (b) attempt to auto-fix any failing CI checks.
+
+## Overview
+
+The workflow contains **two jobs that start in parallel**:
+
+| Job | Wall-clock | Cap | Permissions | Purpose |
+|---|---|---|---|---|
+| `review` | 5–6 min typical | 20 min | `contents: read`, `pull-requests: write`, `issues: write` | Review the diff, post findings as a PR comment, gate the check on critical-severity findings |
+| `autofix-loop` | up to 60 min | 60 min | `contents: write`, `checks: read`, `actions: read`, plus PR/issue write | Wait for every other check on HEAD to settle, then ask Claude to fix any failures and push the fix back to the PR branch |
+
+They are *parallel in start time*, but `autofix-loop` spends most of its life polling. It is effectively gated on every other check (including `review`) reaching a terminal state.
+
+## `review` job
+
+Inputs: `pull_request` event payload, the PR diff at HEAD.
+
+Steps:
+
+1. **Cache check.** Computes a SHA-256 of the three-dot diff against `master` (`git diff origin/master...HEAD`), excluding `*.lock` and `**/dist/**`. Searches prior PR comments authored by `github-actions[bot]` for a matching `<!-- claude-review-cache: <hash> -->` sentinel. A hit short-circuits the rest of the job and re-emits the sentinel so the cache lineage chains forward. This is invariant under rebase onto a newer `master`.
+2. **Run Claude** in `-p` mode with an inlined prompt that tells it to follow `.claude/commands/review-pr.md`, classify findings into `critical` / `medium` / `low` / `nit`, and write the result to `/tmp/review-result.json`. The session transcript (`stream.jsonl`) is uploaded as an artifact.
+3. **Gate.** Reads `/tmp/review-result.json`, posts a markdown summary as a PR comment, and:
+   - Exits non-zero if `counts.critical > 0` (blocks the check).
+   - Emits a warning if `counts.medium > 0` (advisory; does not block).
+   - On a clean review (`critical == 0`), embeds the cache sentinel so the next push of the same diff hits the cache.
+
+Failure modes the gate handles:
+
+- Claude wrote `review-result.json` to the workspace root instead of `/tmp` → moved automatically.
+- `review-result.json` missing entirely → posts a diagnostic PR comment with `ls /tmp`, the assistant transcript, tool calls, and stderr — visible without artifact download access.
+
+## `autofix-loop` job
+
+Skipped on fork PRs (`github.event.pull_request.head.repo.full_name == github.repository`), since the workflow can't push to a fork branch.
+
+### App token (not `GITHUB_TOKEN`)
+
+Checkout uses a token minted from the `RELEASE_APP_ID` / `RELEASE_APP_PRIVATE_KEY` GitHub App secrets (the same App release-please uses). This is **load-bearing**: pushes made with the default `GITHUB_TOKEN` do **not** trigger new `pull_request` events (anti-loop protection). With the App token, each autofix push triggers a fresh workflow run, the loop's next iteration sees new check-runs, and the loop can converge.
+
+### Iteration budget
+
+`MAX_ITERATIONS` is sized dynamically by total diff lines (`additions + deletions`):
+
+| Diff size | Max iterations |
+|---|---|
+| ≤ 500 | 5 |
+| ≤ 1500 | 7 |
+| ≤ 3000 | 10 |
+| ≤ 5000 | 12 |
+| > 5000 | 15 |
+
+### Loop body
+
+Each iteration:
+
+1. Sleep 45 seconds.
+2. Fetch all check-runs for current HEAD via `gh api`, **excluding only `Claude Autofix Loop`** (the loop excludes itself but not the `review` job — failing reviews are something the loop will try to fix).
+3. If no check-runs exist yet, or any are still `queued` / `in_progress` → continue (loop again).
+4. If all completed and none failed → exit 0, write a success line to `$GITHUB_STEP_SUMMARY`.
+5. If any failed:
+   - Write the failing check metadata to `/tmp/autofix/failing-checks.json`.
+   - **If `Claude Review` is among the failures**, fetch the latest "Claude Review" PR comment and write its body to `/tmp/autofix/review-findings.md`. Claude is told to prioritize critical/medium severity findings before build/test failures.
+   - Run Claude with a prompt that tells it to read the failing-checks JSON, fetch logs via `gh run view`, fix the root cause (NOT modify tests to mask it), follow `CLAUDE.md` conventions, and verify locally with `bun run lint && bun run build && bun run test`. **Claude must not commit, push, or comment** — the workflow does that.
+   - `--max-turns` is 30 if review-findings are present, 20 otherwise.
+   - If the working tree is clean after Claude exits → break the loop with a "manual intervention required" summary.
+   - Otherwise `git add -u` (tracked files only — avoids staging stray secrets or build artifacts), commit as `claude-autofix[bot]`, and push with up-to-5-attempt exponential backoff retry.
+
+If the iteration budget is exhausted without going green, the job exits cleanly with a "Reached max iterations" summary; the PR is left in its current state for human review.
+
+## Why two jobs instead of one
+
+The two-job split is a deliberate trade-off:
+
+- **Cache short-circuit.** The review job can skip the expensive Claude call entirely when the diff hash matches a known-green sentinel. Folding everything into the autofix loop would either lose this or require duplicating the cache logic per iteration.
+- **Least privilege.** `review` runs read-only. Only `autofix-loop` carries `contents: write`. Merging them would give the reviewer push rights it does not need.
+- **Independent timeouts.** Review's 20-minute cap kills hung sessions fast; autofix needs 60 minutes for the polling window plus multiple Claude calls.
+- **Fast user-visible feedback.** The review comment lands within a few minutes of the push regardless of how long autofix takes (or whether autofix runs at all on a fork PR).
+
+The "review feeds autofix" integration already exists — autofix detects when `Claude Review` is among the failing checks and pulls the structured findings into its prompt — so consolidation would not unlock new behaviour, only collapse the surface.
+
+## Why you might see no autofix commits
+
+Two common reasons:
+
+1. **All non-self checks were green** when the loop polled. The loop exits after the first pass without invoking Claude.
+2. **Claude could not produce a fix.** It exited with a clean working tree, the loop broke, and the job summary contains "Stopped at iteration N: Claude could not produce a fix". Manual intervention is required.
+
+A third, rarer case: the push iteration succeeded but the next iteration polled before any new check-runs were registered against the new SHA, then saw no failures and exited. The 45 s sleep and the App-token push (which forces a new `pull_request` event) make this unlikely.
+
+## Required secrets
+
+| Secret | Used by | Purpose |
+|---|---|---|
+| `CLAUDE_CODE_OAUTH_TOKEN` | both jobs | Authenticates the Claude Code CLI. Generated with `claude setup-token` on a trusted machine. |
+| `RELEASE_APP_ID`, `RELEASE_APP_PRIVATE_KEY` | `autofix-loop` only | GitHub App credentials minted into a checkout token. Required for autofix pushes to dispatch new workflow runs. |
+| `GITHUB_TOKEN` (default) | both | Posting PR comments, reading check-runs, the cache sentinel lookup. |
+
+## Concurrency
+
+`concurrency.group: claude-review-${{ github.event.pull_request.number }}` with `cancel-in-progress: true`. A new push to a PR cancels the in-flight review and autofix runs for that PR; only the latest push is reviewed and fixed.
+
+## Artifacts
+
+`review` uploads `/tmp/claude-review/` (containing `stream.jsonl` and `stderr.log`), the inline prompt, and `review-result.json` as `claude-review-pr-<n>` with 14-day retention.

--- a/docs/ci-claude-review.md
+++ b/docs/ci-claude-review.md
@@ -4,14 +4,16 @@ This page documents `.github/workflows/claude-review.yml`, the workflow that run
 
 ## Overview
 
-The workflow contains **two jobs that start in parallel**:
+The workflow contains **two jobs**:
 
 | Job | Wall-clock | Cap | Permissions | Purpose |
 |---|---|---|---|---|
 | `review` | 5–6 min typical | 20 min | `contents: read`, `pull-requests: write`, `issues: write` | Review the diff, post findings as a PR comment, gate the check on critical-severity findings |
 | `autofix-loop` | up to 60 min | 60 min | `contents: write`, `checks: read`, `actions: read`, plus PR/issue write | Wait for every other check on HEAD to settle, then ask Claude to fix any failures and push the fix back to the PR branch |
 
-They are *parallel in start time*, but `autofix-loop` spends most of its life polling. It is effectively gated on every other check (including `review`) reaching a terminal state.
+`autofix-loop` declares `needs: review` so it does not start until `review` has finished. This avoids billing the autofix runner for the 5–6 min it would otherwise sleep through review's run.
+
+The workflow itself is filtered with `paths-ignore` for docs-only / `.meta/`-only / `LICENSE` / `.gitignore` / `.editorconfig` PRs — those don't trigger any runner. **Caveat:** if you ever mark "Claude Review" as a required status check, switch this to a per-job `paths-changed` pre-step instead, since required checks that never get triggered will block merge on filtered PRs.
 
 ## `review` job
 
@@ -33,7 +35,11 @@ Failure modes the gate handles:
 
 ## `autofix-loop` job
 
-Skipped on fork PRs (`github.event.pull_request.head.repo.full_name == github.repository`), since the workflow can't push to a fork branch.
+Skipped on fork PRs (`github.event.pull_request.head.repo.full_name == github.repository`), since the workflow can't push to a fork branch. Also skipped when `review` short-circuited on its diff-hash cache (no new code since a known-green review, so there's nothing for autofix to do) — the `if:` condition checks `needs.review.outputs.cache_hit`.
+
+### Pre-check short-circuit
+
+Before paying for the App-token mint, checkout, bun install, and Claude CLI install, the job runs a single `gh api .../check-runs` call. If every non-self check on HEAD is already complete and green, the rest of the steps are skipped via `steps.precheck.outputs.skip`. This catches the common "PR was green on first try" case where the loop would otherwise wake up, spin for 45 s, and exit having done nothing.
 
 ### App token (not `GITHUB_TOKEN`)
 


### PR DESCRIPTION
## Summary

Implements cost-reduction optimizations for the Claude Review + Autofix Loop CI workflow by skipping unnecessary runs, caching dependencies, and short-circuiting when no work is needed. These changes reduce runner billing on docs-only and cache-hit PRs without altering the core review/autofix behavior.

## Changes

- **Workflow filtering**: Added `paths-ignore` to skip `claude-review.yml` entirely on docs-only, `.meta/`-only, and license-only PRs (no code to review or fix).
- **Dependency caching**: Added `actions/cache` for `~/.bun/install/cache` keyed on `bun.lock` in both `review` and `autofix-loop` jobs, saving ~30s per job on cache hits.
- **Review job outputs**: Exposed `cache_hit` and `diff_hash` outputs so `autofix-loop` can detect when the diff hasn't changed since a known-green review.
- **Autofix pre-check**: Added a `precheck` step that queries GitHub's check-runs API before spinning up expensive resources. If all non-self checks are already complete and green, the job exits immediately without installing dependencies or running Claude.
- **Autofix job dependency**: Made `autofix-loop` depend on `review` with `needs: review` so it doesn't get billed for the 5–6 minutes it would otherwise sleep through review's run. Also added `cache_hit` condition to skip autofix when review's cache short-circuited.
- **Documentation**: Added `docs/ci-claude-review.md` explaining the workflow architecture, job responsibilities, cost optimizations, and failure modes.
- **Story tracking**: Added `.meta/epics/epic-cicd-pipelines-build-system/stories/reduce-claude-review-runner-costs.md` documenting the problem, plan, and acceptance criteria.

## Related GitPM stories

- `.meta/epics/epic-cicd-pipelines-build-system/stories/reduce-claude-review-runner-costs.md`

## Test plan

- [ ] Verify docs-only PR does not trigger `claude-review.yml` runner
- [ ] Verify `bun install` cache hits on second consecutive PR push
- [ ] Verify `autofix-loop` exits in <30s when `review` cache short-circuits
- [ ] Verify `autofix-loop` pre-check skips remaining steps when all checks are green

## Related issues

Closes #216

https://claude.ai/code/session_0178hw1rrhaTofN34WZGr2jh