### PR TITLE
feat: pass adapter result payload into post-* hook context

### DIFF
--- a/packages/cli/src/commands/import.ts
+++ b/packages/cli/src/commands/import.ts
@@ -138,6 +138,7 @@ export const importCommand = new Command('import')
       metaDir,
       event: 'post-import',
       adapterName: adapter.name,
+      result: result.value,
     });
   });
 

--- a/packages/cli/src/commands/pull.ts
+++ b/packages/cli/src/commands/pull.ts
@@ -70,6 +70,7 @@ export const pullCommand = new Command('pull')
       metaDir,
       event: 'post-sync',
       adapterName: adapter.name,
+      result: result.value,
     });
   });
 

--- a/packages/cli/src/commands/push.ts
+++ b/packages/cli/src/commands/push.ts
@@ -111,6 +111,7 @@ export const pushCommand = new Command('push')
       metaDir,
       event: 'post-export',
       adapterName: adapter.name,
+      result: result.value,
     });
   });
 

--- a/packages/cli/src/commands/sync.ts
+++ b/packages/cli/src/commands/sync.ts
@@ -105,6 +105,7 @@ export const syncCommand = new Command('sync')
       metaDir,
       event: 'post-sync',
       adapterName: adapter.name,
+      result: result.value,
     });
   });
 

--- a/packages/core/src/adapter.ts
+++ b/packages/core/src/adapter.ts
@@ -7,12 +7,16 @@ export interface ImportResult {
   epics: number;
   stories: number;
   totalFiles: number;
+  /** Relative .meta/ paths of files written during import. */
+  writtenPaths: string[];
 }
 
 export interface ExportResult {
   created: { milestones: number; issues: number };
   updated: { milestones: number; issues: number };
   totalChanges: number;
+  /** Relative .meta/ paths of local entities that were exported to the remote. */
+  exportedPaths: string[];
 }
 
 export interface SyncResult {
@@ -21,6 +25,10 @@ export interface SyncResult {
   conflicts: FieldConflict[];
   resolved: number;
   skipped: number;
+  /** Relative .meta/ paths of local files updated by remote (pull side). */
+  pulledPaths: string[];
+  /** Relative .meta/ paths of local entities sent to remote (push side). */
+  pushedPaths: string[];
 }
 
 export type ConflictStrategy = 'local-wins' | 'remote-wins' | 'ask';

--- a/packages/core/src/adapter.ts
+++ b/packages/core/src/adapter.ts
@@ -7,7 +7,7 @@ export interface ImportResult {
   epics: number;
   stories: number;
   totalFiles: number;
-  /** Relative .meta/ paths of files written during import. */
+  /** Entity .meta/ paths written during import (excludes sync config/state). */
   writtenPaths: string[];
 }
 
@@ -15,7 +15,6 @@ export interface ExportResult {
   created: { milestones: number; issues: number };
   updated: { milestones: number; issues: number };
   totalChanges: number;
-  /** Relative .meta/ paths of local entities that were exported to the remote. */
   exportedPaths: string[];
 }
 
@@ -25,9 +24,7 @@ export interface SyncResult {
   conflicts: FieldConflict[];
   resolved: number;
   skipped: number;
-  /** Relative .meta/ paths of local files updated by remote (pull side). */
   pulledPaths: string[];
-  /** Relative .meta/ paths of local entities sent to remote (push side). */
   pushedPaths: string[];
 }
 

--- a/packages/core/src/plugin-loader.test.ts
+++ b/packages/core/src/plugin-loader.test.ts
@@ -1,4 +1,4 @@
-import { mkdir, rm, writeFile } from 'node:fs/promises';
+import { mkdir, readFile, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
@@ -324,6 +324,47 @@ describe('runHooks', () => {
       tmpDir,
     );
     expect(result.ok).toBe(true);
+  });
+
+  it('passes result payload through to the hook', async () => {
+    const hookPath = join(tmpDir, 'hook-result.mjs');
+    const capturePath = join(tmpDir, 'captured.json');
+    await writeFile(
+      hookPath,
+      `import { writeFile } from 'node:fs/promises';
+export default async function(ctx) {
+  await writeFile(${JSON.stringify(capturePath)}, JSON.stringify(ctx.result));
+}`,
+    );
+
+    const config: GitpmConfig = {
+      adapters: [],
+      hooks: { 'post-import': hookPath },
+    };
+    const result = await runHooks(
+      config,
+      'post-import',
+      {
+        metaDir: '/tmp',
+        event: 'post-import',
+        result: {
+          milestones: 1,
+          epics: 2,
+          stories: 3,
+          totalFiles: 6,
+          writtenPaths: ['.meta/epics/foo.md', '.meta/stories/bar.md'],
+        },
+      },
+      tmpDir,
+    );
+    expect(result.ok).toBe(true);
+
+    const captured = JSON.parse(await readFile(capturePath, 'utf-8'));
+    expect(captured.writtenPaths).toEqual([
+      '.meta/epics/foo.md',
+      '.meta/stories/bar.md',
+    ]);
+    expect(captured.stories).toBe(3);
   });
 });
 

--- a/packages/core/src/plugin-loader.ts
+++ b/packages/core/src/plugin-loader.ts
@@ -24,10 +24,7 @@ interface BaseHookContext {
   adapterName?: string;
 }
 
-/**
- * Discriminated by `event` so post-* hooks see a typed `result` and pre-* hooks
- * have no `result` field at all.
- */
+/** Discriminated by `event`: post-* hooks see a typed `result`; pre-* hooks have none. */
 export type HookContext =
   | (BaseHookContext & { event: 'pre-import' | 'pre-export' | 'pre-sync' })
   | (BaseHookContext & { event: 'post-import'; result: ImportResult })

--- a/packages/core/src/plugin-loader.ts
+++ b/packages/core/src/plugin-loader.ts
@@ -1,7 +1,12 @@
 import { access, readdir, readFile } from 'node:fs/promises';
 import { dirname, isAbsolute, join, resolve } from 'node:path';
 import { pathToFileURL } from 'node:url';
-import type { SyncAdapter } from './adapter.js';
+import type {
+  ExportResult,
+  ImportResult,
+  SyncAdapter,
+  SyncResult,
+} from './adapter.js';
 import { isSyncAdapter } from './adapter.js';
 import type { GitpmConfig, HookEvent } from './config.js';
 import { createDefaultGitpmConfig, gitpmConfigSchema } from './config.js';
@@ -14,11 +19,20 @@ const CONFIG_FILENAMES = [
   'gitpm.config.json',
 ];
 
-export interface HookContext {
+interface BaseHookContext {
   metaDir: string;
-  event: HookEvent;
   adapterName?: string;
 }
+
+/**
+ * Discriminated by `event` so post-* hooks see a typed `result` and pre-* hooks
+ * have no `result` field at all.
+ */
+export type HookContext =
+  | (BaseHookContext & { event: 'pre-import' | 'pre-export' | 'pre-sync' })
+  | (BaseHookContext & { event: 'post-import'; result: ImportResult })
+  | (BaseHookContext & { event: 'post-export'; result: ExportResult })
+  | (BaseHookContext & { event: 'post-sync'; result: SyncResult });
 
 /**
  * Load gitpm.config from the project root directory.

--- a/packages/sync-github/src/__tests__/import.test.ts
+++ b/packages/sync-github/src/__tests__/import.test.ts
@@ -62,6 +62,10 @@ describe('importFromGitHub', () => {
     expect(result.value.epics).toBe(2);
     expect(result.value.stories).toBe(4); // issues 3,4,5,6 (PR filtered out)
     expect(result.value.totalFiles).toBeGreaterThan(0);
+    expect(result.value.writtenPaths).toHaveLength(9);
+    expect(result.value.writtenPaths.every((p) => p.startsWith('.meta/'))).toBe(
+      true,
+    );
   });
 
   it('creates a valid .meta tree', async () => {

--- a/packages/sync-github/src/export.ts
+++ b/packages/sync-github/src/export.ts
@@ -41,6 +41,7 @@ export async function exportToGitHub(
       created: { milestones: 0, issues: 0 },
       updated: { milestones: 0, issues: 0 },
       totalChanges: 0,
+      exportedPaths: [],
     };
 
     // 3. Process milestones
@@ -73,6 +74,7 @@ export async function exportToGitHub(
             remote_hash: hash,
             synced_at: new Date().toISOString(),
           };
+          result.exportedPaths.push(milestone.filePath);
         }
         result.created.milestones++;
       } else {
@@ -105,6 +107,7 @@ export async function exportToGitHub(
               remote_hash: currentHash,
               synced_at: new Date().toISOString(),
             };
+            result.exportedPaths.push(milestone.filePath);
           }
           result.updated.milestones++;
         }
@@ -175,6 +178,7 @@ export async function exportToGitHub(
             remote_hash: hash,
             synced_at: new Date().toISOString(),
           };
+          result.exportedPaths.push(entity.filePath);
         }
         result.created.issues++;
       } else {
@@ -228,6 +232,7 @@ export async function exportToGitHub(
               closed_on_remote: expectedState === 'closed' ? true : undefined,
               synced_at: new Date().toISOString(),
             };
+            result.exportedPaths.push(entity.filePath);
           }
           result.updated.issues++;
         }

--- a/packages/sync-github/src/import.ts
+++ b/packages/sync-github/src/import.ts
@@ -184,6 +184,7 @@ export async function importFromGitHub(
 
     // 8. Write all entities to disk
     let totalFiles = 0;
+    const writtenPaths: string[] = [];
     // filePath values start with ".meta/", replace that prefix with the actual metaDir
     const resolveEntityPath = (filePath: string) => {
       const relative = filePath.replace(/^\.meta\//, '');
@@ -195,6 +196,7 @@ export async function importFromGitHub(
     const roadmapResult = await writeFile(roadmap, roadmapPath);
     if (!roadmapResult.ok) return roadmapResult;
     totalFiles++;
+    writtenPaths.push(roadmap.filePath);
 
     // Write milestones
     for (const ms of milestones) {
@@ -202,6 +204,7 @@ export async function importFromGitHub(
       const result = await writeFile(ms, msPath);
       if (!result.ok) return result;
       totalFiles++;
+      writtenPaths.push(ms.filePath);
     }
 
     // Write epics
@@ -210,6 +213,7 @@ export async function importFromGitHub(
       const result = await writeFile(epic, epicPath);
       if (!result.ok) return result;
       totalFiles++;
+      writtenPaths.push(epic.filePath);
     }
 
     // Write stories
@@ -218,6 +222,7 @@ export async function importFromGitHub(
       const result = await writeFile(story, storyPath);
       if (!result.ok) return result;
       totalFiles++;
+      writtenPaths.push(story.filePath);
     }
 
     // 9. Save config
@@ -239,6 +244,7 @@ export async function importFromGitHub(
         epics: epics.length,
         stories: stories.length,
         totalFiles,
+        writtenPaths,
       },
     };
   } catch (err) {

--- a/packages/sync-github/src/sync.ts
+++ b/packages/sync-github/src/sync.ts
@@ -103,6 +103,8 @@ export async function syncWithGitHub(
       skipped: 0,
       resumedFromCheckpoint,
       failedEntities: [],
+      pulledPaths: [],
+      pushedPaths: [],
     };
 
     // Helper to save checkpoint on failure (skipped during dry runs)
@@ -194,6 +196,7 @@ export async function syncWithGitHub(
               };
             }
             result.pulled.milestones++;
+            result.pulledPaths.push(localEntity.filePath);
             processedEntityIds.add(entityId);
             continue;
           }
@@ -228,6 +231,7 @@ export async function syncWithGitHub(
               };
             }
             result.pushed.milestones++;
+            result.pushedPaths.push(localEntity.filePath);
           } else if (direction === 'remote_changed') {
             // Pull remote → local
             if (!dryRun) {
@@ -243,6 +247,7 @@ export async function syncWithGitHub(
               };
             }
             result.pulled.milestones++;
+            result.pulledPaths.push(localEntity.filePath);
           } else {
             // Both changed — conflict
             const conflict: FieldConflict = {
@@ -317,6 +322,7 @@ export async function syncWithGitHub(
               };
             }
             result.pulled.issues++;
+            result.pulledPaths.push(localEntity.filePath);
             processedEntityIds.add(entityId);
             continue;
           }
@@ -359,6 +365,7 @@ export async function syncWithGitHub(
               };
             }
             result.pushed.issues++;
+            result.pushedPaths.push(localEntity.filePath);
           } else if (direction === 'remote_changed') {
             if (
               !dryRun &&
@@ -376,6 +383,7 @@ export async function syncWithGitHub(
               };
             }
             result.pulled.issues++;
+            result.pulledPaths.push(localEntity.filePath);
           } else {
             // Both changed — conflict
             const conflict: FieldConflict = {
@@ -485,6 +493,7 @@ export async function syncWithGitHub(
             };
           }
           result.pushed.milestones++;
+          result.pushedPaths.push(entity.filePath);
         } else {
           if (!dryRun) {
             const params = entityToGhIssue(entity);
@@ -518,6 +527,7 @@ export async function syncWithGitHub(
             };
           }
           result.pushed.issues++;
+          result.pushedPaths.push(entity.filePath);
         }
 
         processedEntityIds.add(entity.id);

--- a/packages/sync-github/src/types.ts
+++ b/packages/sync-github/src/types.ts
@@ -22,6 +22,7 @@ export interface ImportResult {
   epics: number;
   stories: number;
   totalFiles: number;
+  writtenPaths: string[];
 }
 
 export interface GitHubConfig {
@@ -89,6 +90,7 @@ export interface ExportResult {
   created: { milestones: number; issues: number };
   updated: { milestones: number; issues: number };
   totalChanges: number;
+  exportedPaths: string[];
 }
 
 export interface SyncOptions {
@@ -117,6 +119,8 @@ export interface SyncResult {
   skipped: number;
   resumedFromCheckpoint: boolean;
   failedEntities: { entityId: string; error: string }[];
+  pulledPaths: string[];
+  pushedPaths: string[];
 }
 
 export interface FieldChange {

--- a/packages/sync-gitlab/src/__tests__/import.test.ts
+++ b/packages/sync-gitlab/src/__tests__/import.test.ts
@@ -73,6 +73,10 @@ describe('importFromGitLab', () => {
     expect(result.value.stories).toBe(3);
     // total files = milestones + epics + stories + roadmap + config + state
     expect(result.value.totalFiles).toBe(2 + 2 + 3 + 1 + 1 + 1);
+    expect(result.value.writtenPaths).toHaveLength(8);
+    expect(result.value.writtenPaths.every((p) => p.startsWith('.meta/'))).toBe(
+      true,
+    );
   });
 
   it('creates valid tree structure', async () => {

--- a/packages/sync-gitlab/src/export.ts
+++ b/packages/sync-gitlab/src/export.ts
@@ -46,6 +46,7 @@ export async function exportToGitLab(
       created: { milestones: 0, issues: 0 },
       updated: { milestones: 0, issues: 0 },
       totalChanges: 0,
+      exportedPaths: [],
     };
 
     // 4. Process milestones
@@ -78,6 +79,7 @@ export async function exportToGitLab(
             remote_hash: hash,
             synced_at: new Date().toISOString(),
           };
+          result.exportedPaths.push(milestone.filePath);
         }
         result.created.milestones++;
       } else {
@@ -110,6 +112,7 @@ export async function exportToGitLab(
               remote_hash: currentHash,
               synced_at: new Date().toISOString(),
             };
+            result.exportedPaths.push(milestone.filePath);
           }
           result.updated.milestones++;
         }
@@ -178,6 +181,7 @@ export async function exportToGitLab(
             remote_hash: hash,
             synced_at: new Date().toISOString(),
           };
+          result.exportedPaths.push(entity.filePath);
         }
         result.created.issues++;
       } else {
@@ -220,6 +224,7 @@ export async function exportToGitLab(
               remote_hash: currentHash,
               synced_at: new Date().toISOString(),
             };
+            result.exportedPaths.push(entity.filePath);
           }
           result.updated.issues++;
         }

--- a/packages/sync-gitlab/src/import.ts
+++ b/packages/sync-gitlab/src/import.ts
@@ -199,6 +199,7 @@ export async function importFromGitLab(
 
     // 10. Write all entities to disk
     let totalFiles = 0;
+    const writtenPaths: string[] = [];
     const resolveEntityPath = (filePath: string) => {
       const relative = filePath.replace(/^\.meta\//, '');
       return join(metaDir, relative);
@@ -209,6 +210,7 @@ export async function importFromGitLab(
     const roadmapResult = await writeFile(roadmap, roadmapPath);
     if (!roadmapResult.ok) return roadmapResult;
     totalFiles++;
+    writtenPaths.push(roadmap.filePath);
 
     // Write milestones
     for (const ms of milestones) {
@@ -216,6 +218,7 @@ export async function importFromGitLab(
       const result = await writeFile(ms, msPath);
       if (!result.ok) return result;
       totalFiles++;
+      writtenPaths.push(ms.filePath);
     }
 
     // Write epics
@@ -224,6 +227,7 @@ export async function importFromGitLab(
       const result = await writeFile(epic, epicPath);
       if (!result.ok) return result;
       totalFiles++;
+      writtenPaths.push(epic.filePath);
     }
 
     // Write stories
@@ -232,6 +236,7 @@ export async function importFromGitLab(
       const result = await writeFile(story, storyPath);
       if (!result.ok) return result;
       totalFiles++;
+      writtenPaths.push(story.filePath);
     }
 
     // 11. Save config
@@ -253,6 +258,7 @@ export async function importFromGitLab(
         epics: epics.length,
         stories: stories.length,
         totalFiles,
+        writtenPaths,
       },
     };
   } catch (err) {

--- a/packages/sync-gitlab/src/sync.ts
+++ b/packages/sync-gitlab/src/sync.ts
@@ -67,6 +67,8 @@ export async function syncWithGitLab(
       conflicts: [],
       resolved: 0,
       skipped: 0,
+      pulledPaths: [],
+      pushedPaths: [],
     };
 
     // 4. Build entity lookup maps
@@ -123,6 +125,7 @@ export async function syncWithGitLab(
             };
           }
           result.pulled.milestones++;
+          result.pulledPaths.push(localEntity.filePath);
           continue;
         }
 
@@ -151,6 +154,7 @@ export async function syncWithGitLab(
             };
           }
           result.pushed.milestones++;
+          result.pushedPaths.push(localEntity.filePath);
         } else if (direction === 'remote_changed') {
           if (!dryRun) {
             applyRemoteMilestone(localEntity, remoteMilestone);
@@ -165,6 +169,7 @@ export async function syncWithGitLab(
             };
           }
           result.pulled.milestones++;
+          result.pulledPaths.push(localEntity.filePath);
         } else {
           // Both changed — conflict
           const conflict: FieldConflict = {
@@ -237,6 +242,7 @@ export async function syncWithGitLab(
             };
           }
           result.pulled.issues++;
+          result.pulledPaths.push(localEntity.filePath);
           continue;
         }
 
@@ -269,6 +275,7 @@ export async function syncWithGitLab(
             };
           }
           result.pushed.issues++;
+          result.pushedPaths.push(localEntity.filePath);
         } else if (direction === 'remote_changed') {
           if (
             !dryRun &&
@@ -286,6 +293,7 @@ export async function syncWithGitLab(
             };
           }
           result.pulled.issues++;
+          result.pulledPaths.push(localEntity.filePath);
         } else {
           // Both changed — conflict
           const conflict: FieldConflict = {
@@ -372,6 +380,7 @@ export async function syncWithGitLab(
           };
         }
         result.pushed.milestones++;
+        result.pushedPaths.push(entity.filePath);
       } else {
         if (!dryRun) {
           const params = entityToGlIssue(entity);
@@ -405,6 +414,7 @@ export async function syncWithGitLab(
           };
         }
         result.pushed.issues++;
+        result.pushedPaths.push(entity.filePath);
       }
     }
 

--- a/packages/sync-gitlab/src/types.ts
+++ b/packages/sync-gitlab/src/types.ts
@@ -23,6 +23,7 @@ export interface ImportResult {
   epics: number;
   stories: number;
   totalFiles: number;
+  writtenPaths: string[];
 }
 
 export interface GitLabConfig {
@@ -77,6 +78,7 @@ export interface ExportResult {
   created: { milestones: number; issues: number };
   updated: { milestones: number; issues: number };
   totalChanges: number;
+  exportedPaths: string[];
 }
 
 export interface SyncOptions {
@@ -98,6 +100,8 @@ export interface SyncResult {
   conflicts: FieldConflict[];
   resolved: number;
   skipped: number;
+  pulledPaths: string[];
+  pushedPaths: string[];
 }
 
 export interface FieldChange {

--- a/packages/sync-jira/src/__tests__/import.test.ts
+++ b/packages/sync-jira/src/__tests__/import.test.ts
@@ -159,6 +159,13 @@ describe('importFromJira', () => {
     expect(result.value.epics).toBe(1);
     expect(result.value.stories).toBe(1);
     expect(result.value.totalFiles).toBe(1 + 1 + 1 + 1 + 1 + 1);
+    expect(result.value.writtenPaths).toHaveLength(4);
+    expect(result.value.writtenPaths).toContain(
+      '.meta/epics/auth-epic/epic.md',
+    );
+    expect(result.value.writtenPaths).toContain(
+      '.meta/epics/auth-epic/stories/login-form.md',
+    );
 
     const epicPath = join(metaDir, 'epics', 'auth-epic', 'epic.md');
     await expect(stat(epicPath)).resolves.toBeDefined();

--- a/packages/sync-jira/src/export.ts
+++ b/packages/sync-jira/src/export.ts
@@ -43,6 +43,7 @@ export async function exportToJira(
       created: { milestones: 0, issues: 0 },
       updated: { milestones: 0, issues: 0 },
       totalChanges: 0,
+      exportedPaths: [],
     };
 
     // 4. Process epics and stories (milestones = sprints are typically
@@ -113,6 +114,7 @@ export async function exportToJira(
             remote_hash: hash,
             synced_at: new Date().toISOString(),
           };
+          result.exportedPaths.push(entity.filePath);
         }
         result.created.issues++;
       } else {
@@ -152,6 +154,7 @@ export async function exportToJira(
               remote_hash: currentHash,
               synced_at: new Date().toISOString(),
             };
+            result.exportedPaths.push(entity.filePath);
           }
           result.updated.issues++;
         }

--- a/packages/sync-jira/src/import.ts
+++ b/packages/sync-jira/src/import.ts
@@ -156,6 +156,7 @@ export async function importFromJira(
 
     // 7. Write all entities to disk
     let totalFiles = 0;
+    const writtenPaths: string[] = [];
     const resolveEntityPath = (filePath: string) => {
       const relative = filePath.replace(/^\.meta\//, '');
       return join(metaDir, relative);
@@ -165,12 +166,14 @@ export async function importFromJira(
     const roadmapResult = await writeFile(roadmap, roadmapPath);
     if (!roadmapResult.ok) return roadmapResult;
     totalFiles++;
+    writtenPaths.push(roadmap.filePath);
 
     for (const ms of milestones) {
       const msPath = resolveEntityPath(ms.filePath);
       const result = await writeFile(ms, msPath);
       if (!result.ok) return result;
       totalFiles++;
+      writtenPaths.push(ms.filePath);
     }
 
     for (const epic of epics) {
@@ -178,6 +181,7 @@ export async function importFromJira(
       const result = await writeFile(epic, epicPath);
       if (!result.ok) return result;
       totalFiles++;
+      writtenPaths.push(epic.filePath);
     }
 
     for (const story of stories) {
@@ -185,6 +189,7 @@ export async function importFromJira(
       const result = await writeFile(story, storyPath);
       if (!result.ok) return result;
       totalFiles++;
+      writtenPaths.push(story.filePath);
     }
 
     // 8. Save config
@@ -211,6 +216,7 @@ export async function importFromJira(
         epics: epics.length,
         stories: stories.length,
         totalFiles,
+        writtenPaths,
       },
     };
   } catch (err) {

--- a/packages/sync-jira/src/sync.ts
+++ b/packages/sync-jira/src/sync.ts
@@ -74,6 +74,8 @@ export async function syncWithJira(
       conflicts: [],
       resolved: 0,
       skipped: 0,
+      pulledPaths: [],
+      pushedPaths: [],
     };
 
     // 4. Build entity lookup maps
@@ -143,6 +145,7 @@ export async function syncWithJira(
             };
           }
           result.pulled.issues++;
+          result.pulledPaths.push(localEntity.filePath);
           continue;
         }
 
@@ -195,6 +198,7 @@ export async function syncWithJira(
             };
           }
           result.pushed.issues++;
+          result.pushedPaths.push(localEntity.filePath);
         } else if (direction === 'remote_changed') {
           if (
             !dryRun &&
@@ -212,6 +216,7 @@ export async function syncWithJira(
             };
           }
           result.pulled.issues++;
+          result.pulledPaths.push(localEntity.filePath);
         } else {
           // Both changed — conflict
           const conflict: FieldConflict = {
@@ -304,6 +309,7 @@ export async function syncWithJira(
         };
       }
       result.pushed.issues++;
+      result.pushedPaths.push(entity.filePath);
     }
 
     // 7. Save state

--- a/packages/sync-jira/src/types.ts
+++ b/packages/sync-jira/src/types.ts
@@ -15,6 +15,7 @@ export interface ImportResult {
   epics: number;
   stories: number;
   totalFiles: number;
+  writtenPaths: string[];
 }
 
 export interface JiraConfig {
@@ -67,6 +68,7 @@ export interface ExportResult {
   created: { milestones: number; issues: number };
   updated: { milestones: number; issues: number };
   totalChanges: number;
+  exportedPaths: string[];
 }
 
 export interface JiraSyncOptions {
@@ -87,6 +89,8 @@ export interface SyncResult {
   conflicts: FieldConflict[];
   resolved: number;
   skipped: number;
+  pulledPaths: string[];
+  pushedPaths: string[];
 }
 
 export interface FieldChange {


### PR DESCRIPTION
## Summary

This PR adds file path tracking to operation results across import, export, and sync operations. Each result type now includes arrays of relative `.meta/` paths that were affected by the operation, enabling hooks and other consumers to know exactly which files were created, updated, or synced.

## Changes

- **Core adapter types** (`packages/core/src/adapter.ts`): Added `writtenPaths`, `exportedPaths`, `pulledPaths`, and `pushedPaths` fields to `ImportResult`, `ExportResult`, and `SyncResult` interfaces
- **Hook context typing** (`packages/core/src/plugin-loader.ts`): Implemented discriminated union type for `HookContext` so post-operation hooks receive typed `result` payloads while pre-operation hooks have no result field
- **Import operations**: Updated all three adapters (GitHub, GitLab, Jira) to track and return `writtenPaths` during import
- **Export operations**: Updated all three adapters to track and return `exportedPaths` during export
- **Sync operations**: Updated all three adapters to track and return `pulledPaths` and `pushedPaths` during sync
- **CLI commands**: Modified import, push, pull, and sync commands to pass operation results to post-operation hooks
- **Adapter-specific types**: Updated type definitions in each adapter package to match core interfaces
- **Tests**: Added test coverage for hook result payload passing and verified path tracking in import operations

## Related GitPM stories

-

## Test plan

- Added unit test for hook result payload passing in `plugin-loader.test.ts`
- Added assertions in import tests to verify `writtenPaths` are populated and correctly formatted
- Existing test suite covers the changes

https://claude.ai/code/session_01Hsqx8k2rqiYfHvm9dfevCJ